### PR TITLE
docs(firestore): add Security Rules design and initial rules file

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,3 +96,4 @@ export default defineConfig([
 | Document | Description |
 |----------|-------------|
 | [docs/operations/LOCAL_DEVELOPMENT_MANUAL.md](docs/operations/LOCAL_DEVELOPMENT_MANUAL.md) | Step-by-step local development guide including VS Code Tunnel |
+| [docs/operations/FIRESTORE_SECURITY_RULES.md](docs/operations/FIRESTORE_SECURITY_RULES.md) | Firestore Security Rules design, phase plan, and deploy checklist |

--- a/docs/operations/FIRESTORE_SECURITY_RULES.md
+++ b/docs/operations/FIRESTORE_SECURITY_RULES.md
@@ -1,0 +1,258 @@
+# Firestore Security Rules Design
+
+> **Status: Draft — 人間承認待ち**
+> このドキュメントは Firestore Security Rules の設計方針を定義します。
+> `firestore.rules` の deploy は必ず人間が行ってください。AI は deploy しません。
+
+---
+
+## 基本方針
+
+| 原則 | 内容 |
+|------|------|
+| Deny by default | 明示的に許可されていない全ての読み書きを拒否する |
+| 未認証 write 禁止 | `request.auth != null` を全ての write 条件に必須とする |
+| UID 単位のアクセス制御 | `request.auth.uid == userId` でユーザーごとにデータを分離する |
+| Firestore 本格利用は認証確認後 | Google Auth が本番で動作確認されるまで Firestore への書き込みを開始しない |
+| rules deploy は手動 | AI は `firebase deploy` を実行しない。人間が承認・deploy する |
+
+---
+
+## コレクション設計
+
+### Phase 0（現在）: Firestore 未使用
+
+アプリに Firebase Auth は実装済みですが、Firestore への読み書きはまだ実装していません。  
+全アクセスを deny にした状態で rules を配置し、安全な初期状態を確立します。
+
+### Phase 1（次フェーズ）: ユーザー個人データ
+
+```
+Firestore (default)
+└── users/
+    └── {userId}/                  ← Firebase Auth の UID
+        └── nailItems/
+            └── {itemId}/          ← Firestore 自動生成 ID
+                ├── title: string
+                ├── imageUrl: string       ← Firebase Storage URL
+                ├── thumbnailUrl: string
+                ├── tags: string[]
+                ├── createdAt: Timestamp
+                └── updatedAt: Timestamp
+```
+
+**アクセスルール:**
+- `users/{userId}/nailItems/{itemId}` — ログイン済み本人のみ read / write
+- `userId` = Firebase Auth の `uid` と一致する場合のみ許可
+
+### Phase 2（将来）: 公開サンプルデータ
+
+```
+Firestore (default)
+└── publicSamples/
+    └── {sampleId}/                ← 管理者が Firebase Console から追加
+        ├── title: string
+        ├── imageUrl: string
+        ├── tags: string[]
+        └── order: number
+```
+
+**アクセスルール:**
+- 全員 read 可（未ログインでも閲覧可能）
+- write は Firebase Console から手動のみ（クライアントからの write は禁止）
+
+---
+
+## フェーズ別 Rules
+
+### Phase 0 — Deny All（現在の `firestore.rules`）
+
+```
+rules_version = '2';
+service cloud.firestore {
+  match /databases/{database}/documents {
+    match /{document=**} {
+      allow read, write: if false;
+    }
+  }
+}
+```
+
+**目的:** Firestore が初期化されているが、まだ何も使わない段階で意図しないアクセスを完全にブロックする。
+
+---
+
+### Phase 1 — 認証ユーザーの個人データ（人間承認後に移行）
+
+```
+rules_version = '2';
+service cloud.firestore {
+  match /databases/{database}/documents {
+
+    // Default deny
+    match /{document=**} {
+      allow read, write: if false;
+    }
+
+    // User's private nail items — authenticated owner only
+    match /users/{userId}/nailItems/{itemId} {
+      allow read, write: if request.auth != null
+                          && request.auth.uid == userId;
+    }
+
+    // User profile document — authenticated owner only
+    match /users/{userId} {
+      allow read, write: if request.auth != null
+                          && request.auth.uid == userId;
+    }
+  }
+}
+```
+
+**Phase 1 への移行条件（全て揃ったら人間が承認）:**
+1. Google Auth がブラウザ・スマートフォンで動作確認済み
+2. `NailItem` データモデルが確定済み（[PRODUCT_SPEC.md](../product/PRODUCT_SPEC.md) の Q13 解決）
+3. Human Gate G3（DB スキーマ変更）・G4（認証・認可変更）の承認取得
+4. Firebase Emulator でのローカルテスト完了
+
+---
+
+### Phase 2 — 公開サンプル追加（将来・人間承認後）
+
+```
+rules_version = '2';
+service cloud.firestore {
+  match /databases/{database}/documents {
+
+    // Default deny
+    match /{document=**} {
+      allow read, write: if false;
+    }
+
+    // Public sample nail items — read only for everyone
+    match /publicSamples/{sampleId} {
+      allow read: if true;
+      allow write: if false;  // Firebase Console のみ
+    }
+
+    // User's private nail items — authenticated owner only
+    match /users/{userId}/nailItems/{itemId} {
+      allow read, write: if request.auth != null
+                          && request.auth.uid == userId;
+    }
+
+    // User profile — authenticated owner only
+    match /users/{userId} {
+      allow read, write: if request.auth != null
+                          && request.auth.uid == userId;
+    }
+  }
+}
+```
+
+---
+
+## アクセス制御マトリクス
+
+| コレクション | 未認証 read | 未認証 write | 認証済み自分 read | 認証済み自分 write | 認証済み他人 |
+|-------------|------------|------------|----------------|-----------------|------------|
+| `/{document=**}` (Phase 0) | ❌ | ❌ | ❌ | ❌ | ❌ |
+| `users/{uid}/nailItems/*` (Phase 1+) | ❌ | ❌ | ✅ | ✅ | ❌ |
+| `users/{uid}` (Phase 1+) | ❌ | ❌ | ✅ | ✅ | ❌ |
+| `publicSamples/*` (Phase 2+) | ✅ | ❌ | ✅ | ❌ | ✅ |
+
+---
+
+## Deploy 手順（人間が実行する）
+
+> **AI はこの手順を実行しません。** 人間が確認・承認してから実行してください。
+
+### 前提条件
+
+```powershell
+# Firebase CLI のインストール（未インストールの場合）
+npm install -g firebase-tools
+
+# Firebase にログイン
+firebase login
+
+# プロジェクトの確認
+firebase projects:list
+```
+
+### Rules の deploy
+
+```powershell
+# プロジェクトディレクトリで実行
+cd C:\dev\agent-sandbox
+
+# ドライラン（実際には deploy しない）
+firebase deploy --only firestore:rules --dry-run
+
+# 本番 deploy（承認済みの場合のみ）
+firebase deploy --only firestore:rules --project nail-report-dev-ksc0000
+```
+
+### Emulator でのローカルテスト
+
+```powershell
+# Firebase Emulator の起動
+firebase emulators:start --only firestore
+
+# ブラウザで Emulator UI を開く
+# → http://localhost:4000
+```
+
+---
+
+## セキュリティチェックリスト
+
+Deploy 前に人間が確認する項目:
+
+```text
+[ ] rules_version が '2' になっている
+[ ] デフォルト deny (match /{document=**} { allow read, write: if false; }) が含まれている
+[ ] 全公開 write (allow write: if true) が存在しないことを確認
+[ ] request.auth != null が全ての write 条件に含まれている
+[ ] userId 比較が request.auth.uid == userId になっている（== であること）
+[ ] publicSamples の write が if false になっている
+[ ] Firebase Console で Rules の "Playground" 機能を使って動作確認済み
+[ ] 本番 Project ID を確認している（nail-report-dev-ksc0000）
+```
+
+---
+
+## Human Gate 対応
+
+Firestore Security Rules は以下の Human Gate に該当します。
+
+| Gate | 理由 | 対応 |
+|------|------|------|
+| **G3** DB スキーマ変更 | コレクション構造・フィールド定義 | Phase 1 移行前に人間承認 |
+| **G4** 認証・認可変更 | UID ベースのアクセス制御ルール | Phase 1 移行前に人間承認 |
+| **G6** セキュリティ関連変更 | Rules の変更は全てセキュリティ影響あり | 変更のたびに人間承認 |
+| **G15** 本番公開判断 | `firebase deploy` は本番への公開 | AI は実行しない |
+
+---
+
+## 人間承認が必要な項目（優先度順）
+
+| # | 項目 | 優先度 | Gate |
+|---|------|--------|------|
+| A1 | Phase 0 rules の `firebase deploy` 実行 | **高** | G15 |
+| A2 | Google Auth の実機動作確認完了 | **高** | G4 |
+| A3 | `NailItem` データモデルの最終確定 | **高** | G3 |
+| A4 | Phase 1 rules への移行承認 | 中 | G3/G4 |
+| A5 | Firebase Emulator セットアップ（任意だが推奨） | 中 | — |
+| A6 | `publicSamples` コレクション方針の確定 | 低 | G1 |
+
+---
+
+## 関連ドキュメント
+
+| ドキュメント | 内容 |
+|---|---|
+| [LOCAL_DEVELOPMENT_MANUAL.md](./LOCAL_DEVELOPMENT_MANUAL.md) | ローカル開発手順 |
+| [PRODUCT_SPEC.md](../product/PRODUCT_SPEC.md) | データモデル・プロダクト仕様 |
+| [HUMAN_GATES.md](../harness/HUMAN_GATES.md) | Human Gate 定義 |
+| [ACCEPTANCE_CRITERIA.md](../product/ACCEPTANCE_CRITERIA.md) | セキュリティ変更の完了条件 |

--- a/firebase.json
+++ b/firebase.json
@@ -1,0 +1,5 @@
+{
+  "firestore": {
+    "rules": "firestore.rules"
+  }
+}

--- a/firestore.rules
+++ b/firestore.rules
@@ -1,0 +1,57 @@
+rules_version = '2';
+
+// nail-report-dev-ksc0000  Firestore Security Rules
+//
+// CURRENT PHASE: 0 — Deny all by default
+//   Firestore is initialized but no client reads/writes are implemented yet.
+//   Do NOT remove the deny-all block until Phase 1 is approved by a human.
+//
+// HOW TO DEPLOY (human only):
+//   firebase deploy --only firestore:rules --project nail-report-dev-ksc0000
+//
+// See docs/operations/FIRESTORE_SECURITY_RULES.md for full design.
+
+service cloud.firestore {
+  match /databases/{database}/documents {
+
+    // ================================================================
+    // Phase 0 (active): Deny everything
+    // ================================================================
+    match /{document=**} {
+      allow read, write: if false;
+    }
+
+    // ================================================================
+    // Phase 1 (pending human approval — Human Gate G3/G4):
+    //   User-scoped access for authenticated owners only.
+    //
+    // Conditions before enabling:
+    //   - Google Auth confirmed working in browser + mobile
+    //   - NailItem data model finalized (see PRODUCT_SPEC.md Q13)
+    //   - Human approval received for G3 (schema) and G4 (auth/authz)
+    //   - Tested locally with Firebase Emulator
+    // ================================================================
+    //
+    // match /users/{userId}/nailItems/{itemId} {
+    //   allow read, write: if request.auth != null
+    //                       && request.auth.uid == userId;
+    // }
+    //
+    // match /users/{userId} {
+    //   allow read, write: if request.auth != null
+    //                       && request.auth.uid == userId;
+    // }
+
+    // ================================================================
+    // Phase 2 (pending human approval — Human Gate G1/G3):
+    //   Public sample data — read-only for everyone.
+    //   Write via Firebase Console only (not from the client).
+    // ================================================================
+    //
+    // match /publicSamples/{sampleId} {
+    //   allow read: if true;
+    //   allow write: if false;
+    // }
+
+  }
+}


### PR DESCRIPTION
## 概要

Firestore Security Rules の設計文書と初期 rules ファイルを追加します。
**`firebase deploy` は実行していません。** deploy は人間が承認後に手動で実行してください。

## 変更内容

### 新規ファイル
- `docs/operations/FIRESTORE_SECURITY_RULES.md` — 設計方針・コレクション構造・フェーズ別 rules・アクセス制御マトリクス・deploy 手順・承認チェックリスト
- `firestore.rules` — Phase 0: Deny all by default（Phase 1/2 はコメントアウト）
- `firebase.json` — Firestore rules ファイル参照のみ（最小構成）

### 変更ファイル
- `README.md` — Operations 表に `FIRESTORE_SECURITY_RULES.md` へのリンクを追加

## セキュリティ方針

- **Phase 0（現在）**: 全アクセスを `allow read, write: if false` で完全拒否
- **Phase 1（コメントアウト）**: `users/{userId}/nailItems/*` — 認証済み本人のみ read/write
- **Phase 2（コメントアウト）**: `publicSamples/*` — 全員 read、write 不可

## 確認事項

- [x] `firebase deploy` は実行していない（ローカルにファイルを配置したのみ）
- [x] 全公開 `allow read, write: if true` は存在しない
- [x] 未認証 write は全フェーズで禁止
- [x] `npm run build` 成功（built in 96ms）
- [x] `src/` / `package.json` / `.github/workflows/` への変更なし

## ⚠️ merge 後に人間が行うこと（優先度順）

| # | 項目 | Human Gate |
|---|------|-----------|
| A1 | `firebase deploy --only firestore:rules` の実行 | G15 |
| A2 | Google Auth の実機動作確認（PC ブラウザ・iPhone Safari） | G4 |
| A3 | `NailItem` データモデルの最終確定 | G3 |
| A4 | Phase 1 rules への移行承認（A2・A3 完了後） | G3/G4 |

詳細は [FIRESTORE_SECURITY_RULES.md](docs/operations/FIRESTORE_SECURITY_RULES.md) を参照。