### PR TITLE
chore: ignore Claude Code local settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ dist-ssr
 *.sln
 *.sw?
 .aider*
+
+# Claude Code local settings
+.claude/


### PR DESCRIPTION
Adds .claude/ to .gitignore so local Claude Code settings are not shown as untracked files.