### PR TITLE
fix: satisfy react hooks lint for nail item fetch

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -34,19 +34,34 @@ function App() {
   const [editingId, setEditingId] = useState<string | null>(null)
   const [nailLoading, setNailLoading] = useState(false)
   const [nailError, setNailError] = useState('')
-  const [isFetching, setIsFetching] = useState(false)
+  const [nailItemsUserId, setNailItemsUserId] = useState<string | null>(null)
   const [searchQuery, setSearchQuery] = useState('')
   const fileInputRef = useRef<HTMLInputElement>(null)
 
-  useEffect(() => onAuthStateChanged(auth, setUser), [])
+  useEffect(() => onAuthStateChanged(auth, nextUser => {
+    setUser(nextUser)
+    if (!nextUser) {
+      setNailItems([])
+      setNailItemsUserId(null)
+    }
+  }), [])
 
   useEffect(() => {
-    if (!user) { setNailItems([]); return }
-    setIsFetching(true)
+    if (!user) return
+    let didCancel = false
     fetchNailItems(user.uid)
-      .then(items => setNailItems(sortByDate(items)))
-      .catch((e: unknown) => console.error('fetch failed', e))
-      .finally(() => setIsFetching(false))
+      .then(items => {
+        if (didCancel) return
+        setNailItems(sortByDate(items))
+        setNailItemsUserId(user.uid)
+      })
+      .catch((e: unknown) => {
+        console.error('fetch failed', e)
+        if (didCancel) return
+        setNailItems([])
+        setNailItemsUserId(user.uid)
+      })
+    return () => { didCancel = true }
   }, [user])
 
   const ALLOWED_TYPES = ['image/jpeg', 'image/png', 'image/webp']
@@ -113,6 +128,7 @@ function App() {
         }
       }
       setNailItems(sortByDate(await fetchNailItems(uid)))
+      setNailItemsUserId(uid)
       resetForm()
     } catch (e: unknown) {
       const msg = e instanceof Error ? e.message : String(e)
@@ -148,6 +164,7 @@ function App() {
       }
       await deleteNailItem(uid, itemId)
       setNailItems(sortByDate(await fetchNailItems(uid)))
+      setNailItemsUserId(uid)
     } catch (e: unknown) {
       setNailError(String(e))
     } finally {
@@ -156,6 +173,7 @@ function App() {
   }
 
   const editingItem = editingId ? nailItems.find(i => i.id === editingId) : null
+  const isFetching = Boolean(user && nailItemsUserId !== user.uid)
 
   const filteredItems = searchQuery.trim()
     ? nailItems.filter(item => {


### PR DESCRIPTION
## Summary
- `isFetching` をステートから派生値に変更し、`react-hooks/exhaustive-deps` lint エラーを解消
- fetch の `useEffect` にキャンセルフラグ (`didCancel`) を追加し、アンマウント時の state 更新を防止
- auth state change 時に `setNailItems([])` を `onAuthStateChanged` コールバック内に移動

## Test plan
- [ ] `npm run lint` がエラーなしで通過する
- [ ] ログイン後にネイルアイテムが正常に読み込まれる
- [ ] ログアウト後にリストがクリアされる
- [ ] 高速なユーザー切り替え時に stale な state が残らない

🤖 Generated with [Claude Code](https://claude.com/claude-code)