### PR TITLE
feat: UI polish — Nailous title, card grid, tag badges, loading/error states

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,109 +1,26 @@
 #center {
   display: flex;
   flex-direction: column;
-  gap: 25px;
-  place-content: center;
+  gap: 20px;
+  place-content: start;
   place-items: center;
   flex-grow: 1;
+  padding: 32px 20px 48px;
+}
 
-  @media (max-width: 1024px) {
-    padding: 32px 20px 24px;
-    gap: 18px;
+@media (max-width: 480px) {
+  #center {
+    padding: 20px 16px 40px;
+    gap: 16px;
   }
 }
 
-#nail-section {
-  margin: 16px 0;
-  width: 100%;
-  max-width: 400px;
-  text-align: left;
-}
-
-#nail-section h2 {
-  font-size: 1rem;
-  margin: 0 0 12px;
-}
-
-#nail-form {
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-  margin-bottom: 16px;
-}
-
-.nail-input {
-  padding: 8px;
-  border: 1px solid var(--border);
-  border-radius: 6px;
-  font-size: 0.9rem;
-  box-sizing: border-box;
-  width: 100%;
-}
-
-.nail-form-actions {
-  display: flex;
-  gap: 8px;
-}
-
-.nail-error {
-  font-size: 0.85rem;
-  color: #c00;
+#app-title {
+  font-size: 2rem;
+  font-weight: 700;
+  letter-spacing: 0.02em;
   margin: 0;
-}
-
-.nail-empty {
-  font-size: 0.85rem;
-  color: #888;
-}
-
-#nail-list {
-  list-style: none;
-  padding: 0;
-  margin: 0;
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-}
-
-#nail-list li {
-  display: flex;
-  justify-content: space-between;
-  align-items: flex-start;
-  padding: 8px;
-  border: 1px solid var(--border);
-  border-radius: 6px;
-  gap: 8px;
-}
-
-#nail-list li.editing {
-  border-color: var(--accent);
-}
-
-.nail-item-info {
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
-  flex: 1;
-  min-width: 0;
-}
-
-.nail-item-title {
-  font-size: 0.9rem;
-  font-weight: 500;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.nail-item-tags {
-  font-size: 0.75rem;
-  color: #888;
-}
-
-.nail-item-actions {
-  display: flex;
-  gap: 6px;
-  flex-shrink: 0;
+  color: var(--text-h);
 }
 
 #auth-bar {
@@ -111,7 +28,7 @@
   display: flex;
   justify-content: center;
   align-items: center;
-  margin-bottom: 16px;
+  margin-bottom: 4px;
 }
 
 .auth-user {
@@ -147,4 +64,178 @@
 
 .auth-signin:hover {
   background: rgba(255, 255, 255, 0.08);
+}
+
+#nail-section {
+  width: 100%;
+  max-width: 600px;
+  text-align: left;
+}
+
+#nail-form {
+  background: var(--social-bg);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  margin-bottom: 24px;
+}
+
+.nail-form-title {
+  font-size: 1rem;
+  font-weight: 600;
+  margin: 0;
+  line-height: 1;
+  letter-spacing: 0;
+}
+
+.nail-input {
+  padding: 9px 12px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  font-size: 0.9rem;
+  box-sizing: border-box;
+  width: 100%;
+  background: transparent;
+  color: inherit;
+}
+
+.nail-form-actions {
+  display: flex;
+  gap: 8px;
+}
+
+.nail-error {
+  font-size: 0.85rem;
+  color: #c00;
+  border-left: 3px solid #c00;
+  background: rgba(204, 0, 0, 0.06);
+  padding: 10px 12px;
+  border-radius: 0 4px 4px 0;
+  margin: 0;
+}
+
+.nail-loading {
+  text-align: center;
+  padding: 40px 0;
+  font-size: 0.9rem;
+  color: #888;
+}
+
+.nail-empty {
+  text-align: center;
+  padding: 48px 0;
+}
+
+.nail-empty-main {
+  font-size: 1rem;
+  color: var(--text-h);
+  margin: 0 0 6px;
+}
+
+.nail-empty-sub {
+  font-size: 0.85rem;
+  color: #888;
+  margin: 0;
+}
+
+#nail-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 12px;
+}
+
+@media (max-width: 480px) {
+  #nail-list {
+    grid-template-columns: 1fr;
+  }
+}
+
+#nail-list.loading {
+  opacity: 0.5;
+  pointer-events: none;
+}
+
+#nail-list li {
+  display: flex;
+  flex-direction: column;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  overflow: hidden;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.06);
+}
+
+#nail-list li.editing {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 2px var(--accent-border);
+}
+
+.nail-card-thumb {
+  position: relative;
+  aspect-ratio: 4 / 3;
+  overflow: hidden;
+  background: var(--border);
+}
+
+.nail-thumb-placeholder {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.75rem;
+  color: #aaa;
+}
+
+.nail-thumb-img {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.nail-card-body {
+  padding: 10px 12px;
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.nail-item-title {
+  font-size: 0.9rem;
+  font-weight: 600;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--text-h);
+}
+
+.nail-item-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+}
+
+.nail-tag {
+  font-size: 0.7rem;
+  padding: 2px 8px;
+  background: var(--accent-bg);
+  color: var(--accent);
+  border-radius: 9999px;
+  line-height: 1.6;
+}
+
+.nail-item-actions {
+  display: flex;
+  gap: 6px;
+  justify-content: flex-end;
+  padding: 8px 12px;
+  border-top: 1px solid var(--border);
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,14 +14,17 @@ function App() {
   const [editingId, setEditingId] = useState<string | null>(null)
   const [nailLoading, setNailLoading] = useState(false)
   const [nailError, setNailError] = useState('')
+  const [isFetching, setIsFetching] = useState(false)
 
   useEffect(() => onAuthStateChanged(auth, setUser), [])
 
   useEffect(() => {
     if (!user) { setNailItems([]); return }
+    setIsFetching(true)
     fetchNailItems(user.uid)
       .then(setNailItems)
       .catch((e: unknown) => console.error('fetch failed', e))
+      .finally(() => setIsFetching(false))
   }, [user])
 
   const parseTags = (s: string): string[] =>
@@ -74,95 +77,114 @@ function App() {
 
   return (
     <section id="center">
-        <div id="auth-bar">
-          {user === undefined ? null : user ? (
-            <div className="auth-user">
-              <span>{user.displayName ?? user.email}</span>
-              <button type="button" onClick={() => {
-                signOutUser().catch((e: unknown) => console.error('sign-out failed', e))
-              }}>Sign out</button>
+      <h1 id="app-title">Nailous</h1>
+      <div id="auth-bar">
+        {user === undefined ? null : user ? (
+          <div className="auth-user">
+            <span>{user.displayName ?? user.email}</span>
+            <button type="button" onClick={() => {
+              signOutUser().catch((e: unknown) => console.error('sign-out failed', e))
+            }}>Sign out</button>
+          </div>
+        ) : (
+          <button type="button" className="auth-signin" onClick={() => {
+            signInWithGoogle().catch((e: unknown) => console.error('sign-in failed', e))
+          }}>
+            Sign in with Google
+          </button>
+        )}
+      </div>
+      {user && (
+        <div id="nail-section">
+          <div id="nail-form">
+            <h2 className="nail-form-title">{editingId ? 'Edit Nail Item' : 'Add Nail Item'}</h2>
+            <input
+              type="text"
+              value={nailTitle}
+              onChange={e => setNailTitle(e.target.value)}
+              placeholder="Title *"
+              className="nail-input"
+            />
+            <input
+              type="text"
+              value={nailTags}
+              onChange={e => setNailTags(e.target.value)}
+              placeholder="Tags (comma separated)"
+              className="nail-input"
+            />
+            <input
+              type="text"
+              value={nailImageUrl}
+              onChange={e => setNailImageUrl(e.target.value)}
+              placeholder="Image URL (optional)"
+              className="nail-input"
+            />
+            <div className="nail-form-actions">
+              <button
+                type="button"
+                onClick={handleSubmitNailItem}
+                disabled={nailLoading || nailTitle.trim() === ''}
+              >
+                {nailLoading ? 'Saving...' : editingId ? 'Update' : 'Add'}
+              </button>
+              {editingId && (
+                <button type="button" onClick={resetForm} disabled={nailLoading}>
+                  Cancel
+                </button>
+              )}
+            </div>
+            {nailError && <p className="nail-error">{nailError}</p>}
+          </div>
+          {isFetching ? (
+            <p className="nail-loading">Loading...</p>
+          ) : nailItems.length === 0 ? (
+            <div className="nail-empty">
+              <p className="nail-empty-main">No nail items yet.</p>
+              <p className="nail-empty-sub">Add your first one above.</p>
             </div>
           ) : (
-            <button type="button" className="auth-signin" onClick={() => {
-              signInWithGoogle().catch((e: unknown) => console.error('sign-in failed', e))
-            }}>
-              Sign in with Google
-            </button>
+            <ul id="nail-list" className={nailLoading ? 'loading' : ''}>
+              {nailItems.map(item => (
+                <li key={item.id} className={editingId === item.id ? 'editing' : ''}>
+                  <div className="nail-card-thumb">
+                    <div className="nail-thumb-placeholder">No image</div>
+                    {item.imageUrl && (
+                      <img
+                        className="nail-thumb-img"
+                        src={item.imageUrl}
+                        alt={item.title}
+                        onError={e => { (e.currentTarget as HTMLImageElement).style.display = 'none' }}
+                      />
+                    )}
+                  </div>
+                  <div className="nail-card-body">
+                    <span className="nail-item-title">{item.title}</span>
+                    {item.tags.length > 0 && (
+                      <div className="nail-item-tags">
+                        {item.tags.map(t => (
+                          <span key={t} className="nail-tag">#{t}</span>
+                        ))}
+                      </div>
+                    )}
+                  </div>
+                  <div className="nail-item-actions">
+                    <button
+                      type="button"
+                      onClick={() => handleStartEdit(item)}
+                      disabled={nailLoading}
+                    >Edit</button>
+                    <button
+                      type="button"
+                      onClick={() => handleDeleteNailItem(item.id)}
+                      disabled={nailLoading}
+                    >Delete</button>
+                  </div>
+                </li>
+              ))}
+            </ul>
           )}
         </div>
-        {user && (
-          <div id="nail-section">
-            <h2>My Nail Items</h2>
-            <div id="nail-form">
-              <input
-                type="text"
-                value={nailTitle}
-                onChange={e => setNailTitle(e.target.value)}
-                placeholder="Title *"
-                className="nail-input"
-              />
-              <input
-                type="text"
-                value={nailTags}
-                onChange={e => setNailTags(e.target.value)}
-                placeholder="Tags (comma separated)"
-                className="nail-input"
-              />
-              <input
-                type="text"
-                value={nailImageUrl}
-                onChange={e => setNailImageUrl(e.target.value)}
-                placeholder="Image URL (optional)"
-                className="nail-input"
-              />
-              <div className="nail-form-actions">
-                <button
-                  type="button"
-                  onClick={handleSubmitNailItem}
-                  disabled={nailLoading || nailTitle.trim() === ''}
-                >
-                  {nailLoading ? 'Saving...' : editingId ? 'Update' : 'Add NailItem'}
-                </button>
-                {editingId && (
-                  <button type="button" onClick={resetForm} disabled={nailLoading}>
-                    Cancel
-                  </button>
-                )}
-              </div>
-              {nailError && <p className="nail-error">{nailError}</p>}
-            </div>
-            {nailItems.length === 0 ? (
-              <p className="nail-empty">No nail items yet.</p>
-            ) : (
-              <ul id="nail-list">
-                {nailItems.map(item => (
-                  <li key={item.id} className={editingId === item.id ? 'editing' : ''}>
-                    <div className="nail-item-info">
-                      <span className="nail-item-title">{item.title}</span>
-                      {item.tags.length > 0 && (
-                        <span className="nail-item-tags">
-                          {item.tags.map(t => '#' + t).join(' ')}
-                        </span>
-                      )}
-                    </div>
-                    <div className="nail-item-actions">
-                      <button
-                        type="button"
-                        onClick={() => handleStartEdit(item)}
-                        disabled={nailLoading}
-                      >Edit</button>
-                      <button
-                        type="button"
-                        onClick={() => handleDeleteNailItem(item.id)}
-                        disabled={nailLoading}
-                      >Delete</button>
-                    </div>
-                  </li>
-                ))}
-              </ul>
-            )}
-          </div>
-        )}
+      )}
     </section>
   )
 }


### PR DESCRIPTION
## Summary

- **アプリタイトル**: "Nailous" を `<h1>` として画面上部に追加
- **レイアウト**: `place-content: start` に変更（アイテム増加時の自然なスクロール）、`#nail-section` を `max-width: 600px` に拡大
- **フォーム**: カード形式（背景・border・border-radius）、タイトルが "Add" / "Edit" で動的切り替え
- **カードグリッド**: 2列（デスクトップ）/ 1列（モバイル ≤480px）のCSS grid
- **サムネイル**: 4:3 アスペクト比、imageUrl あり → `<img>`、imageUrl なし or 読み込みエラー → "No image" プレースホルダー
- **タグバッジ**: pill 形状、`--accent-bg` / `--accent` カラー使用
- **ローディング**: `isFetching` state 追加で初回取得中に "Loading..." 表示、操作中は grid を opacity 0.5 + pointer-events none でディム
- **エラー表示**: 左ボーダー付きエラーボックスに改善
- **空状態**: メインテキスト + サブテキストの2行表示

## 維持した機能

- Google Auth（サインイン / サインアウト）
- NailItem 作成 / 一覧 / 編集 / 削除（CRUD 全操作）
- Firestore 接続

## Test plan

- [ ] `npm run build` が通ること
- [ ] `commands/check-css-guard.ps1` が passed になること
- [ ] サインインなし → "Nailous" タイトル + Sign in ボタンのみ
- [ ] サインイン直後 → "Loading..." 表示後にリスト / 空状態に切り替わること
- [ ] NailItem 追加（imageUrl なし）→ プレースホルダーカードが表示されること
- [ ] NailItem 追加（imageUrl あり）→ サムネイル画像が表示されること
- [ ] タグを入力した場合 → バッジ形式で表示されること
- [ ] Edit → フォームに "Edit Nail Item" タイトル、対象カードがハイライト
- [ ] Update / Delete が正常動作すること
- [ ] モバイル幅（375px）でカードが1列になること
- [ ] サインアウト → リストが消えてサインインボタンに戻ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)