### PR TITLE
feat: add CSV and JSON export for NailItems

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -580,3 +580,43 @@
   text-overflow: ellipsis;
   white-space: nowrap;
 }
+
+.summary-export-note {
+  font-size: 0.75rem;
+  color: var(--text);
+  margin: 0;
+  line-height: 1.5;
+}
+
+.summary-export-actions {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.btn-export {
+  padding: 7px 16px;
+  border: 1px solid var(--accent-border);
+  border-radius: 6px;
+  background: var(--accent-bg);
+  color: var(--accent);
+  font-size: 0.85rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background 0.18s ease, color 0.18s ease;
+}
+
+.btn-export:hover:not(:disabled) {
+  background: var(--accent);
+  color: #fff;
+}
+
+.btn-export:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.btn-export:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -69,6 +69,65 @@ const getNailSummary = (items: NailItemDoc[]): NailSummary => {
   }
 }
 
+interface ExportedNailItem {
+  id: string
+  title: string
+  tags: string
+  memo: string
+  imageUrl: string
+  createdAt: string
+  updatedAt: string
+}
+
+const formatTimestampForExport = (ts: { toDate(): Date } | null | undefined): string => {
+  if (!ts) return ''
+  try { return ts.toDate().toISOString() } catch { return '' }
+}
+
+const formatNailItemForExport = (item: NailItemDoc): ExportedNailItem => ({
+  id: item.id,
+  title: item.title,
+  tags: item.tags.join(';'),
+  memo: item.memo ?? '',
+  imageUrl: item.imageUrl ?? '',
+  createdAt: formatTimestampForExport(item.createdAt),
+  updatedAt: formatTimestampForExport(item.updatedAt),
+})
+
+const CSV_HEADERS = ['id', 'title', 'tags', 'memo', 'imageUrl', 'createdAt', 'updatedAt'] as const
+
+const escapeCsvCell = (value: string): string => {
+  if (/[",\n\r]/.test(value)) return `"${value.replace(/"/g, '""')}"`
+  return value
+}
+
+const toCsv = (items: NailItemDoc[]): string => {
+  const header = CSV_HEADERS.join(',')
+  const rows = items.map(item => {
+    const e = formatNailItemForExport(item)
+    return CSV_HEADERS.map(k => escapeCsvCell(e[k])).join(',')
+  })
+  return [header, ...rows].join('\r\n')
+}
+
+const toJson = (items: NailItemDoc[]): string =>
+  JSON.stringify(items.map(formatNailItemForExport), null, 2)
+
+const downloadTextFile = (filename: string, content: string, mimeType: string): void => {
+  const blob = new Blob([content], { type: mimeType })
+  const url = URL.createObjectURL(blob)
+  const a = document.createElement('a')
+  a.href = url
+  a.download = filename
+  a.click()
+  URL.revokeObjectURL(url)
+}
+
+const getExportDateStamp = (): string => {
+  const d = new Date()
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`
+}
+
 function App() {
   const [user, setUser] = useState<User | null | undefined>(undefined)
   const [nailItems, setNailItems] = useState<NailItemDoc[]>([])
@@ -404,6 +463,32 @@ function App() {
                   </ul>
                 </div>
               )}
+              <div className="summary-section">
+                <h4 className="summary-section-title">エクスポート</h4>
+                <p className="summary-export-note">エクスポートには保存済みのネイル情報と画像URLが含まれます。画像ファイル本体は含まれません。</p>
+                <div className="summary-export-actions">
+                  <button
+                    type="button"
+                    className="btn-export"
+                    onClick={() => downloadTextFile(
+                      `nail-report-export-${getExportDateStamp()}.csv`,
+                      toCsv(nailItems),
+                      'text/csv;charset=utf-8;'
+                    )}
+                    disabled={nailItems.length === 0}
+                  >Export CSV</button>
+                  <button
+                    type="button"
+                    className="btn-export"
+                    onClick={() => downloadTextFile(
+                      `nail-report-export-${getExportDateStamp()}.json`,
+                      toJson(nailItems),
+                      'application/json'
+                    )}
+                    disabled={nailItems.length === 0}
+                  >Export JSON</button>
+                </div>
+              </div>
             </div>
           )}
           {!isFetching && nailItems.length > 0 && (


### PR DESCRIPTION
## Summary

- Add CSV and JSON export for loaded NailItems
- Generate export files client-side from existing `nailItems` state (no new Firestore calls)
- Add Export CSV / Export JSON buttons inside the collection summary dashboard
- Include a privacy note explaining that image files are not included, only image URLs

## Export fields

| field | type | notes |
|---|---|---|
| `id` | string | Firestore document ID |
| `title` | string | |
| `tags` | string | `;` separated (e.g. `pink;gel;spring`) |
| `memo` | string | |
| `imageUrl` | string | empty string if no image |
| `createdAt` | string | ISO 8601 (`toISOString()`) |
| `updatedAt` | string | ISO 8601, empty if not set |

## Implementation

- `formatTimestampForExport()` — converts Firestore Timestamp to ISO string, safe against null/exception
- `formatNailItemForExport()` — maps `NailItemDoc` to flat `ExportedNailItem` (tags joined as `;`)
- `escapeCsvCell()` — RFC 4180 escaping: wraps in `"` and doubles internal `"` when value contains `,` `"` `\n` `\r`
- `toCsv()` — header row + data rows, CRLF line endings
- `toJson()` — `JSON.stringify(..., null, 2)` of exported items array
- `downloadTextFile()` — Blob + `<a download>` pattern, no new library
- `getExportDateStamp()` — `YYYY-MM-DD` suffix for filenames

## Human Gates decisions

- G1: Export fields are limited to the 7 fields listed above; CSV tags use `;` separator
- G6: Privacy note added in UI — `エクスポートには保存済みのネイル情報と画像URLが含まれます。画像ファイル本体は含まれません。`

## Out of Scope

- Share URL / public collection
- ZIP export / Storage image download / Google Drive integration
- AI / 3D / AR
- Firestore schema changes / Firebase Rules changes / Firebase deploy
- New dependencies

## Pre-merge checklist

- [x] `npm run build` — pass
- [x] `npm run lint` — pass
- [x] `.\commands\check-css-guard.ps1` — CSS guard passed

## Test plan

- [ ] Manual: 0 items — Export buttons disabled
- [ ] Manual: CSV download works
- [ ] Manual: JSON download works
- [ ] Manual: CSV escaping correct for `,` `"` and newlines in title/memo
- [ ] Manual: tags exported as `;` separated values
- [ ] Manual: imageUrl exported as string, no image binary
- [ ] Manual: existing CRUD / image upload / summary dashboard unaffected

Closes #53