### PR TITLE
feat: add memo field to NailItem create, edit, and card display

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -112,6 +112,21 @@
   color: inherit;
 }
 
+.nail-textarea {
+  padding: 9px 12px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  font-size: 0.9rem;
+  font-family: inherit;
+  line-height: 1.5;
+  box-sizing: border-box;
+  width: 100%;
+  background: transparent;
+  color: inherit;
+  resize: vertical;
+  min-height: 72px;
+}
+
 .nail-file-area {
   display: flex;
   flex-direction: column;
@@ -270,6 +285,18 @@
   text-overflow: ellipsis;
   white-space: nowrap;
   color: var(--text-h);
+}
+
+.nail-item-memo {
+  font-size: 0.78rem;
+  color: var(--text);
+  line-height: 1.5;
+  margin: 0;
+  overflow: hidden;
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+  line-clamp: 2;
 }
 
 .nail-item-tags {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,7 @@ function App() {
   const [nailItems, setNailItems] = useState<NailItemDoc[]>([])
   const [nailTitle, setNailTitle] = useState('')
   const [nailTags, setNailTags] = useState('')
+  const [nailMemo, setNailMemo] = useState('')
   const [nailImageFile, setNailImageFile] = useState<File | null>(null)
   const [editingId, setEditingId] = useState<string | null>(null)
   const [nailLoading, setNailLoading] = useState(false)
@@ -60,6 +61,7 @@ function App() {
   const resetForm = () => {
     setNailTitle('')
     setNailTags('')
+    setNailMemo('')
     setNailImageFile(null)
     if (fileInputRef.current) fileInputRef.current.value = ''
     setEditingId(null)
@@ -75,7 +77,7 @@ function App() {
     const uid = user.uid
     setNailLoading(true)
     setNailError('')
-    const baseInput = { title: nailTitle.trim(), tags: parseTags(nailTags), memo: '' }
+    const baseInput = { title: nailTitle.trim(), tags: parseTags(nailTags), memo: nailMemo.trim() }
     try {
       if (editingId) {
         const editingItem = nailItems.find(i => i.id === editingId)
@@ -107,6 +109,7 @@ function App() {
     setEditingId(item.id)
     setNailTitle(item.title)
     setNailTags(item.tags.join(', '))
+    setNailMemo(item.memo ?? '')
     setNailImageFile(null)
     if (fileInputRef.current) fileInputRef.current.value = ''
     setNailError('')
@@ -171,6 +174,14 @@ function App() {
               placeholder="Tags (comma separated)"
               className="nail-input"
             />
+            <textarea
+              value={nailMemo}
+              onChange={e => setNailMemo(e.target.value)}
+              placeholder="Memo (salon, price, scene...)"
+              className="nail-textarea"
+              rows={3}
+              maxLength={500}
+            />
             <div className="nail-file-area">
               <input
                 ref={fileInputRef}
@@ -230,6 +241,9 @@ function App() {
                           <span key={t} className="nail-tag">#{t}</span>
                         ))}
                       </div>
+                    )}
+                    {item.memo && (
+                      <p className="nail-item-memo">{item.memo}</p>
                     )}
                   </div>
                   <div className="nail-item-actions">


### PR DESCRIPTION
## Summary

- フォームに `memo` textarea を追加（Tags 入力の下、ファイル選択の上）
- Add/Update 時に `nailMemo.trim()` を Firestore へ送信
- Edit 時に `item.memo ?? ''` でフォームに復元
- Cancel / resetForm 時に memo をリセット
- カードの `.nail-card-body` にメモを 2行クランプで表示
- 既存データ（memo フィールドなし）は `item.memo && ...` で安全に処理

## 変更ファイル

| ファイル | 変更内容 |
|---|---|
| `src/App.tsx` | `nailMemo` state 追加、baseInput 修正、handleStartEdit/resetForm 更新、textarea・カード表示追加（+16行） |
| `src/App.css` | `.nail-textarea`・`.nail-item-memo` 追加（+27行） |

## 変更なしのファイル

- `src/lib/firestore.ts` — `NailItemInput.memo` はすでに実装済みのため変更不要
- `firestore.rules` — 変更なし
- `package.json` — 変更なし

## Test plan

- [x] `npm run build` 成功
- [x] `check-css-guard.ps1` → `CSS guard passed.`
- [x] 実機確認済み（memo 入力・保存・表示・編集・リセット）
- [ ] 既存アイテム（memo なし）が正常表示されること
- [ ] 長い memo が 2行でクランプされること
- [ ] モバイル幅（480px）で textarea が崩れないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)