### PR TITLE
security: sync deployed publicShares Firestore rules

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -60,23 +60,23 @@ service cloud.firestore {
     //   Deploy only after human approval (Human Gate G15).
     // ================================================================
     //
-    // match /publicShares/{shareId} {
-    //   // Anyone can read a share that is explicitly enabled
-    //   allow read: if resource.data.isEnabled == true;
-    //
-    //   // Authenticated owner can create a share
-    //   allow create: if request.auth != null
-    //                  && request.resource.data.ownerUid == request.auth.uid
-    //                  && request.resource.data.source == 'snapshot'
-    //                  && request.resource.data.isEnabled == true;
-    //
-    //   // Authenticated owner can update (e.g., set isEnabled:false to revoke)
-    //   allow update: if request.auth != null
-    //                  && resource.data.ownerUid == request.auth.uid;
-    //
-    //   // No client-side delete — revoke by setting isEnabled:false
-    //   allow delete: if false;
-    // }
+    match /publicShares/{shareId} {
+      // Anyone can read a share that is explicitly enabled
+      allow read: if resource.data.isEnabled == true;
+
+      // Authenticated owner can create a share
+      allow create: if request.auth != null
+                     && request.resource.data.ownerUid == request.auth.uid
+                     && request.resource.data.source == 'snapshot'
+                     && request.resource.data.isEnabled == true;
+
+      // Authenticated owner can update (e.g., set isEnabled:false to revoke)
+      allow update: if request.auth != null
+                     && resource.data.ownerUid == request.auth.uid;
+
+      // No client-side delete — revoke by setting isEnabled:false
+      allow delete: if false;
+    }
 
   }
 }


### PR DESCRIPTION
## Summary
- Enable the publicShares Firestore rules that were previously documented as deploy pending
- Sync repository state with the rules already deployed by a human operator
- Keep users/{uid}/nailItems owner-only and leave Storage Rules unchanged

## Background
- PR #67 added the publicShares rules design and docs as deploy pending
- The rules were verified/deployed manually to unblock PR #68 share link creation UI testing
- This PR records the deployed firestore.rules state in Git

## Scope
- firestore.rules publicShares rule activation only

## Out of Scope
- Firebase deploy
- Storage Rules changes
- public share page
- share creation UI changes
- image sharing
- memo sharing

## Test plan
- [x] npm run build
- [x] npm run lint
- [x] .\commands\check-css-guard.ps1

Closes #69
Related: #61 #67 #62 #68
