### PR TITLE
feat: add client-side search by title and tag

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -82,6 +82,35 @@
   text-align: left;
 }
 
+#nail-search {
+  margin-bottom: 16px;
+}
+
+.nail-search-input {
+  width: 100%;
+  padding: 9px 12px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  font-size: 0.9rem;
+  box-sizing: border-box;
+  background: transparent;
+  color: inherit;
+}
+
+.nail-search-input:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+  border-color: transparent;
+}
+
+.nail-search-empty {
+  text-align: center;
+  padding: 40px 0;
+  font-size: 0.9rem;
+  color: #888;
+  margin: 0;
+}
+
 #nail-form {
   background: var(--social-bg);
   border: 1px solid var(--border);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -35,6 +35,7 @@ function App() {
   const [nailLoading, setNailLoading] = useState(false)
   const [nailError, setNailError] = useState('')
   const [isFetching, setIsFetching] = useState(false)
+  const [searchQuery, setSearchQuery] = useState('')
   const fileInputRef = useRef<HTMLInputElement>(null)
 
   useEffect(() => onAuthStateChanged(auth, setUser), [])
@@ -156,6 +157,14 @@ function App() {
 
   const editingItem = editingId ? nailItems.find(i => i.id === editingId) : null
 
+  const filteredItems = searchQuery.trim()
+    ? nailItems.filter(item => {
+        const q = searchQuery.trim().toLowerCase()
+        return item.title.toLowerCase().includes(q) ||
+          item.tags.some(t => t.toLowerCase().includes(q))
+      })
+    : nailItems
+
   return (
     <section id="center">
       <h1 id="app-title">Nailous</h1>
@@ -230,6 +239,17 @@ function App() {
             </div>
             {nailError && <p className="nail-error">{nailError}</p>}
           </div>
+          {!isFetching && nailItems.length > 0 && (
+            <div id="nail-search">
+              <input
+                type="search"
+                value={searchQuery}
+                onChange={e => setSearchQuery(e.target.value)}
+                placeholder="タイトル・タグで検索"
+                className="nail-search-input"
+              />
+            </div>
+          )}
           {isFetching ? (
             <p className="nail-loading">Loading...</p>
           ) : nailItems.length === 0 ? (
@@ -237,9 +257,11 @@ function App() {
               <p className="nail-empty-main">No nail items yet.</p>
               <p className="nail-empty-sub">Add your first one above.</p>
             </div>
+          ) : filteredItems.length === 0 ? (
+            <p className="nail-search-empty">「{searchQuery}」に一致するアイテムがありません。</p>
           ) : (
             <ul id="nail-list" className={nailLoading ? 'loading' : ''}>
-              {nailItems.map(item => {
+              {filteredItems.map(item => {
                 const createdDate = formatDate(item.createdAt)
                 const updatedDate = (item.updatedAt && item.createdAt &&
                   item.updatedAt.seconds !== item.createdAt.seconds)


### PR DESCRIPTION
## Summary
- `searchQuery` state を追加、`filteredItems` をコンポーネント内 derived 値として計算
- タイトルまたはタグの部分一致（大小文字区別なし）でリアルタイム絞り込み
- アイテムが 1 件以上ある場合のみ検索ボックスを表示（`#nail-search`）
- 検索結果 0 件時は「〇〇に一致するアイテムがありません」を表示
- 検索ボックスは `focus-visible` でアクセシブルなフォーカスリング付き

## Test plan
- [ ] 検索ボックスにタイトルの一部を入力 → リアルタイムで絞り込まれる
- [ ] タグ名で検索 → 該当タグを持つアイテムが表示される
- [ ] 検索結果 0 件 → 「〇〇に一致するアイテムがありません」が表示される
- [ ] 検索ボックスをクリア → 全件に戻る
- [ ] アイテムが 0 件のとき検索ボックスが表示されない
- [ ] 検索中に Add / Edit / Delete が正常動作する
- [ ] `npm run build` 成功・CSS guard 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)