### PR TITLE
feat: NailItem CRUD UI (create / read / update / delete)

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -247,18 +247,48 @@
   }
 }
 
-#smoke-test {
+#nail-section {
   margin: 16px 0;
+  width: 100%;
+  max-width: 400px;
+  text-align: left;
+}
+
+#nail-section h2 {
+  font-size: 1rem;
+  margin: 0 0 12px;
+}
+
+#nail-form {
   display: flex;
   flex-direction: column;
   gap: 8px;
-  align-items: flex-start;
+  margin-bottom: 16px;
 }
 
-.nail-status {
+.nail-input {
+  padding: 8px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  font-size: 0.9rem;
+  box-sizing: border-box;
+  width: 100%;
+}
+
+.nail-form-actions {
+  display: flex;
+  gap: 8px;
+}
+
+.nail-error {
+  font-size: 0.85rem;
+  color: #c00;
+  margin: 0;
+}
+
+.nail-empty {
   font-size: 0.85rem;
   color: #888;
-  margin: 0;
 }
 
 #nail-list {
@@ -267,12 +297,48 @@
   margin: 0;
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: 8px;
 }
 
 #nail-list li {
-  font-size: 0.85rem;
-  padding: 2px 0;
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  padding: 8px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  gap: 8px;
+}
+
+#nail-list li.editing {
+  border-color: var(--accent);
+}
+
+.nail-item-info {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  flex: 1;
+  min-width: 0;
+}
+
+.nail-item-title {
+  font-size: 0.9rem;
+  font-weight: 500;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.nail-item-tags {
+  font-size: 0.75rem;
+  color: #888;
+}
+
+.nail-item-actions {
+  display: flex;
+  gap: 6px;
+  flex-shrink: 0;
 }
 
 #auth-bar {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from 'react'
 import { auth, signInWithGoogle, signOutUser, onAuthStateChanged } from './lib/auth'
 import type { User } from './lib/auth'
-import { createTestNailItem, fetchNailItems } from './lib/firestore'
+import { addNailItem, updateNailItem, deleteNailItem, fetchNailItems } from './lib/firestore'
 import type { NailItemDoc } from './lib/firestore'
 import reactLogo from './assets/react.svg'
 import viteLogo from './assets/vite.svg'
@@ -20,26 +20,67 @@ function App() {
   const [todos, setTodos] = useState<Todo[]>([])
   const [user, setUser] = useState<User | null | undefined>(undefined)
   const [nailItems, setNailItems] = useState<NailItemDoc[]>([])
-  const [nailStatus, setNailStatus] = useState('')
+  const [nailTitle, setNailTitle] = useState('')
+  const [nailTags, setNailTags] = useState('')
+  const [nailImageUrl, setNailImageUrl] = useState('')
+  const [editingId, setEditingId] = useState<string | null>(null)
   const [nailLoading, setNailLoading] = useState(false)
+  const [nailError, setNailError] = useState('')
 
   useEffect(() => onAuthStateChanged(auth, setUser), [])
 
   useEffect(() => {
-    if (!user) { setNailItems([]); setNailStatus(''); return }
+    if (!user) { setNailItems([]); return }
     fetchNailItems(user.uid)
       .then(setNailItems)
       .catch((e: unknown) => console.error('fetch failed', e))
   }, [user])
 
-  const handleCreateNailItem = () => {
-    if (!user) return
+  const parseTags = (s: string): string[] =>
+    s.split(',').map(t => t.trim()).filter(Boolean)
+
+  const resetForm = () => {
+    setNailTitle('')
+    setNailTags('')
+    setNailImageUrl('')
+    setEditingId(null)
+    setNailError('')
+  }
+
+  const handleSubmitNailItem = () => {
+    if (!user || nailTitle.trim() === '') return
+    const uid = user.uid
     setNailLoading(true)
-    setNailStatus('')
-    createTestNailItem(user.uid)
-      .then(id => { setNailStatus(`Created: ${id}`); return fetchNailItems(user.uid) })
+    setNailError('')
+    const input = { title: nailTitle.trim(), imageUrl: nailImageUrl.trim(), tags: parseTags(nailTags), memo: '' }
+    const op: Promise<void> = editingId
+      ? updateNailItem(uid, editingId, input)
+      : addNailItem(uid, input).then(() => {})
+    op
+      .then(() => fetchNailItems(uid))
+      .then(items => { setNailItems(items); resetForm() })
+      .catch((e: unknown) => setNailError(String(e)))
+      .finally(() => setNailLoading(false))
+  }
+
+  const handleStartEdit = (item: NailItemDoc) => {
+    setEditingId(item.id)
+    setNailTitle(item.title)
+    setNailTags(item.tags.join(', '))
+    setNailImageUrl(item.imageUrl)
+    setNailError('')
+  }
+
+  const handleDeleteNailItem = (itemId: string) => {
+    if (!user) return
+    const uid = user.uid
+    if (editingId === itemId) resetForm()
+    setNailLoading(true)
+    setNailError('')
+    deleteNailItem(uid, itemId)
+      .then(() => fetchNailItems(uid))
       .then(setNailItems)
-      .catch((e: unknown) => setNailStatus(`Error: ${String(e)}`))
+      .catch((e: unknown) => setNailError(String(e)))
       .finally(() => setNailLoading(false))
   }
 
@@ -95,15 +136,73 @@ function App() {
           )}
         </div>
         {user && (
-          <div id="smoke-test">
-            <button type="button" onClick={handleCreateNailItem} disabled={nailLoading}>
-              {nailLoading ? 'Creating...' : 'Create test NailItem'}
-            </button>
-            {nailStatus && <p className="nail-status">{nailStatus}</p>}
-            {nailItems.length > 0 && (
+          <div id="nail-section">
+            <h2>My Nail Items</h2>
+            <div id="nail-form">
+              <input
+                type="text"
+                value={nailTitle}
+                onChange={e => setNailTitle(e.target.value)}
+                placeholder="Title *"
+                className="nail-input"
+              />
+              <input
+                type="text"
+                value={nailTags}
+                onChange={e => setNailTags(e.target.value)}
+                placeholder="Tags (comma separated)"
+                className="nail-input"
+              />
+              <input
+                type="text"
+                value={nailImageUrl}
+                onChange={e => setNailImageUrl(e.target.value)}
+                placeholder="Image URL (optional)"
+                className="nail-input"
+              />
+              <div className="nail-form-actions">
+                <button
+                  type="button"
+                  onClick={handleSubmitNailItem}
+                  disabled={nailLoading || nailTitle.trim() === ''}
+                >
+                  {nailLoading ? 'Saving...' : editingId ? 'Update' : 'Add NailItem'}
+                </button>
+                {editingId && (
+                  <button type="button" onClick={resetForm} disabled={nailLoading}>
+                    Cancel
+                  </button>
+                )}
+              </div>
+              {nailError && <p className="nail-error">{nailError}</p>}
+            </div>
+            {nailItems.length === 0 ? (
+              <p className="nail-empty">No nail items yet.</p>
+            ) : (
               <ul id="nail-list">
                 {nailItems.map(item => (
-                  <li key={item.id}>{item.title}</li>
+                  <li key={item.id} className={editingId === item.id ? 'editing' : ''}>
+                    <div className="nail-item-info">
+                      <span className="nail-item-title">{item.title}</span>
+                      {item.tags.length > 0 && (
+                        <span className="nail-item-tags">
+                          {item.tags.map(t => '#' + t).join(' ')}
+                        </span>
+                      )}
+                    </div>
+                    <div className="nail-item-actions">
+                      <button
+                        type="button"
+                        onClick={() => handleStartEdit(item)}
+                        disabled={nailLoading}
+                      >Edit</button>
+                      <button
+                        type="button"
+                        onClick={() => handleDeleteNailItem(item.id)}
+                        disabled={nailLoading}
+                      >Delete</button>
+                    </div>
+                  </li>
                 ))}
               </ul>
             )}

--- a/src/lib/firestore.ts
+++ b/src/lib/firestore.ts
@@ -1,4 +1,8 @@
-import { collection, addDoc, getDocs, serverTimestamp } from 'firebase/firestore'
+import {
+  collection, addDoc, getDocs,
+  doc, updateDoc, deleteDoc,
+  serverTimestamp,
+} from 'firebase/firestore'
 import type { Timestamp } from 'firebase/firestore'
 import { db } from './firebase'
 
@@ -16,25 +20,53 @@ export interface NailItemDoc extends NailItem {
   id: string
 }
 
-export const createTestNailItem = async (userId: string): Promise<string> => {
+export interface NailItemInput {
+  title: string
+  imageUrl: string
+  tags: string[]
+  memo: string
+}
+
+export const fetchNailItems = async (userId: string): Promise<NailItemDoc[]> => {
+  const ref = collection(db, 'users', userId, 'nailItems')
+  const snapshot = await getDocs(ref)
+  return snapshot.docs.map(snap => ({
+    id: snap.id,
+    ...(snap.data() as NailItem),
+  }))
+}
+
+export const addNailItem = async (userId: string, input: NailItemInput): Promise<string> => {
   const ref = collection(db, 'users', userId, 'nailItems')
   const snap = await addDoc(ref, {
-    title: `test-nail-${Date.now()}`,
-    imageUrl: '',
-    thumbnailUrl: '',
-    tags: [] as string[],
-    memo: 'smoke test',
+    title: input.title,
+    imageUrl: input.imageUrl,
+    thumbnailUrl: input.imageUrl,
+    tags: input.tags,
+    memo: input.memo,
     createdAt: serverTimestamp(),
     updatedAt: serverTimestamp(),
   })
   return snap.id
 }
 
-export const fetchNailItems = async (userId: string): Promise<NailItemDoc[]> => {
-  const ref = collection(db, 'users', userId, 'nailItems')
-  const snapshot = await getDocs(ref)
-  return snapshot.docs.map(doc => ({
-    id: doc.id,
-    ...(doc.data() as NailItem),
-  }))
+export const updateNailItem = async (
+  userId: string,
+  itemId: string,
+  input: NailItemInput,
+): Promise<void> => {
+  const ref = doc(db, 'users', userId, 'nailItems', itemId)
+  await updateDoc(ref, {
+    title: input.title,
+    imageUrl: input.imageUrl,
+    thumbnailUrl: input.imageUrl,
+    tags: input.tags,
+    memo: input.memo,
+    updatedAt: serverTimestamp(),
+  })
+}
+
+export const deleteNailItem = async (userId: string, itemId: string): Promise<void> => {
+  const ref = doc(db, 'users', userId, 'nailItems', itemId)
+  await deleteDoc(ref)
 }


### PR DESCRIPTION
## Summary

smoke test UI (`#smoke-test`) を本格的な NailItem CRUD UI (`#nail-section`) に置き換えます。

## 変更内容

### `src/lib/firestore.ts`
- `createTestNailItem` 削除（smoke test 専用）
- `NailItemInput` 型を追加
- `addNailItem(userId, input)` — タイトル・タグ・imageUrl を受け取り作成
- `updateNailItem(userId, itemId, input)` — 全フィールドを上書き（`thumbnailUrl` も同期）
- `deleteNailItem(userId, itemId)` — ドキュメント削除

### `src/App.tsx`
- state: `nailTitle` / `nailTags` / `nailImageUrl` / `editingId` / `nailError` を追加
- handlers: `resetForm` / `handleSubmitNailItem` / `handleStartEdit` / `handleDeleteNailItem`
- JSX: `#nail-section` — タイトル・タグ・imageURL 入力フォーム、Add/Update/Cancel ボタン、アイテム一覧（Edit/Delete）
- `nailTitle` が空のとき Add ボタンを `disabled`
- 編集中アイテムは `li.editing` でハイライト
- エラーは `.nail-error` でフォーム下に表示

### `src/App.css`
- smoke test スタイルを削除
- `#nail-section` / `#nail-form` / `.nail-input` / `.nail-form-actions` / `.nail-item-info/title/tags/actions` / `#nail-list li.editing` を追加
- 平坦セレクタのみ使用（CSS guard 準拠）

## 変更なし
- Firebase Storage 連携なし（`imageUrl` はテキスト入力）
- `firestore.rules` 変更なし
- Todo デモ機能維持
- `package.json` 変更なし

## Test plan（人間が実施）

- [ ] `npm run dev` → ログイン前は `#nail-section` 非表示
- [ ] Sign-In → フォームと一覧が表示される
- [ ] タイトル入力 → Add NailItem → 一覧に追加
- [ ] タイトル空のまま → Add ボタンが disabled
- [ ] Edit クリック → フォームが既存値で pre-fill、ボタンが Update / Cancel に変わる
- [ ] Update → 一覧が更新される
- [ ] Cancel → フォームがリセット、作成モードに戻る
- [ ] Delete → 一覧から消える、Firestore Console でも確認
- [ ] Sign out → `#nail-section` が非表示
- [ ] Sign in し直し → 前回データが復元される
- [ ] Todo 機能（追加・完了・削除）が引き続き動作する
- [ ] iPad (VS Code Tunnel) でも同様に動作する

🤖 Generated with [Claude Code](https://claude.com/claude-code)