### PR TITLE
feat: sort nail items by latest date descending

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,13 @@ import type { NailItemDoc } from './lib/firestore'
 import { uploadNailImage, deleteNailImage } from './lib/storage'
 import './App.css'
 
+const sortByDate = (items: NailItemDoc[]): NailItemDoc[] =>
+  [...items].sort((a, b) => {
+    const ta = (a.updatedAt ?? a.createdAt)?.seconds ?? 0
+    const tb = (b.updatedAt ?? b.createdAt)?.seconds ?? 0
+    return tb - ta
+  })
+
 const formatDate = (ts: { toDate(): Date } | null | undefined): string | null => {
   if (!ts) return null
   try {
@@ -36,7 +43,7 @@ function App() {
     if (!user) { setNailItems([]); return }
     setIsFetching(true)
     fetchNailItems(user.uid)
-      .then(setNailItems)
+      .then(items => setNailItems(sortByDate(items)))
       .catch((e: unknown) => console.error('fetch failed', e))
       .finally(() => setIsFetching(false))
   }, [user])
@@ -104,7 +111,7 @@ function App() {
           await updateNailItem(uid, itemId, { ...baseInput, imageUrl })
         }
       }
-      setNailItems(await fetchNailItems(uid))
+      setNailItems(sortByDate(await fetchNailItems(uid)))
       resetForm()
     } catch (e: unknown) {
       const msg = e instanceof Error ? e.message : String(e)
@@ -139,7 +146,7 @@ function App() {
         await deleteNailImage(uid, itemId).catch(() => {})
       }
       await deleteNailItem(uid, itemId)
-      setNailItems(await fetchNailItems(uid))
+      setNailItems(sortByDate(await fetchNailItems(uid)))
     } catch (e: unknown) {
       setNailError(String(e))
     } finally {


### PR DESCRIPTION
## Summary
- `sortByDate` ヘルパーをコンポーネント外に追加（`updatedAt ?? createdAt` の `seconds` 降順）
- `fetchNailItems` の結果を返す 3 箇所すべてで `sortByDate` を適用
  - 初回ロード（useEffect）
  - Add/Update 後のリフレッシュ
  - Delete 後のリフレッシュ
- `createdAt`/`updatedAt` が null のアイテムは `seconds = 0` にフォールバックして最下部へ

## Test plan
- [ ] 新規追加したアイテムがリストの一番上に表示される
- [ ] 既存アイテムを編集・保存すると一番上に移動する
- [ ] 既存アイテムの表示順が崩れていない
- [ ] `npm run build` 成功・TypeScript エラーなし

🤖 Generated with [Claude Code](https://claude.com/claude-code)