### PR TITLE
feat: add public share collection page

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -82,6 +82,115 @@
   text-align: left;
 }
 
+#public-share-page {
+  width: 100%;
+  max-width: 720px;
+  text-align: left;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.public-share-header,
+.public-share-empty {
+  width: 100%;
+  background: var(--social-bg);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 18px;
+  box-sizing: border-box;
+}
+
+.public-share-empty {
+  max-width: 560px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.public-share-kicker {
+  margin: 0 0 10px;
+  font-size: 0.76rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--accent);
+}
+
+.public-share-heading {
+  margin: 0 0 10px;
+  font-size: 1.4rem;
+  line-height: 1.2;
+  color: var(--text-h);
+}
+
+.public-share-note {
+  margin: 0;
+  font-size: 0.86rem;
+  line-height: 1.7;
+  color: var(--text);
+}
+
+.public-share-link {
+  align-self: flex-start;
+  font-size: 0.82rem;
+  color: var(--accent);
+  text-decoration: none;
+  border-bottom: 1px solid transparent;
+}
+
+.public-share-link:hover {
+  border-color: currentColor;
+}
+
+.public-share-link:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+#public-share-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 12px;
+}
+
+.public-share-card {
+  background: var(--social-bg);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  min-height: 148px;
+}
+
+.public-share-card-body {
+  padding: 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  height: 100%;
+  box-sizing: border-box;
+}
+
+.public-share-item-title {
+  font-size: 0.96rem;
+  font-weight: 600;
+  color: var(--text-h);
+}
+
+.public-share-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.public-share-created-at {
+  margin: auto 0 0;
+  font-size: 0.74rem;
+  color: #888;
+}
+
 #nail-search {
   margin-bottom: 16px;
 }
@@ -799,5 +908,9 @@
 @media (max-width: 480px) {
   .share-actions .btn-export {
     width: 100%;
+  }
+
+  #public-share-list {
+    grid-template-columns: 1fr;
   }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,7 +3,8 @@ import { auth, signInWithGoogle, signOutUser, onAuthStateChanged } from './lib/a
 import type { User } from './lib/auth'
 import { addNailItem, updateNailItem, deleteNailItem, fetchNailItems } from './lib/firestore'
 import type { NailItemDoc } from './lib/firestore'
-import { createPublicShare, disablePublicShare } from './lib/publicShares'
+import { createPublicShare, disablePublicShare, getPublicShare } from './lib/publicShares'
+import type { PublicShareDocWithId, PublicShareItemSnapshot } from './lib/publicShares'
 import { uploadNailImage, deleteNailImage } from './lib/storage'
 import './App.css'
 
@@ -139,7 +140,19 @@ const getItemMonth = (item: NailItemDoc): string | null => {
   }
 }
 
+type PublicShareViewState = 'idle' | 'loading' | 'ready' | 'not-found' | 'disabled' | 'error'
+
+const getPublicShareIdFromPath = (pathname: string): string | null => {
+  const m = pathname.match(/^\/share\/([^/]+)\/?$/)
+  return m?.[1] ? decodeURIComponent(m[1]) : null
+}
+
 function App() {
+  const sharePathId = useMemo(
+    () => typeof window === 'undefined' ? null : getPublicShareIdFromPath(window.location.pathname),
+    []
+  )
+  const isPublicSharePage = sharePathId !== null
   const [user, setUser] = useState<User | null | undefined>(undefined)
   const [nailItems, setNailItems] = useState<NailItemDoc[]>([])
   const [nailTitle, setNailTitle] = useState('')
@@ -159,6 +172,10 @@ function App() {
   const [isCreatingShare, setIsCreatingShare] = useState(false)
   const [shareError, setShareError] = useState('')
   const [shareStatusMessage, setShareStatusMessage] = useState('')
+  const [publicShare, setPublicShare] = useState<PublicShareDocWithId | null>(null)
+  const [publicShareState, setPublicShareState] = useState<PublicShareViewState>(
+    isPublicSharePage ? 'loading' : 'idle'
+  )
   const fileInputRef = useRef<HTMLInputElement>(null)
   const previewUrlRef = useRef<string | null>(null)
 
@@ -166,15 +183,77 @@ function App() {
     if (previewUrlRef.current) URL.revokeObjectURL(previewUrlRef.current)
   }, [])
 
+  useEffect(() => {
+    const previousTitle = document.title
+    const meta = document.querySelector('meta[name="robots"]')
+    const previousRobots = meta?.getAttribute('content') ?? null
+    let createdMeta: HTMLMetaElement | null = null
+
+    if (isPublicSharePage) {
+      document.title = 'Shared nail collection'
+      if (meta) {
+        meta.setAttribute('content', 'noindex')
+      } else {
+        createdMeta = document.createElement('meta')
+        createdMeta.name = 'robots'
+        createdMeta.content = 'noindex'
+        document.head.appendChild(createdMeta)
+      }
+    } else {
+      document.title = 'Nailous'
+    }
+
+    return () => {
+      document.title = previousTitle
+      if (createdMeta) {
+        createdMeta.remove()
+      } else if (meta && previousRobots !== null) {
+        meta.setAttribute('content', previousRobots)
+      } else if (meta && isPublicSharePage) {
+        meta.removeAttribute('content')
+      }
+    }
+  }, [isPublicSharePage])
+
+  useEffect(() => {
+    if (!isPublicSharePage || !sharePathId) return
+
+    let didCancel = false
+
+    getPublicShare(sharePathId)
+      .then(share => {
+        if (didCancel) return
+        if (!share) {
+          setPublicShareState('not-found')
+          return
+        }
+        if (share.isEnabled !== true) {
+          setPublicShareState('disabled')
+          return
+        }
+        setPublicShare(share)
+        setPublicShareState('ready')
+      })
+      .catch((e: unknown) => {
+        console.error('public share fetch failed', e)
+        if (didCancel) return
+        setPublicShareState('error')
+      })
+
+    return () => { didCancel = true }
+  }, [isPublicSharePage, sharePathId])
+
   useEffect(() => onAuthStateChanged(auth, nextUser => {
+    if (isPublicSharePage) return
     setUser(nextUser)
     if (!nextUser) {
       setNailItems([])
       setNailItemsUserId(null)
     }
-  }), [])
+  }), [isPublicSharePage])
 
   useEffect(() => {
+    if (isPublicSharePage) return
     if (!user) return
     let didCancel = false
     fetchNailItems(user.uid)
@@ -190,7 +269,7 @@ function App() {
         setNailItemsUserId(user.uid)
       })
     return () => { didCancel = true }
-  }, [user])
+  }, [isPublicSharePage, user])
 
   const ALLOWED_TYPES = ['image/jpeg', 'image/png', 'image/webp']
   const MAX_FILE_BYTES = 5 * 1024 * 1024
@@ -401,6 +480,88 @@ function App() {
     } finally {
       setIsCreatingShare(false)
     }
+  }
+
+  const renderPublicShareState = () => {
+    if (publicShareState === 'loading') {
+      return <p className="public-share-note">Loading shared collection...</p>
+    }
+    if (publicShareState === 'not-found') {
+      return (
+        <div className="public-share-empty">
+          <h2 className="public-share-heading">Shared nail collection</h2>
+          <p className="public-share-note">This shared collection could not be found.</p>
+          <a className="public-share-link" href="/">Back to home</a>
+        </div>
+      )
+    }
+    if (publicShareState === 'disabled') {
+      return (
+        <div className="public-share-empty">
+          <h2 className="public-share-heading">Shared nail collection</h2>
+          <p className="public-share-note">This shared collection is no longer available.</p>
+          <a className="public-share-link" href="/">Back to home</a>
+        </div>
+      )
+    }
+    if (publicShareState === 'error') {
+      return (
+        <div className="public-share-empty">
+          <h2 className="public-share-heading">Shared nail collection</h2>
+          <p className="public-share-note">We could not load this shared collection right now.</p>
+          <a className="public-share-link" href="/">Back to home</a>
+        </div>
+      )
+    }
+    if (!publicShare) return null
+
+    return (
+      <div id="public-share-page">
+        <div className="public-share-header">
+          <p className="public-share-kicker">Shared nail collection</p>
+          <h2 className="public-share-heading">{publicShare.title}</h2>
+          <p className="public-share-note">
+            {publicShare.items.length} items shared. This page is read-only and does not include memo or image data.
+          </p>
+        </div>
+        {publicShare.items.length === 0 ? (
+          <p className="public-share-note">No items are included in this shared collection.</p>
+        ) : (
+          <ul id="public-share-list">
+            {publicShare.items.map((item: PublicShareItemSnapshot) => {
+              const createdDate = formatDate(item.createdAt)
+              return (
+                <li key={item.id} className="public-share-card">
+                  <div className="public-share-card-body">
+                    <span className="public-share-item-title">{item.title}</span>
+                    {item.tags.length > 0 && (
+                      <div className="public-share-tags">
+                        {item.tags.map(tag => (
+                          <span key={tag} className="nail-tag">#{tag}</span>
+                        ))}
+                      </div>
+                    )}
+                    {createdDate && (
+                      <p className="public-share-created-at">{createdDate}</p>
+                    )}
+                  </div>
+                </li>
+              )
+            })}
+          </ul>
+        )}
+        <a className="public-share-link" href="/">Back to home</a>
+      </div>
+    )
+  }
+
+  if (isPublicSharePage) {
+    return (
+      <section id="center">
+        <h1 id="app-title">Nailous</h1>
+        {renderPublicShareState()}
+      </section>
+    )
   }
 
   return (


### PR DESCRIPTION
## Summary
- Add `/share/:shareId` public share collection page
- Read publicShares snapshot data without requiring sign-in
- Show share title, item titles, tags, and optional createdAt
- Add safe not found / disabled / error states
- Add noindex handling for public share pages

## Public fields
- title
- tags
- createdAt optional

## Privacy/Security decisions
- Do not display memo
- Do not display imageUrl
- Do not display Storage images
- Do not display ownerUid / owner email / owner displayName
- Public page is read-only

## Routing
- Uses `window.location.pathname`
- No new routing dependency
- `/share/:shareId` enters public mode
- Other paths keep the existing authenticated app

## Out of Scope
- Share creation UI changes
- Firebase Rules changes
- Firebase deploy
- Storage Rules changes
- Image sharing
- Memo sharing
- Owner profile display
- Docs update

## Test plan
- [x] npm run build
- [x] npm run lint
- [x] .\commands\check-css-guard.ps1
- [ ] Manual: open /share/{shareId}
- [ ] Manual: unauthenticated/incognito view
- [ ] Manual: disabled/not found share
- [ ] Manual: owner info is not displayed
- [ ] Manual: memo/imageUrl are not displayed
- [ ] Manual: existing app path unaffected

Closes #63
