### PR TITLE
feat(storage): image upload UI — storage.ts, firebase.ts storage export, App.tsx

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -102,6 +102,24 @@
   color: inherit;
 }
 
+.nail-file-area {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.nail-file-input {
+  font-size: 0.85rem;
+  color: var(--text);
+  cursor: pointer;
+}
+
+.nail-file-note {
+  font-size: 0.8rem;
+  color: #888;
+  margin: 0;
+}
+
 .nail-form-actions {
   display: flex;
   gap: 8px;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,8 +1,9 @@
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useRef } from 'react'
 import { auth, signInWithGoogle, signOutUser, onAuthStateChanged } from './lib/auth'
 import type { User } from './lib/auth'
 import { addNailItem, updateNailItem, deleteNailItem, fetchNailItems } from './lib/firestore'
 import type { NailItemDoc } from './lib/firestore'
+import { uploadNailImage, deleteNailImage } from './lib/storage'
 import './App.css'
 
 function App() {
@@ -10,11 +11,12 @@ function App() {
   const [nailItems, setNailItems] = useState<NailItemDoc[]>([])
   const [nailTitle, setNailTitle] = useState('')
   const [nailTags, setNailTags] = useState('')
-  const [nailImageUrl, setNailImageUrl] = useState('')
+  const [nailImageFile, setNailImageFile] = useState<File | null>(null)
   const [editingId, setEditingId] = useState<string | null>(null)
   const [nailLoading, setNailLoading] = useState(false)
   const [nailError, setNailError] = useState('')
   const [isFetching, setIsFetching] = useState(false)
+  const fileInputRef = useRef<HTMLInputElement>(null)
 
   useEffect(() => onAuthStateChanged(auth, setUser), [])
 
@@ -33,47 +35,72 @@ function App() {
   const resetForm = () => {
     setNailTitle('')
     setNailTags('')
-    setNailImageUrl('')
+    setNailImageFile(null)
+    if (fileInputRef.current) fileInputRef.current.value = ''
     setEditingId(null)
     setNailError('')
   }
 
-  const handleSubmitNailItem = () => {
+  const handleSubmitNailItem = async () => {
     if (!user || nailTitle.trim() === '') return
     const uid = user.uid
     setNailLoading(true)
     setNailError('')
-    const input = { title: nailTitle.trim(), imageUrl: nailImageUrl.trim(), tags: parseTags(nailTags), memo: '' }
-    const op: Promise<void> = editingId
-      ? updateNailItem(uid, editingId, input)
-      : addNailItem(uid, input).then(() => {})
-    op
-      .then(() => fetchNailItems(uid))
-      .then(items => { setNailItems(items); resetForm() })
-      .catch((e: unknown) => setNailError(String(e)))
-      .finally(() => setNailLoading(false))
+    const baseInput = { title: nailTitle.trim(), tags: parseTags(nailTags), memo: '' }
+    try {
+      if (editingId) {
+        const editingItem = nailItems.find(i => i.id === editingId)
+        let imageUrl = editingItem?.imageUrl ?? ''
+        if (nailImageFile) {
+          imageUrl = await uploadNailImage(uid, editingId, nailImageFile)
+        }
+        await updateNailItem(uid, editingId, { ...baseInput, imageUrl })
+      } else {
+        const itemId = await addNailItem(uid, { ...baseInput, imageUrl: '' })
+        if (nailImageFile) {
+          const imageUrl = await uploadNailImage(uid, itemId, nailImageFile)
+          await updateNailItem(uid, itemId, { ...baseInput, imageUrl })
+        }
+      }
+      setNailItems(await fetchNailItems(uid))
+      resetForm()
+    } catch (e: unknown) {
+      setNailError(String(e))
+    } finally {
+      setNailLoading(false)
+    }
   }
 
   const handleStartEdit = (item: NailItemDoc) => {
     setEditingId(item.id)
     setNailTitle(item.title)
     setNailTags(item.tags.join(', '))
-    setNailImageUrl(item.imageUrl)
+    setNailImageFile(null)
+    if (fileInputRef.current) fileInputRef.current.value = ''
     setNailError('')
   }
 
-  const handleDeleteNailItem = (itemId: string) => {
+  const handleDeleteNailItem = async (itemId: string) => {
     if (!user) return
     const uid = user.uid
+    const item = nailItems.find(i => i.id === itemId)
     if (editingId === itemId) resetForm()
     setNailLoading(true)
     setNailError('')
-    deleteNailItem(uid, itemId)
-      .then(() => fetchNailItems(uid))
-      .then(setNailItems)
-      .catch((e: unknown) => setNailError(String(e)))
-      .finally(() => setNailLoading(false))
+    try {
+      if (item?.imageUrl) {
+        await deleteNailImage(uid, itemId).catch(() => {})
+      }
+      await deleteNailItem(uid, itemId)
+      setNailItems(await fetchNailItems(uid))
+    } catch (e: unknown) {
+      setNailError(String(e))
+    } finally {
+      setNailLoading(false)
+    }
   }
+
+  const editingItem = editingId ? nailItems.find(i => i.id === editingId) : null
 
   return (
     <section id="center">
@@ -112,13 +139,18 @@ function App() {
               placeholder="Tags (comma separated)"
               className="nail-input"
             />
-            <input
-              type="text"
-              value={nailImageUrl}
-              onChange={e => setNailImageUrl(e.target.value)}
-              placeholder="Image URL (optional)"
-              className="nail-input"
-            />
+            <div className="nail-file-area">
+              <input
+                ref={fileInputRef}
+                type="file"
+                accept="image/jpeg,image/png,image/webp"
+                onChange={e => setNailImageFile(e.target.files?.[0] ?? null)}
+                className="nail-file-input"
+              />
+              {editingItem?.imageUrl && !nailImageFile && (
+                <p className="nail-file-note">Current image kept. Select to replace.</p>
+              )}
+            </div>
             <div className="nail-form-actions">
               <button
                 type="button"

--- a/src/lib/firebase.ts
+++ b/src/lib/firebase.ts
@@ -1,6 +1,7 @@
 import { initializeApp } from 'firebase/app'
 import { getAuth } from 'firebase/auth'
 import { getFirestore } from 'firebase/firestore'
+import { getStorage } from 'firebase/storage'
 
 const firebaseConfig = {
   apiKey: import.meta.env.VITE_FIREBASE_API_KEY,
@@ -15,3 +16,4 @@ const app = initializeApp(firebaseConfig)
 
 export const auth = getAuth(app)
 export const db = getFirestore(app)
+export const storage = getStorage(app)

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -1,0 +1,20 @@
+import { ref, uploadBytes, getDownloadURL, deleteObject } from 'firebase/storage'
+import { storage } from './firebase'
+
+export const uploadNailImage = async (
+  userId: string,
+  nailItemId: string,
+  file: File
+): Promise<string> => {
+  const storageRef = ref(storage, `users/${userId}/nailItems/${nailItemId}/original`)
+  await uploadBytes(storageRef, file, { contentType: file.type })
+  return getDownloadURL(storageRef)
+}
+
+export const deleteNailImage = async (
+  userId: string,
+  nailItemId: string
+): Promise<void> => {
+  const storageRef = ref(storage, `users/${userId}/nailItems/${nailItemId}/original`)
+  await deleteObject(storageRef)
+}


### PR DESCRIPTION
## Summary

- **`src/lib/firebase.ts`**: `getStorage` 追加 → `storage` export
- **`src/lib/storage.ts`** 新規作成:
  - `uploadNailImage(userId, nailItemId, file)` — `users/{uid}/nailItems/{id}/original` にアップロード → download URL を返す
  - `deleteNailImage(userId, nailItemId)` — Storage ファイルを削除
- **`src/App.tsx`**:
  - `nailImageUrl` (テキスト入力) → `nailImageFile: File | null` に置き換え
  - `fileInputRef` で `<input type="file">` をリセット可能に
  - `handleSubmitNailItem` を async/await に変更: 新規追加時はドキュメント作成後にアップロード → imageUrl を更新
  - `handleDeleteNailItem`: Firestore 削除前に Storage ファイルを削除（エラーは無視）
  - 編集時に既存画像がある場合は "Current image kept. Select to replace." ヒントを表示
- **`src/App.css`**: `.nail-file-area` / `.nail-file-input` / `.nail-file-note` スタイル追加

## 維持した機能

- Google Auth（サインイン / サインアウト）
- NailItem 作成 / 一覧 / 編集 / 削除

## Test plan

- [ ] `npm run build` が通ること
- [ ] `commands/check-css-guard.ps1` が passed になること
- [ ] 画像なしで NailItem 追加 → プレースホルダーカード表示
- [ ] jpeg/png/webp を選択して追加 → カードにサムネイル表示
- [ ] Edit → "Current image kept." ヒントが表示される
- [ ] Edit で新しいファイルを選択して Update → サムネイルが更新される
- [ ] Edit でファイル未選択のまま Update → 既存サムネイルが保持される
- [ ] Delete → Firebase Console の Storage からファイルが削除されている
- [ ] 5MB 超のファイルを選択して Add → Storage の Rules エラーが表示される
- [ ] jpeg/png/webp 以外のファイル（PDF 等）を選択して Add → Rules エラーが表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)