### PR TITLE
style: add hover lift, shadow, and image zoom to nail cards

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -257,3 +257,40 @@
   padding: 8px 12px;
   border-top: 1px solid var(--border);
 }
+
+#nail-list li {
+  transition: transform 0.22s ease, box-shadow 0.22s ease, border-color 0.22s ease;
+}
+
+#nail-list li:hover {
+  transform: translateY(-3px);
+  box-shadow: var(--shadow);
+  border-color: var(--accent-border);
+}
+
+#nail-list li.editing:hover {
+  transform: none;
+  box-shadow: 0 0 0 2px var(--accent-border);
+  border-color: var(--accent);
+}
+
+.nail-thumb-img {
+  transition: transform 0.3s ease;
+}
+
+#nail-list li:hover .nail-thumb-img {
+  transform: scale(1.05);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  #nail-list li,
+  .nail-thumb-img {
+    transition: none;
+  }
+  #nail-list li:hover {
+    transform: none;
+  }
+  #nail-list li:hover .nail-thumb-img {
+    transform: none;
+  }
+}


### PR DESCRIPTION
## Summary

- カードホバー時のリフト (`translateY(-3px)`) + shadow escalation
- ブランドカラー（紫）のボーダーヒント (`border-color: var(--accent-border)`)
- サムネイル画像ズーム (`scale(1.05)`) — Pinterest/Instagram パターン
- 編集中カードはリフト除外（accent glow を保持）
- `prefers-reduced-motion` 対応でアクセシビリティ確保

## 変更ファイル

- `src/App.css` のみ（+37行、TSX変更なし）

## Test plan

- [x] `npm run build` 成功
- [x] `check-css-guard.ps1` → `CSS guard passed.`
- [x] 実機確認済み（カードホバーで lift + 画像ズーム）
- [ ] 編集中カードがリフトしないことを確認
- [ ] モバイル幅（480px）で表示崩れなし
- [ ] ダークモードで色が正しい

🤖 Generated with [Claude Code](https://claude.com/claude-code)