### PR TITLE
docs: finalize NailItem schema (A3) and mark A2/A3 complete

### DIFF
--- a/docs/operations/FIRESTORE_SECURITY_RULES.md
+++ b/docs/operations/FIRESTORE_SECURITY_RULES.md
@@ -243,9 +243,9 @@ Firestore Security Rules は以下の Human Gate に該当します。
 | # | 項目 | 優先度 | Gate | 状態 |
 |---|------|--------|------|------|
 | A1 | Phase 0 rules の `firebase deploy` 実行 | **高** | G15 | ✅ 完了 2026-05-01 |
-| A2 | Google Auth の実機動作確認完了 | **高** | G4 | ⬜ 未完了 → Issue #A2 |
-| A3 | `NailItem` データモデルの最終確定 | **高** | G3 | ⬜ 未完了 → Issue #A3 |
-| A4 | Phase 1 rules への移行承認 | 中 | G3/G4 | ⬜ 未完了 → Issue #A4 |
+| A2 | Google Auth の実機動作確認完了 | **高** | G4 | ✅ 完了 2026-05-01 |
+| A3 | `NailItem` データモデルの最終確定 | **高** | G3 | ✅ 完了 2026-05-01 |
+| A4 | Phase 1 rules への移行承認 | 中 | G3/G4 | ⬜ 未完了 → Issue #15 |
 | A5 | Firebase Emulator セットアップ（任意だが推奨） | 中 | — | ⬜ 未完了 |
 | A6 | `publicSamples` コレクション方針の確定 | 低 | G1 | ⬜ 未完了 |
 

--- a/docs/product/PRODUCT_SPEC.md
+++ b/docs/product/PRODUCT_SPEC.md
@@ -96,30 +96,62 @@ MVP 追加候補（**[要人間判断]**）:
 
 > アプリが扱うデータの概要を定義します。
 
-### 現在の Todo アイテム（フロントエンド state のみ）
+### NailItem（Firestore — Phase 1 以降）
+
+> **スキーマ確定: 2026-05-01 (A3 完了)**
+
+```
+Firestore (default) / users/{userId}/nailItems/{itemId}
+```
+
+| フィールド | 型 | 必須 | 制約 | 説明 |
+|-----------|-----|------|------|------|
+| `title` | `string` | ✅ | — | ネイルタイトル |
+| `imageUrl` | `string` | ✅ | Firebase Storage URL | フル解像度画像 |
+| `thumbnailUrl` | `string` | ✅ | Firebase Storage URL | サムネイル画像（初期は imageUrl と同値でも可） |
+| `tags` | `string[]` | ✅ | 最大 10 件、空配列可 | スタイル・色・シーン等のタグ |
+| `memo` | `string` | ✅ | 最大 500 文字、空文字可 | サロン名・価格・シーン等のメモ |
+| `createdAt` | `Timestamp` | ✅ | サーバータイムスタンプ | 作成日時 |
+| `updatedAt` | `Timestamp` | ✅ | サーバータイムスタンプ | 更新日時 |
+
+**型定義（TypeScript）:**
 
 ```typescript
-interface Todo {
-  id: number;       // 一意なID
-  text: string;     // Todoテキスト
-  completed: boolean; // 完了フラグ
+interface NailItem {
+  title: string
+  imageUrl: string
+  thumbnailUrl: string
+  tags: string[]
+  memo: string
+  createdAt: Timestamp
+  updatedAt: Timestamp
 }
 ```
 
-### 永続化が必要になった場合の拡張候補（**[要人間判断]**）
+**決定事項:**
+- `thumbnailUrl` を `imageUrl` と別フィールドで保持 — モバイルリスト表示でフル解像度は重い。将来 Cloud Storage Resize Extension で自動生成可能。
+- `memo` を追加 — サロン名・価格・シーンのメモニーズに対応。今入れないと後でマイグレーションが必要。
+- `color` / AI フィールドはスキップ — Gemini API 連携フェーズ（Phase 3 以降）で追加。今追加しても入力 UI がない。
+- `tags` は `string[]` のままで構造化しない — スタイル・色・シーンを自由に分類できる柔軟性を優先。
+
+**アクセスルール（Phase 1 Security Rules 移行後）:**
+- `users/{userId}/nailItems/{itemId}` — ログイン済み本人のみ read / write
+
+---
+
+### Todo（フロントエンド state のみ — 開発用スキャフォールド）
+
+現在の実装に残っている Todo 機能は開発用の足場であり、将来削除予定です。
 
 ```typescript
 interface Todo {
-  id: string;           // UUID
-  text: string;
-  completed: boolean;
-  createdAt: Date;
-  updatedAt: Date;
-  userId?: string;      // マルチユーザー対応時
+  id: number
+  text: string
+  completed: boolean
 }
 ```
 
-DB / ストレージ方式: **[TBD]**
+DB / ストレージ方式: なし（フロントエンド state のみ）
 
 ---
 
@@ -167,6 +199,7 @@ DB / ストレージ方式: **[TBD]**
 | Q4 | デプロイ先は何を使うか | 中 | 人間 |
 | Q5 | モバイル対応のレベル感（レスポンシブのみ / アプリ） | 中 | 人間 |
 | Q6 | プロダクト名 | 低 | 人間 |
+| Q13 | NailItem Firestore スキーマの最終確定 | 高 | ✅ **確定 2026-05-01** — Data Model Overview 参照 |
 
 これらの質問に回答が必要な場合は [HUMAN_TASK_REQUEST.md](../harness/HUMAN_TASK_REQUEST.md) を使って Issue を起票してください。
 


### PR DESCRIPTION
## Summary

- **`docs/product/PRODUCT_SPEC.md`**: NailItem Firestore schema 確定（Q13 解決）
- **`docs/operations/FIRESTORE_SECURITY_RULES.md`**: A2 (Google Auth 確認済) と A3 (スキーマ確定) を ✅ に更新
- Issue #14 クローズ済み

## 確定スキーマ

| フィールド | 型 | 説明 |
|-----------|-----|------|
| `title` | `string` | ネイルタイトル |
| `imageUrl` | `string` | Firebase Storage URL（フル解像度） |
| `thumbnailUrl` | `string` | Firebase Storage URL（サムネイル） |
| `tags` | `string[]` | タグ（最大10件） |
| `memo` | `string` | メモ（最大500文字、空文字可） |
| `createdAt` | `Timestamp` | 作成日時 |
| `updatedAt` | `Timestamp` | 更新日時 |

**thumbnailUrl**: モバイルリスト表示でフル解像度は重いため別フィールドで保持。将来 Cloud Storage Resize Extension で自動生成。  
**memo**: サロン名・価格・シーンのメモに対応。後付けはマイグレーションが必要なため今追加。  
**color / AI フィールド**: Gemini API フェーズまでスキップ（YAGNI）。

## A4 ブロッカー解消状況

| 条件 | 状態 |
|------|------|
| A2 Google Auth 実機確認 | ✅ |
| A3 NailItem スキーマ確定 | ✅ |
| Phase 1 rules Firebase Emulator テスト | ⬜（任意推奨） |
| **A4 移行承認 (Issue #15)** | → 人間が判断可能な状態に |

## Test plan

- [x] `npm run build` passes
- [x] docs 変更のみ、src / package.json 無変更

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)