### PR TITLE
style: unify secondary button style (Cancel, Edit, Delete)

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -285,6 +285,36 @@
   border-top: 1px solid var(--border);
 }
 
+.nail-item-actions button,
+.nail-form-actions button:not(.btn-primary) {
+  background: none;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 6px 12px;
+  font-size: 0.85rem;
+  color: inherit;
+  cursor: pointer;
+  transition: background-color 0.18s ease, border-color 0.18s ease;
+}
+
+.nail-item-actions button:hover:not(:disabled),
+.nail-form-actions button:not(.btn-primary):hover:not(:disabled) {
+  background: var(--accent-bg);
+  border-color: var(--accent-border);
+}
+
+.nail-item-actions button:focus-visible,
+.nail-form-actions button:not(.btn-primary):focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.nail-item-actions button:disabled,
+.nail-form-actions button:not(.btn-primary):disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
 #nail-list li {
   transition: transform 0.22s ease, box-shadow 0.22s ease, border-color 0.22s ease;
 }


### PR DESCRIPTION
## Summary

- Edit / Delete / Cancel ボタンに統一的な secondary スタイルを適用
- `background: none` + `border: 1px solid var(--border)` でクリーンな枠線ボタン
- hover で `background: var(--accent-bg)` + `border-color: var(--accent-border)` のブランドカラー tint
- `focus-visible` リング・`disabled` opacity も合わせて設定
- TSX 変更なし（CSS セレクタのみで対象指定）

## ボタン階層

| 種別 | ボタン | スタイル |
|---|---|---|
| Primary | Add / Update | 紫背景・白文字 (PR #34) |
| Secondary | Edit / Delete / Cancel | 枠線・hover で accent tint (本PR) |
| Auth | Sign in / Sign out | 既存スタイル維持 |

## 依存

> ⚠️ このブランチは `style/primary-button-accent` (#34) を土台にしています。
> PR #34 をマージ後、本 PR の base を `main` に変更してからマージしてください。

## 変更ファイル

- `src/App.css` のみ（+30行）

## Test plan

- [x] `npm run build` 成功
- [x] `check-css-guard.ps1` → `CSS guard passed.`
- [ ] Edit / Delete ボタンに枠線・hover で薄紫
- [ ] Cancel ボタンも同スタイル
- [ ] ダークモードで色が正しい

🤖 Generated with [Claude Code](https://claude.com/claude-code)