### PR TITLE
feat: display createdAt and updatedAt on nail item cards

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -299,6 +299,13 @@
   line-clamp: 2;
 }
 
+.nail-item-date {
+  font-size: 0.72rem;
+  color: #888;
+  margin: 0;
+  margin-top: auto;
+}
+
 .nail-item-tags {
   display: flex;
   flex-wrap: wrap;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,17 @@ import type { NailItemDoc } from './lib/firestore'
 import { uploadNailImage, deleteNailImage } from './lib/storage'
 import './App.css'
 
+const formatDate = (ts: { toDate(): Date } | null | undefined): string | null => {
+  if (!ts) return null
+  try {
+    return ts.toDate().toLocaleDateString('ja-JP', {
+      year: 'numeric', month: 'numeric', day: 'numeric',
+    })
+  } catch {
+    return null
+  }
+}
+
 function App() {
   const [user, setUser] = useState<User | null | undefined>(undefined)
   const [nailItems, setNailItems] = useState<NailItemDoc[]>([])
@@ -220,46 +231,58 @@ function App() {
             </div>
           ) : (
             <ul id="nail-list" className={nailLoading ? 'loading' : ''}>
-              {nailItems.map(item => (
-                <li key={item.id} className={editingId === item.id ? 'editing' : ''}>
-                  <div className="nail-card-thumb">
-                    <div className="nail-thumb-placeholder">No image</div>
-                    {item.imageUrl && (
-                      <img
-                        className="nail-thumb-img"
-                        src={item.imageUrl}
-                        alt={item.title}
-                        onError={e => { (e.currentTarget as HTMLImageElement).style.display = 'none' }}
-                      />
-                    )}
-                  </div>
-                  <div className="nail-card-body">
-                    <span className="nail-item-title">{item.title}</span>
-                    {item.tags.length > 0 && (
-                      <div className="nail-item-tags">
-                        {item.tags.map(t => (
-                          <span key={t} className="nail-tag">#{t}</span>
-                        ))}
-                      </div>
-                    )}
-                    {item.memo && (
-                      <p className="nail-item-memo">{item.memo}</p>
-                    )}
-                  </div>
-                  <div className="nail-item-actions">
-                    <button
-                      type="button"
-                      onClick={() => handleStartEdit(item)}
-                      disabled={nailLoading}
-                    >Edit</button>
-                    <button
-                      type="button"
-                      onClick={() => handleDeleteNailItem(item.id)}
-                      disabled={nailLoading}
-                    >Delete</button>
-                  </div>
-                </li>
-              ))}
+              {nailItems.map(item => {
+                const createdDate = formatDate(item.createdAt)
+                const updatedDate = (item.updatedAt && item.createdAt &&
+                  item.updatedAt.seconds !== item.createdAt.seconds)
+                  ? formatDate(item.updatedAt)
+                  : null
+                return (
+                  <li key={item.id} className={editingId === item.id ? 'editing' : ''}>
+                    <div className="nail-card-thumb">
+                      <div className="nail-thumb-placeholder">No image</div>
+                      {item.imageUrl && (
+                        <img
+                          className="nail-thumb-img"
+                          src={item.imageUrl}
+                          alt={item.title}
+                          onError={e => { (e.currentTarget as HTMLImageElement).style.display = 'none' }}
+                        />
+                      )}
+                    </div>
+                    <div className="nail-card-body">
+                      <span className="nail-item-title">{item.title}</span>
+                      {item.tags.length > 0 && (
+                        <div className="nail-item-tags">
+                          {item.tags.map(t => (
+                            <span key={t} className="nail-tag">#{t}</span>
+                          ))}
+                        </div>
+                      )}
+                      {item.memo && (
+                        <p className="nail-item-memo">{item.memo}</p>
+                      )}
+                      {(createdDate || updatedDate) && (
+                        <p className="nail-item-date">
+                          {createdDate}{updatedDate && `・更新 ${updatedDate}`}
+                        </p>
+                      )}
+                    </div>
+                    <div className="nail-item-actions">
+                      <button
+                        type="button"
+                        onClick={() => handleStartEdit(item)}
+                        disabled={nailLoading}
+                      >Edit</button>
+                      <button
+                        type="button"
+                        onClick={() => handleDeleteNailItem(item.id)}
+                        disabled={nailLoading}
+                      >Delete</button>
+                    </div>
+                  </li>
+                )
+              })}
             </ul>
           )}
         </div>


### PR DESCRIPTION
## Summary

- `formatDate` ヘルパー関数を追加（`ja-JP` ロケール、`YYYY/M/D` 形式）
- カード下部に `createdAt` を表示（`margin-top: auto` でカード最下端に固定）
- `updatedAt.seconds !== createdAt.seconds` のときのみ「・更新 YYYY/M/D」を追記
- `null` / フィールドなしの旧データは日付欄を非表示にして安全処理

## 変更ファイル

| ファイル | 変更内容 |
|---|---|
| `src/App.tsx` | `formatDate` 関数追加、`map` を block body に変換、日付 JSX 追加 |
| `src/App.css` | `.nail-item-date` クラス追加（+7行） |

## 変更なし

- `src/lib/firestore.ts` — `createdAt` / `updatedAt` はすでに取得済み
- `firestore.rules` / `package.json` — 変更なし

## Test plan

- [x] `npm run build` 成功
- [x] `check-css-guard.ps1` → `CSS guard passed.`
- [ ] 新規 Add → カードに日付表示
- [ ] Update 後 →「・更新」が追記される
- [ ] 旧データ（createdAt なし）が表示崩れしない
- [ ] モバイル幅（480px）で崩れない

🤖 Generated with [Claude Code](https://claude.com/claude-code)