### PR TITLE
docs: add nail view prototype as design reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,3 +100,9 @@ export default defineConfig([
 | [docs/operations/FIREBASE_SETUP.md](docs/operations/FIREBASE_SETUP.md) | Firebase Auth setup and verification steps |
 | [docs/operations/FIREBASE_STORAGE_RULES.md](docs/operations/FIREBASE_STORAGE_RULES.md) | Storage Security Rules design, allowed types/sizes, and deploy checklist |
 | [docs/operations/IMAGE_UPLOAD_QA.md](docs/operations/IMAGE_UPLOAD_QA.md) | QA checklist for image upload — normal, error, edit, delete, and pre-merge checks |
+
+### Design References
+
+| Document | Description |
+|----------|-------------|
+| [docs/design-references/nail-view-prototype/README.md](docs/design-references/nail-view-prototype/README.md) | Nail view UI prototype — color palette, layout, and component styles for reference only |

--- a/docs/design-references/nail-view-prototype/README.md
+++ b/docs/design-references/nail-view-prototype/README.md
@@ -1,0 +1,50 @@
+# Nail View Prototype — Design Reference
+
+> このフォルダは **デザイン参考資料** です。現在の React 実装 (`src/`) とは独立しています。
+
+## 概要
+
+`prototype.html` は、別リポジトリ (`C:\dev\nail-report-reference`) に存在した初期 Vite scaffold のデザインを、スタンドアロン HTML として保存したものです。
+
+CSS 変数（カラーパレット・タイポグラフィ）、レイアウトパターン、コンポーネントスタイルの参考として保存しています。
+
+## ファイル構成
+
+| ファイル | 内容 |
+|---|---|
+| `prototype.html` | `index.css` + `App.css` を inline 化したスタンドアロン HTML |
+
+## 使用方法
+
+ブラウザで `prototype.html` を直接開くだけで表示できます（ビルド不要）。
+
+## 重要な注意事項
+
+### このフォルダからやってはいけないこと
+
+- **現在の `src/` へそのままコピーしない**
+  React 実装は現在の `src/App.tsx` / `src/App.css` が正です。
+  prototype.html のコードを直接 `src/` へ貼り付けないでください。
+
+- **Firebase Auth / Firestore / Storage 実装は現在の `src/` 側を正とする**
+  参考プロトタイプは Firebase 連携を持ちません。
+  認証・データ保存・画像アップロードのロジックは `src/lib/` の実装を参照してください。
+
+- **Security Rules / deploy / package 追加はこの参考資料から行わない**
+  `firestore.rules` / `storage.rules` / `firebase.json` / `package.json` の変更は、
+  本体リポジトリの Issue 単位で別途実施してください。
+
+### UI 改善時の手順
+
+UI をこのプロトタイプに近づけたい場合は、**Issue 単位で小さく移植**してください。
+
+1. 移植したいデザイン要素を Issue に記載する
+2. 専用ブランチ (`feat/...` または `style/...`) で `src/App.css` を変更する
+3. `npm run build` と `.\commands\check-css-guard.ps1` で確認する
+4. PR を作成してレビューを受ける
+
+## 参照元
+
+- 元ファイル: `C:\dev\nail-report-reference\src\index.css` + `src\App.css` + `src\App.tsx`
+- コピー対象: CSS（インライン化済み）+ 静的 HTML 構造のみ
+- コピー除外: `.git/`, `node_modules/`, `package.json`, `tsconfig*`, `vite.config.ts`, `.github/`, `commands/`, `agents/`

--- a/docs/design-references/nail-view-prototype/prototype.html
+++ b/docs/design-references/nail-view-prototype/prototype.html
@@ -1,0 +1,369 @@
+<!doctype html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Nail View Prototype — Design Reference</title>
+  <style>
+    /* ===== index.css ===== */
+    :root {
+      --text: #6b6375;
+      --text-h: #08060d;
+      --bg: #fff;
+      --border: #e5e4e7;
+      --code-bg: #f4f3ec;
+      --accent: #aa3bff;
+      --accent-bg: rgba(170, 59, 255, 0.1);
+      --accent-border: rgba(170, 59, 255, 0.5);
+      --social-bg: rgba(244, 243, 236, 0.5);
+      --shadow:
+        rgba(0, 0, 0, 0.1) 0 10px 15px -3px,
+        rgba(0, 0, 0, 0.05) 0 4px 6px -2px;
+
+      --sans: system-ui, 'Segoe UI', Roboto, sans-serif;
+      --heading: system-ui, 'Segoe UI', Roboto, sans-serif;
+      --mono: ui-monospace, Consolas, monospace;
+
+      font: 18px/145% var(--sans);
+      letter-spacing: 0.18px;
+      color-scheme: light dark;
+      color: var(--text);
+      background: var(--bg);
+      font-synthesis: none;
+      text-rendering: optimizeLegibility;
+      -webkit-font-smoothing: antialiased;
+      -moz-osx-font-smoothing: grayscale;
+    }
+
+    @media (max-width: 1024px) {
+      :root { font-size: 16px; }
+    }
+
+    @media (prefers-color-scheme: dark) {
+      :root {
+        --text: #9ca3af;
+        --text-h: #f3f4f6;
+        --bg: #16171d;
+        --border: #2e303a;
+        --code-bg: #1f2028;
+        --accent: #c084fc;
+        --accent-bg: rgba(192, 132, 252, 0.15);
+        --accent-border: rgba(192, 132, 252, 0.5);
+        --social-bg: rgba(47, 48, 58, 0.5);
+        --shadow:
+          rgba(0, 0, 0, 0.4) 0 10px 15px -3px,
+          rgba(0, 0, 0, 0.25) 0 4px 6px -2px;
+      }
+    }
+
+    #root {
+      width: 1126px;
+      max-width: 100%;
+      margin: 0 auto;
+      text-align: center;
+      border-inline: 1px solid var(--border);
+      min-height: 100svh;
+      display: flex;
+      flex-direction: column;
+      box-sizing: border-box;
+    }
+
+    body { margin: 0; }
+
+    h1, h2 {
+      font-family: var(--heading);
+      font-weight: 500;
+      color: var(--text-h);
+    }
+
+    h1 {
+      font-size: 56px;
+      letter-spacing: -1.68px;
+      margin: 32px 0;
+    }
+
+    @media (max-width: 1024px) {
+      h1 { font-size: 36px; margin: 20px 0; }
+    }
+
+    h2 {
+      font-size: 24px;
+      line-height: 118%;
+      letter-spacing: -0.24px;
+      margin: 0 0 8px;
+    }
+
+    @media (max-width: 1024px) {
+      h2 { font-size: 20px; }
+    }
+
+    p { margin: 0; }
+
+    code {
+      font-family: var(--mono);
+      display: inline-flex;
+      border-radius: 4px;
+      color: var(--text-h);
+      font-size: 15px;
+      line-height: 135%;
+      padding: 4px 8px;
+      background: var(--code-bg);
+    }
+
+    /* ===== App.css ===== */
+    #center {
+      display: flex;
+      flex-direction: column;
+      gap: 25px;
+      place-content: center;
+      place-items: center;
+      flex-grow: 1;
+    }
+
+    @media (max-width: 1024px) {
+      #center { padding: 32px 20px 24px; gap: 18px; }
+    }
+
+    .counter {
+      font-size: 16px;
+      font-family: var(--mono);
+      display: inline-flex;
+      border-radius: 4px;
+      color: var(--text-h);
+      padding: 5px 10px;
+      border-radius: 5px;
+      color: var(--accent);
+      background: var(--accent-bg);
+      border: 2px solid transparent;
+      transition: border-color 0.3s;
+      margin-bottom: 24px;
+      cursor: pointer;
+    }
+
+    .counter:hover { border-color: var(--accent-border); }
+
+    #next-steps {
+      display: flex;
+      border-top: 1px solid var(--border);
+      text-align: left;
+    }
+
+    #next-steps > div {
+      flex: 1 1 0;
+      padding: 32px;
+    }
+
+    @media (max-width: 1024px) {
+      #next-steps > div { padding: 24px 20px; }
+      #next-steps { flex-direction: column; text-align: center; }
+    }
+
+    #docs {
+      border-right: 1px solid var(--border);
+    }
+
+    @media (max-width: 1024px) {
+      #docs { border-right: none; border-bottom: 1px solid var(--border); }
+    }
+
+    #next-steps ul {
+      list-style: none;
+      padding: 0;
+      display: flex;
+      gap: 8px;
+      margin: 32px 0 0;
+    }
+
+    #next-steps ul a {
+      color: var(--text-h);
+      font-size: 16px;
+      border-radius: 6px;
+      background: var(--social-bg);
+      display: flex;
+      padding: 6px 12px;
+      align-items: center;
+      gap: 8px;
+      text-decoration: none;
+      transition: box-shadow 0.3s;
+    }
+
+    #next-steps ul a:hover { box-shadow: var(--shadow); }
+
+    @media (max-width: 1024px) {
+      #next-steps ul { margin-top: 20px; flex-wrap: wrap; justify-content: center; }
+      #next-steps ul li { flex: 1 1 calc(50% - 8px); }
+      #next-steps ul a { width: 100%; justify-content: center; box-sizing: border-box; }
+    }
+
+    #spacer {
+      height: 88px;
+      border-top: 1px solid var(--border);
+    }
+
+    @media (max-width: 1024px) {
+      #spacer { height: 48px; }
+    }
+
+    .ticks {
+      position: relative;
+      width: 100%;
+    }
+
+    .ticks::before,
+    .ticks::after {
+      content: '';
+      position: absolute;
+      top: -4.5px;
+      border: 5px solid transparent;
+    }
+
+    .ticks::before { left: 0; border-left-color: var(--border); }
+    .ticks::after  { right: 0; border-right-color: var(--border); }
+
+    #todo-list {
+      list-style-type: none;
+      padding: 0;
+      margin: 28px 0;
+    }
+
+    #todo-list li {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      gap: 12px;
+      padding: 10px 12px;
+      border-bottom: 1px solid var(--border);
+    }
+
+    #todo-list li:last-child { border-bottom: none; }
+
+    #todo-list .todo-text {
+      flex-grow: 1;
+      cursor: pointer;
+      line-height: 1.5;
+    }
+
+    #todo-list li.completed .todo-text {
+      text-decoration: line-through;
+      opacity: 0.65;
+    }
+
+    #todo-list button {
+      background: none;
+      border: 1px solid var(--border);
+      border-radius: 6px;
+      cursor: pointer;
+      padding: 6px 10px;
+    }
+
+    #todo-list button:hover { background: rgba(255, 255, 255, 0.08); }
+
+    .todo-input {
+      padding: 8px;
+      border: 1px solid var(--border);
+      border-radius: 6px;
+      margin-bottom: 10px;
+      width: 300px;
+      box-sizing: border-box;
+    }
+
+    .add-button {
+      padding: 8px 16px;
+      background-color: var(--accent);
+      color: white;
+      border: none;
+      border-radius: 6px;
+      cursor: pointer;
+    }
+
+    .add-button:hover { background-color: color-mix(in srgb, var(--accent) 80%, black); }
+
+    /* ===== Prototype notice banner ===== */
+    .proto-notice {
+      background: var(--accent-bg);
+      border: 1px solid var(--accent-border);
+      border-radius: 6px;
+      padding: 8px 16px;
+      font-size: 13px;
+      color: var(--accent);
+      margin: 16px auto 0;
+      max-width: 600px;
+      text-align: center;
+    }
+  </style>
+</head>
+<body>
+  <div id="root">
+    <!-- DESIGN REFERENCE NOTICE -->
+    <div class="proto-notice">
+      📌 これはデザイン参考資料です。現在の React 実装 (src/) とは独立しています。
+    </div>
+
+    <section id="center">
+      <!-- Hero placeholder (assets/react.svg, vite.svg は元リポジトリ由来のため省略) -->
+      <div style="height: 80px; display: flex; align-items: center; justify-content: center; color: var(--text); font-size: 13px;">
+        [hero image area — react.svg / vite.svg / hero.png]
+      </div>
+
+      <div>
+        <h1>Get started</h1>
+        <p>
+          Edit <code>src/App.tsx</code> and save to test <code>HMR</code>
+        </p>
+      </div>
+
+      <button type="button" class="counter">
+        Count is 0
+      </button>
+
+      <input
+        type="text"
+        placeholder="Add a new todo..."
+        class="todo-input"
+      />
+      <button class="add-button">Add</button>
+
+      <ul id="todo-list">
+        <li>
+          <span class="todo-text">Sample todo item 1</span>
+          <button type="button">Delete</button>
+        </li>
+        <li class="completed">
+          <span class="todo-text">Completed item (line-through)</span>
+          <button type="button">Delete</button>
+        </li>
+        <li>
+          <span class="todo-text">Sample todo item 3</span>
+          <button type="button">Delete</button>
+        </li>
+      </ul>
+    </section>
+
+    <div class="ticks"></div>
+
+    <section id="next-steps">
+      <div id="docs">
+        <h2>Documentation</h2>
+        <p>Your questions, answered</p>
+        <ul>
+          <li><a href="#">Explore Vite</a></li>
+          <li><a href="#">Learn more</a></li>
+        </ul>
+      </div>
+      <div id="social">
+        <h2>Connect with us</h2>
+        <p>Join the Vite community</p>
+        <ul>
+          <li><a href="#">GitHub</a></li>
+          <li><a href="#">Discord</a></li>
+          <li><a href="#">X.com</a></li>
+          <li><a href="#">Bluesky</a></li>
+        </ul>
+      </div>
+    </section>
+
+    <div class="ticks"></div>
+    <section id="spacer"></section>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary

- `docs/design-references/nail-view-prototype/prototype.html` を新規作成
  - `C:\dev\nail-report-reference` の `index.css` + `App.css` を inline 化したスタンドアロン HTML
  - ブラウザで直接開くだけで表示可能（ビルド不要）
- `docs/design-references/nail-view-prototype/README.md` を新規作成
  - 参考資料であること・`src/` へのコピー禁止・Firebase 実装は本体を正とすることを明記
- `README.md` に Design References セクションを追加

## コピー元・除外

| コピーしたもの | コピーしなかったもの |
|---|---|
| `src/index.css`（CSS変数・グローバルスタイル） | `.git/`, `node_modules/` |
| `src/App.css`（コンポーネントスタイル） | `package.json`, `tsconfig*`, `vite.config.ts` |
| `src/App.tsx`（静的HTML構造として再現） | `.github/`, `commands/`, `agents/` |

## Test plan

- [ ] `npm run build` 成功 ✅
- [ ] `check-css-guard.ps1` → `CSS guard passed.` ✅
- [ ] `src/` に変更なし ✅
- [ ] `prototype.html` をブラウザで開いてデザインが確認できる

Generated with Claude Code