### PR TITLE
feat: add publicShares snapshot data model (#60)

### DIFF
--- a/src/lib/publicShares.ts
+++ b/src/lib/publicShares.ts
@@ -1,0 +1,65 @@
+import {
+  collection, addDoc, doc, updateDoc, getDoc,
+  serverTimestamp,
+} from 'firebase/firestore'
+import type { Timestamp } from 'firebase/firestore'
+import { db } from './firebase'
+
+// Snapshot of a single NailItem stored in publicShares.
+// memo and imageUrl are intentionally excluded.
+export interface PublicShareItemSnapshot {
+  id: string
+  title: string
+  tags: string[]
+  createdAt: Timestamp | null
+}
+
+// Document stored at publicShares/{shareId}.
+// ownerUid is not exposed in any public UI.
+// isEnabled: false disables public read (revoke).
+export interface PublicShareDoc {
+  ownerUid: string
+  isEnabled: boolean
+  createdAt: Timestamp
+  updatedAt: Timestamp
+  title: string
+  source: 'snapshot'
+  items: PublicShareItemSnapshot[]
+}
+
+export interface PublicShareDocWithId extends PublicShareDoc {
+  id: string
+}
+
+export const createPublicShare = async (
+  ownerUid: string,
+  title: string,
+  items: PublicShareItemSnapshot[],
+): Promise<string> => {
+  const ref = collection(db, 'publicShares')
+  const snap = await addDoc(ref, {
+    ownerUid,
+    isEnabled: true,
+    createdAt: serverTimestamp(),
+    updatedAt: serverTimestamp(),
+    title,
+    source: 'snapshot',
+    items,
+  })
+  return snap.id
+}
+
+export const disablePublicShare = async (shareId: string): Promise<void> => {
+  const ref = doc(db, 'publicShares', shareId)
+  await updateDoc(ref, {
+    isEnabled: false,
+    updatedAt: serverTimestamp(),
+  })
+}
+
+export const getPublicShare = async (shareId: string): Promise<PublicShareDocWithId | null> => {
+  const ref = doc(db, 'publicShares', shareId)
+  const snap = await getDoc(ref)
+  if (!snap.exists()) return null
+  return { id: snap.id, ...(snap.data() as PublicShareDoc) }
+}


### PR DESCRIPTION
## Summary

- src/lib/publicShares.ts を新規追加
- PublicShareItemSnapshot / PublicShareDoc / PublicShareDocWithId 型を定義
- Firestore helpers: createPublicShare / disablePublicShare / getPublicShare

## Design decisions

- memo / imageUrl は intentionally 除外（個人情報リスク・画像URL漏洩リスク）
- shareId は Firestore auto-ID（推測困難）
- ownerUid は UI に出さない
- isEnabled: false で revoke 可能
- Storage Rules / Firebase Rules / Firebase deploy はこの PR では変更しない

## Checklist

- [x] build PASS
- [x] lint PASS
- [x] css guard PASS
- [x] 新規 dependency なし
- [x] Firestore schema 変更なし（既存 nailItems コレクション無変更）
- [x] Firebase Rules 変更なし（Issue #61 で別途設計）
- [x] Firebase deploy なし

Closes #60
Related: #59 #61 #62 #63