### PR TITLE
feat: add delete confirmation dialog

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -117,8 +117,9 @@ function App() {
 
   const handleDeleteNailItem = async (itemId: string) => {
     if (!user) return
-    const uid = user.uid
     const item = nailItems.find(i => i.id === itemId)
+    if (!window.confirm(`「${item?.title ?? 'このアイテム'}」を削除しますか？\nこの操作は取り消せません。`)) return
+    const uid = user.uid
     if (editingId === itemId) resetForm()
     setNailLoading(true)
     setNailError('')


### PR DESCRIPTION
## Summary
- `handleDeleteNailItem` に `window.confirm` ガードを追加
- アイテムタイトルを含む確認メッセージを表示（例:「サンプルネイル」を削除しますか？）
- キャンセル時は loading 状態に入らず即 return
- `item` の取得を confirm より前に移動（タイトル参照のため）

## Test plan
- [ ] Delete ボタン押下 → 確認ダイアログが表示される
- [ ] キャンセル → アイテムが削除されない・リストに残る
- [ ] OK → アイテムが削除される・リストが更新される
- [ ] 編集中アイテムの Delete → confirm OK 後にフォームもリセットされる
- [ ] `npm run build` 成功・TypeScript エラーなし

🤖 Generated with [Claude Code](https://claude.com/claude-code)