### PR TITLE
a11y: add focus-visible ring to Sign in / Sign out buttons

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -52,6 +52,11 @@
   background: rgba(255, 255, 255, 0.08);
 }
 
+.auth-user button:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
 .auth-signin {
   padding: 8px 20px;
   border: 1px solid var(--border);
@@ -64,6 +69,11 @@
 
 .auth-signin:hover {
   background: rgba(255, 255, 255, 0.08);
+}
+
+.auth-signin:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
 }
 
 #nail-section {


### PR DESCRIPTION
## Summary

- `.auth-user button:focus-visible` — Sign out ボタンに accent focus ring を追加
- `.auth-signin:focus-visible` — Sign in with Google ボタンに accent focus ring を追加

## 背景

Issue A〜E で全ボタンに focus-visible を適用済みでしたが、auth 系ボタンのみ未対応でした。本 PR でアプリ内の全インタラクティブ要素が `outline: 2px solid var(--accent); outline-offset: 2px` で統一されます。

## 変更ファイル

- `src/App.css` のみ（+10行、TSX 変更なし）

## Test plan

- [x] `npm run build` 成功
- [x] `check-css-guard.ps1` → `CSS guard passed.`
- [ ] `Tab` キーで Sign in / Sign out に移動すると紫の focus ring が表示される
- [ ] マウスクリック時に ring が出ない（`:focus-visible` のみ適用）
- [ ] 既存の hover 表現が維持されている

🤖 Generated with [Claude Code](https://claude.com/claude-code)