### PR TITLE
feat: improve nail image upload UX with preview and cleanup

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -31,12 +31,18 @@ function App() {
   const [nailTags, setNailTags] = useState('')
   const [nailMemo, setNailMemo] = useState('')
   const [nailImageFile, setNailImageFile] = useState<File | null>(null)
+  const [nailImagePreview, setNailImagePreview] = useState<string | null>(null)
   const [editingId, setEditingId] = useState<string | null>(null)
   const [nailLoading, setNailLoading] = useState(false)
   const [nailError, setNailError] = useState('')
   const [nailItemsUserId, setNailItemsUserId] = useState<string | null>(null)
   const [searchQuery, setSearchQuery] = useState('')
   const fileInputRef = useRef<HTMLInputElement>(null)
+  const previewUrlRef = useRef<string | null>(null)
+
+  useEffect(() => () => {
+    if (previewUrlRef.current) URL.revokeObjectURL(previewUrlRef.current)
+  }, [])
 
   useEffect(() => onAuthStateChanged(auth, nextUser => {
     setUser(nextUser)
@@ -75,18 +81,35 @@ function App() {
     return null
   }
 
+  const clearPreview = () => {
+    if (previewUrlRef.current) { URL.revokeObjectURL(previewUrlRef.current); previewUrlRef.current = null }
+    setNailImagePreview(null)
+  }
+
   const handleNailFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0] ?? null
-    if (!file) { setNailImageFile(null); setNailError(''); return }
+    if (!file) { setNailImageFile(null); clearPreview(); setNailError(''); return }
     const err = validateImageFile(file)
     if (err) {
       setNailError(err)
       setNailImageFile(null)
+      clearPreview()
       if (fileInputRef.current) fileInputRef.current.value = ''
       return
     }
     setNailError('')
     setNailImageFile(file)
+    clearPreview()
+    const url = URL.createObjectURL(file)
+    previewUrlRef.current = url
+    setNailImagePreview(url)
+  }
+
+  const handleRemoveFile = () => {
+    setNailImageFile(null)
+    clearPreview()
+    setNailError('')
+    if (fileInputRef.current) fileInputRef.current.value = ''
   }
 
   const parseTags = (s: string): string[] =>
@@ -97,6 +120,7 @@ function App() {
     setNailTags('')
     setNailMemo('')
     setNailImageFile(null)
+    clearPreview()
     if (fileInputRef.current) fileInputRef.current.value = ''
     setEditingId(null)
     setNailError('')
@@ -146,6 +170,7 @@ function App() {
     setNailTags(item.tags.join(', '))
     setNailMemo(item.memo ?? '')
     setNailImageFile(null)
+    clearPreview()
     if (fileInputRef.current) fileInputRef.current.value = ''
     setNailError('')
   }
@@ -236,8 +261,29 @@ function App() {
                 onChange={handleNailFileChange}
                 className="nail-file-input"
               />
+              {nailImageFile && nailImagePreview && (
+                <div className="nail-file-preview-area">
+                  <img
+                    className="nail-file-preview"
+                    src={nailImagePreview}
+                    alt="選択画像のプレビュー"
+                  />
+                  <div className="nail-file-info-row">
+                    <span className="nail-file-info">
+                      {nailImageFile.name}（{(nailImageFile.size / 1024 / 1024).toFixed(1)}MB）
+                    </span>
+                    <button
+                      type="button"
+                      className="nail-file-remove"
+                      onClick={handleRemoveFile}
+                    >
+                      削除
+                    </button>
+                  </div>
+                </div>
+              )}
               {editingItem?.imageUrl && !nailImageFile && (
-                <p className="nail-file-note">Current image kept. Select to replace.</p>
+                <p className="nail-file-note">現在の画像を維持します。変更するには新しい画像を選択してください。</p>
               )}
             </div>
             <div className="nail-form-actions">


### PR DESCRIPTION
## Summary

- ファイル選択時にサムネイルプレビューを表示する
- プレビュー下にファイル名・サイズを表示し「削除」ボタンで選択解除できるようにする
- 不正ファイル（PDF・5MB超）選択時にプレビューを表示せずエラーメッセージを即時表示する
- 送信直前にも `validateImageFile` を再チェックし二重検証を保証する

## Merge 前の必須作業

> ⚠️ **PR #45 (`ai/fix-lint-set-state-effect`) とマージ競合があります。**
>
> PR #45 が main にマージされた後、このブランチを以下の手順でリベースしてください。
>
> ```powershell
> git fetch origin
> git checkout fix/issue-27-upload-ux
> git rebase origin/main
> # src/App.tsx のコンフリクトを手動解決:
> #   - const [isFetching, setIsFetching] = useState(false)  ← この行を削除
> #   - PR #45 の derived isFetching を残す
> git push --force-with-lease origin fix/issue-27-upload-ux
> ```
>
> **競合箇所:** `src/App.tsx` の `isFetching` state 宣言 1 箇所のみ。
> PR #45 は `isFetching` を `const [isFetching, setIsFetching] = useState(false)` から
> `const isFetching = Boolean(user && nailItemsUserId !== user.uid)` の派生値に変更します。
> PR #47 はその行を変更せずに保持しているため、#45 マージ後に手動解決が必要です。

## Test plan

- [ ] PR #45 が main にマージ済みであることを確認する
- [ ] このブランチを origin/main にリベース済みであることを確認する
- [ ] jpeg/png/webp（5MB以下）を選択するとプレビューが表示される
- [ ] ファイル名とサイズがプレビュー下に表示される
- [ ] 「削除」ボタンでプレビューが消えファイル選択がリセットされる
- [ ] PDF を選択するとエラーが表示されプレビューは表示されない
- [ ] 5MB超の画像を選択するとサイズ付きエラーが表示される
- [ ] Edit モードで画像未選択時に「現在の画像を維持します」メッセージが表示される
- [ ] `npm run build` が成功している
- [ ] `npm run lint` がエラーなしで通過する

Closes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)