### PR TITLE
feat: add share link creation UI

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -603,6 +603,99 @@
   flex-wrap: wrap;
 }
 
+.share-section {
+  background: var(--social-bg);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 16px;
+  margin-bottom: 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+#nail-share {
+  padding-top: 4px;
+}
+
+.share-privacy-note,
+.share-description,
+.share-status,
+.share-error {
+  margin: 0;
+  font-size: 0.78rem;
+  line-height: 1.6;
+}
+
+.share-privacy-note {
+  padding: 10px 12px;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  color: var(--text);
+}
+
+.share-description {
+  color: var(--text);
+}
+
+.share-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px 12px;
+  font-size: 0.75rem;
+  color: #888;
+}
+
+.share-actions {
+  align-items: center;
+}
+
+.btn-export-danger {
+  border-color: rgba(204, 0, 0, 0.24);
+  background: rgba(204, 0, 0, 0.08);
+  color: #b42318;
+}
+
+.btn-export-danger:hover:not(:disabled) {
+  background: #b42318;
+  border-color: #b42318;
+  color: #fff;
+}
+
+.share-url-box {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 10px 12px;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+}
+
+.share-url-label {
+  font-size: 0.72rem;
+  font-weight: 600;
+  color: var(--text);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.share-url-value {
+  font-size: 0.76rem;
+  color: var(--text-h);
+  word-break: break-all;
+  white-space: pre-wrap;
+}
+
+.share-status {
+  color: var(--accent);
+}
+
+.share-error {
+  color: #c00;
+}
+
 .btn-export {
   padding: 7px 16px;
   border: 1px solid var(--accent-border);
@@ -701,4 +794,10 @@
 .filter-clear:focus-visible {
   outline: 2px solid var(--accent);
   outline-offset: 2px;
+}
+
+@media (max-width: 480px) {
+  .share-actions .btn-export {
+    width: 100%;
+  }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import { auth, signInWithGoogle, signOutUser, onAuthStateChanged } from './lib/a
 import type { User } from './lib/auth'
 import { addNailItem, updateNailItem, deleteNailItem, fetchNailItems } from './lib/firestore'
 import type { NailItemDoc } from './lib/firestore'
+import { createPublicShare, disablePublicShare } from './lib/publicShares'
 import { uploadNailImage, deleteNailImage } from './lib/storage'
 import './App.css'
 
@@ -153,6 +154,11 @@ function App() {
   const [searchQuery, setSearchQuery] = useState('')
   const [activeTagFilter, setActiveTagFilter] = useState<string | null>(null)
   const [activeMonthFilter, setActiveMonthFilter] = useState<string | null>(null)
+  const [shareUrl, setShareUrl] = useState('')
+  const [shareId, setShareId] = useState('')
+  const [isCreatingShare, setIsCreatingShare] = useState(false)
+  const [shareError, setShareError] = useState('')
+  const [shareStatusMessage, setShareStatusMessage] = useState('')
   const fileInputRef = useRef<HTMLInputElement>(null)
   const previewUrlRef = useRef<string | null>(null)
 
@@ -326,6 +332,76 @@ function App() {
     if (activeMonthFilter !== null && getItemMonth(item) !== activeMonthFilter) return false
     return true
   })
+
+  const handleCreateShareLink = async () => {
+    if (!user || filteredItems.length === 0) return
+
+    setIsCreatingShare(true)
+    setShareError('')
+    setShareStatusMessage('')
+
+    try {
+      const nextShareId = await createPublicShare(
+        user.uid,
+        `Nail collection snapshot ${new Date().toLocaleDateString('ja-JP')}`,
+        filteredItems.map(item => ({
+          id: item.id,
+          title: item.title,
+          tags: item.tags,
+          createdAt: item.createdAt ?? null,
+        }))
+      )
+      const nextShareUrl = `${window.location.origin}/share/${nextShareId}`
+      setShareId(nextShareId)
+      setShareUrl(nextShareUrl)
+      setShareStatusMessage('Share link created. Copy it to share this snapshot.')
+    } catch (e: unknown) {
+      const message = e instanceof Error ? e.message : 'Failed to create share link.'
+      setShareError(message)
+    } finally {
+      setIsCreatingShare(false)
+    }
+  }
+
+  const handleCopyShareLink = async () => {
+    if (!shareUrl) return
+
+    setShareError('')
+    setShareStatusMessage('')
+
+    if (!navigator.clipboard?.writeText) {
+      setShareError('Clipboard API is not available in this browser.')
+      return
+    }
+
+    try {
+      await navigator.clipboard.writeText(shareUrl)
+      setShareStatusMessage('Share link copied to clipboard.')
+    } catch (e: unknown) {
+      const message = e instanceof Error ? e.message : 'Failed to copy share link.'
+      setShareError(message)
+    }
+  }
+
+  const handleDisableShare = async () => {
+    if (!shareId) return
+
+    setIsCreatingShare(true)
+    setShareError('')
+    setShareStatusMessage('')
+
+    try {
+      await disablePublicShare(shareId)
+      setShareId('')
+      setShareUrl('')
+      setShareStatusMessage('Share link disabled.')
+    } catch (e: unknown) {
+      const message = e instanceof Error ? e.message : 'Failed to disable share link.'
+      setShareError(message)
+    } finally {
+      setIsCreatingShare(false)
+    }
+  }
 
   return (
     <section id="center">
@@ -513,6 +589,55 @@ function App() {
                   >Export JSON</button>
                 </div>
               </div>
+            </div>
+          )}
+          {!isFetching && (
+            <div id="nail-share" className="share-section">
+              <h3 className="summary-heading">Share collection</h3>
+              <p className="share-privacy-note">
+                共有リンクを知っている人は、このコレクションを閲覧できます。MVPではメモと画像は共有対象に含まれません。個人情報を含む内容を共有しないよう確認してください。共有はいつでも停止できます。
+              </p>
+              <p className="share-description">
+                現在表示中のアイテムを共有します。検索・タグ・月フィルターが適用されている場合、その結果だけが共有されます。
+              </p>
+              <div className="share-meta">
+                <span>{filteredItems.length} items ready to share</span>
+                {filteredItems.length === 0 && <span>No items to share</span>}
+              </div>
+              <div className="summary-export-actions share-actions">
+                <button
+                  type="button"
+                  className="btn-export"
+                  onClick={handleCreateShareLink}
+                  disabled={isCreatingShare || filteredItems.length === 0}
+                >
+                  {isCreatingShare ? 'Creating...' : 'Create share link'}
+                </button>
+                <button
+                  type="button"
+                  className="btn-export"
+                  onClick={handleCopyShareLink}
+                  disabled={!shareUrl}
+                >
+                  Copy share link
+                </button>
+                <button
+                  type="button"
+                  className="btn-export btn-export-danger"
+                  onClick={handleDisableShare}
+                  disabled={!shareId || isCreatingShare}
+                >
+                  Disable share
+                </button>
+              </div>
+              {shareUrl && (
+                <div className="share-url-box">
+                  <span className="share-url-label">Share URL</span>
+                  <code className="share-url-value">{shareUrl}</code>
+                </div>
+              )}
+              {shareStatusMessage && <p className="share-status">{shareStatusMessage}</p>}
+              {shareError && <p className="share-error">{shareError}</p>}
             </div>
           )}
           {!isFetching && nailItems.length > 0 && (activeTagFilter !== null || activeMonthFilter !== null) && (


### PR DESCRIPTION
## Summary
- Add authenticated share link creation UI for the publicShares snapshot MVP
- Share the currently displayed NailItems after search/tag/month filters
- Add privacy note before sharing
- Add create, copy, and disable share actions

## Share target
- Current filtered NailItems
- Snapshot fields: id / title / tags / createdAt

## Privacy/Security decisions
- Exclude memo
- Exclude imageUrl
- Exclude Storage images
- Exclude owner email / displayName
- Share can be revoked with isEnabled:false

## Out of Scope
- Public share page
- Firebase Rules changes
- Firebase deploy
- Storage Rules changes
- Image sharing
- Memo sharing
- Individual item selection UI
- Docs update

## Test plan
- [x] npm run build
- [x] npm run lint
- [x] .\commands\check-css-guard.ps1
- [ ] Manual: 0 items disables create
- [ ] Manual: create share link
- [ ] Manual: copy share link
- [ ] Manual: disable share
- [ ] Manual/code check: memo/imageUrl are not included
- [ ] Manual: existing CRUD / upload / summary / filters / export unaffected

Closes #62