### PR TITLE
style: add accent primary button (Add/Update)

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -123,6 +123,33 @@
 .nail-form-actions {
   display: flex;
   gap: 8px;
+  align-items: center;
+}
+
+.btn-primary {
+  background: var(--accent);
+  color: #fff;
+  border: 1px solid transparent;
+  border-radius: 6px;
+  padding: 8px 20px;
+  font-size: 0.9rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: filter 0.18s ease, opacity 0.18s ease;
+}
+
+.btn-primary:hover:not(:disabled) {
+  filter: brightness(0.88);
+}
+
+.btn-primary:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.btn-primary:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
 }
 
 .nail-error {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -186,6 +186,7 @@ function App() {
             <div className="nail-form-actions">
               <button
                 type="button"
+                className="btn-primary"
                 onClick={handleSubmitNailItem}
                 disabled={nailLoading || nailTitle.trim() === ''}
               >


### PR DESCRIPTION
## Summary

- Add/Update ボタンに `btn-primary` クラスを付与
- `background: var(--accent)` + `color: #fff` でアクセントカラー化（ダーク/ライト自動対応）
- `filter: brightness(0.88)` で hover 時に暗くなる（色変数追加なし）
- `opacity: 0.5` + `cursor: not-allowed` で disabled 状態を明示
- `focus-visible` リングでキーボードアクセシビリティ確保
- `.nail-form-actions` に `align-items: center` を追加して Cancel ボタンと縦揃え

## 変更ファイル

- `src/App.tsx` — `className="btn-primary"` を submit ボタンに追加（+1行）
- `src/App.css` — `.btn-primary` スタイル群を追加（+27行）

## Test plan

- [x] `npm run build` 成功
- [x] `check-css-guard.ps1` → `CSS guard passed.`
- [x] 実機確認済み（accent ボタン表示・hover・disabled）
- [ ] ダークモードで色が正しい
- [ ] キーボード Tab → Enter で Add が動作する

🤖 Generated with [Claude Code](https://claude.com/claude-code)