### PR TITLE
feat: Firestore smoke test — NailItem create/fetch

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -247,6 +247,34 @@
   }
 }
 
+#smoke-test {
+  margin: 16px 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  align-items: flex-start;
+}
+
+.nail-status {
+  font-size: 0.85rem;
+  color: #888;
+  margin: 0;
+}
+
+#nail-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+#nail-list li {
+  font-size: 0.85rem;
+  padding: 2px 0;
+}
+
 #auth-bar {
   min-height: 40px;
   display: flex;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,8 @@
 import { useState, useEffect } from 'react'
 import { auth, signInWithGoogle, signOutUser, onAuthStateChanged } from './lib/auth'
 import type { User } from './lib/auth'
+import { createTestNailItem, fetchNailItems } from './lib/firestore'
+import type { NailItemDoc } from './lib/firestore'
 import reactLogo from './assets/react.svg'
 import viteLogo from './assets/vite.svg'
 import heroImg from './assets/hero.png'
@@ -17,8 +19,29 @@ function App() {
   const [inputValue, setInputValue] = useState('')
   const [todos, setTodos] = useState<Todo[]>([])
   const [user, setUser] = useState<User | null | undefined>(undefined)
+  const [nailItems, setNailItems] = useState<NailItemDoc[]>([])
+  const [nailStatus, setNailStatus] = useState('')
+  const [nailLoading, setNailLoading] = useState(false)
 
   useEffect(() => onAuthStateChanged(auth, setUser), [])
+
+  useEffect(() => {
+    if (!user) { setNailItems([]); setNailStatus(''); return }
+    fetchNailItems(user.uid)
+      .then(setNailItems)
+      .catch((e: unknown) => console.error('fetch failed', e))
+  }, [user])
+
+  const handleCreateNailItem = () => {
+    if (!user) return
+    setNailLoading(true)
+    setNailStatus('')
+    createTestNailItem(user.uid)
+      .then(id => { setNailStatus(`Created: ${id}`); return fetchNailItems(user.uid) })
+      .then(setNailItems)
+      .catch((e: unknown) => setNailStatus(`Error: ${String(e)}`))
+      .finally(() => setNailLoading(false))
+  }
 
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setInputValue(e.target.value)
@@ -71,6 +94,21 @@ function App() {
             </button>
           )}
         </div>
+        {user && (
+          <div id="smoke-test">
+            <button type="button" onClick={handleCreateNailItem} disabled={nailLoading}>
+              {nailLoading ? 'Creating...' : 'Create test NailItem'}
+            </button>
+            {nailStatus && <p className="nail-status">{nailStatus}</p>}
+            {nailItems.length > 0 && (
+              <ul id="nail-list">
+                {nailItems.map(item => (
+                  <li key={item.id}>{item.title}</li>
+                ))}
+              </ul>
+            )}
+          </div>
+        )}
         <div className="hero">
           <img src={heroImg} className="base" width="170" height="179" alt="" />
           <img src={reactLogo} className="framework" alt="React logo" />

--- a/src/lib/firebase.ts
+++ b/src/lib/firebase.ts
@@ -1,5 +1,6 @@
 import { initializeApp } from 'firebase/app'
 import { getAuth } from 'firebase/auth'
+import { getFirestore } from 'firebase/firestore'
 
 const firebaseConfig = {
   apiKey: import.meta.env.VITE_FIREBASE_API_KEY,
@@ -13,7 +14,4 @@ const firebaseConfig = {
 const app = initializeApp(firebaseConfig)
 
 export const auth = getAuth(app)
-
-// Firestore is initialized here once Security Rules are approved:
-// import { getFirestore } from 'firebase/firestore'
-// export const db = getFirestore(app)
+export const db = getFirestore(app)

--- a/src/lib/firestore.ts
+++ b/src/lib/firestore.ts
@@ -1,0 +1,40 @@
+import { collection, addDoc, getDocs, serverTimestamp } from 'firebase/firestore'
+import type { Timestamp } from 'firebase/firestore'
+import { db } from './firebase'
+
+export interface NailItem {
+  title: string
+  imageUrl: string
+  thumbnailUrl: string
+  tags: string[]
+  memo: string
+  createdAt: Timestamp | null
+  updatedAt: Timestamp | null
+}
+
+export interface NailItemDoc extends NailItem {
+  id: string
+}
+
+export const createTestNailItem = async (userId: string): Promise<string> => {
+  const ref = collection(db, 'users', userId, 'nailItems')
+  const snap = await addDoc(ref, {
+    title: `test-nail-${Date.now()}`,
+    imageUrl: '',
+    thumbnailUrl: '',
+    tags: [] as string[],
+    memo: 'smoke test',
+    createdAt: serverTimestamp(),
+    updatedAt: serverTimestamp(),
+  })
+  return snap.id
+}
+
+export const fetchNailItems = async (userId: string): Promise<NailItemDoc[]> => {
+  const ref = collection(db, 'users', userId, 'nailItems')
+  const snapshot = await getDocs(ref)
+  return snapshot.docs.map(doc => ({
+    id: doc.id,
+    ...(doc.data() as NailItem),
+  }))
+}


### PR DESCRIPTION
## Summary

Phase 1 Firestore Security Rules が正しく機能することを確認するための最小実装です。

## 変更内容

### `src/lib/firebase.ts`
- `getFirestore` を有効化、`db` をエクスポート

### `src/lib/firestore.ts` (新規)
- `NailItem` / `NailItemDoc` 型定義
- `createTestNailItem(userId)` — `users/{uid}/nailItems` に最小データを書き込む
- `fetchNailItems(userId)` — `users/{uid}/nailItems` を一覧取得する

### `src/App.tsx`
- ログイン済みの場合のみ `#smoke-test` セクションを表示
- 「Create test NailItem」ボタン（loading 状態あり）
- 作成結果 / エラーを `nailStatus` に表示
- サインイン時に自動フェッチ、サインアウト時にリストをクリア
- 既存 Todo 機能・`#auth-bar` は変更なし

### `src/App.css`
- `#smoke-test` / `.nail-status` / `#nail-list` スタイル追加

## Rules 安全確認

- `user` が `null` の場合は Firestore 操作を実行しない (`if (!user) return`)
- path は `users/${user.uid}/nailItems` — Phase 1 rules の `request.auth.uid == userId` を満たす
- エラーは `.catch()` で捕捉して画面表示

## Test plan（人間が実施）

- [ ] `npm run dev` 起動 → `http://localhost:5173`
- [ ] 未ログイン時に `#smoke-test` セクションが表示されない
- [ ] Google Sign-In 後に「Create test NailItem」ボタンが表示される
- [ ] ボタンクリックで「Creating...」→「Created: {id}」に変わる
- [ ] リストに `test-nail-{timestamp}` が表示される
- [ ] Firebase Console → Firestore → `users/{uid}/nailItems` にドキュメントが存在する
- [ ] Sign out → リストが消える
- [ ] Sign in し直す → 前回作成アイテムが再表示される
- [ ] iPad (VS Code Tunnel) でも同様に確認

## Bundle size 変化

| | 変更前 | 変更後 |
|--|--------|--------|
| JS (gzip) | 93.99 kB | 164.84 kB |

Firestore SDK (+`firebase/firestore`) が追加されたため増加。想定内。

🤖 Generated with [Claude Code](https://claude.com/claude-code)