### PR TITLE
ci: add GitHub Actions build guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,34 @@
+name: CI
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+
+jobs:
+  build:
+    name: Build and guard
+    runs-on: windows-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run CSS guard
+        shell: pwsh
+        run: .\commands\check-css-guard.ps1
+
+      - name: Build
+        run: npm run build


### PR DESCRIPTION
Adds GitHub Actions CI to run npm ci, CSS guard, and npm run build on pull requests and main pushes.