### PR TITLE
docs: add public sharing privacy notes

### DIFF
--- a/docs/operations/FIRESTORE_SECURITY_RULES.md
+++ b/docs/operations/FIRESTORE_SECURITY_RULES.md
@@ -1,11 +1,11 @@
 # Firestore Security Rules Design
 
-> **Status: Phase 1 Active — deployed 2026-05-14 / Phase 3 designed 2026-05-17 (pending deploy)**
+> **Status: Phase 1 Active — deployed 2026-05-14 / Phase 3 Active — deployed 2026-05-17**
 > このドキュメントは Firestore Security Rules の設計方針を定義します。
 > `firestore.rules` の deploy は原則として人間が行ってください。AI が実行するのは、人間が明示的に委譲した場合のみです。
 >
-> **リポジトリ状態:** `firestore.rules` は Phase 1（認証ユーザー本人のみ read / write）です。
-> **本番 deploy 状態:** 2026-05-14 01:35 JST に `nail-report-dev-ksc0000` へ deploy 済みです。
+> **リポジトリ状態:** `firestore.rules` は Phase 1 + Phase 3 publicShares rules を含みます。
+> **本番 deploy 状態:** 2026-05-14 01:35 JST に Phase 1、2026-05-17 03:37 JST に Phase 3 を `nail-report-dev-ksc0000` へ deploy 済みです。
 > **実行記録:** 人間の委譲承認に基づき Codex が `firebase deploy --only firestore:rules,storage --project nail-report-dev-ksc0000` を実行しました。
 
 ---
@@ -49,7 +49,7 @@ Firestore (default)
 - `users/{userId}/nailItems/{itemId}` — ログイン済み本人のみ read / write
 - `userId` = Firebase Auth の `uid` と一致する場合のみ許可
 
-### Phase 3（設計済み・deploy pending）: 公開共有リンク
+### Phase 3（実装済み・deploy 済み）: 公開共有リンク
 
 ```
 Firestore (default)
@@ -156,7 +156,7 @@ service cloud.firestore {
 
 ---
 
-### Phase 3 — 公開共有リンク MVP（設計済み・deploy は人間が実施）
+### Phase 3 — 公開共有リンク MVP（deploy 済み）
 
 ```
 rules_version = '2';
@@ -356,8 +356,8 @@ Firestore Security Rules は以下の Human Gate に該当します。
 | A4 | Phase 1 rules への移行承認 | 中 | G3/G4 | ✅ 承認済み 2026-05-01 / deploy 済み 2026-05-14 |
 | A5 | Firebase Emulator セットアップ（任意だが推奨） | 中 | — | ⬜ 未完了 |
 | A6 | `publicSamples` コレクション方針の確定 | 低 | G1 | ⬜ 未完了 |
-| A7 | Phase 3 rules の Rules Playground 確認 | **高** | G6 | ⬜ 未完了 |
-| A8 | Phase 3 rules の `firebase deploy` 実行 | **高** | G15 | ⬜ 未完了（人間が実行） |
+| A7 | Phase 3 rules の Rules Playground 確認 | **高** | G6 | ✅ 完了 2026-05-17 |
+| A8 | Phase 3 rules の `firebase deploy` 実行 | **高** | G15 | ✅ 完了 2026-05-17 |
 
 ---
 
@@ -367,6 +367,7 @@ Firestore Security Rules は以下の Human Gate に該当します。
 |---|------|---------|------------|--------|------|
 | 1 | 2026-05-01 | Phase 0 (deny-all) | `firebase deploy --only firestore:rules --project nail-report-dev-ksc0000` | 人間 (ksc0000) | ✅ 成功 |
 | 2 | 2026-05-14 | Phase 1 (認証ユーザー個人データ) | `firebase deploy --only firestore:rules,storage --project nail-report-dev-ksc0000` | Codex（ksc0000 承認） | ✅ 成功 |
+| 3 | 2026-05-17 | Phase 3 (publicShares 公開共有リンク) | `firebase deploy --only firestore:rules --project nail-report-dev-ksc0000` | Codex（ksc0000 承認） | ✅ 成功 |
 
 ---
 

--- a/docs/operations/PUBLIC_SHARING_PRIVACY.md
+++ b/docs/operations/PUBLIC_SHARING_PRIVACY.md
@@ -1,0 +1,162 @@
+# Public Sharing Privacy Notes
+
+> **Status: MVP implemented and browser QA passed on 2026-05-17**
+> このドキュメントは、`publicShares/{shareId}` を使った public sharing 機能の privacy note と運用上の注意をまとめたものです。
+> 対象読者は、共有リンクを使うユーザーと、この機能を保守する開発者の両方です。
+
+---
+
+## ユーザー向けガイド
+
+### 共有リンクの仕組み
+
+public sharing は **unlisted share link** 方式です。
+
+- 共有リンクを知っている人は、このコレクションを閲覧できます
+- 一般公開一覧や検索ページに積極的に載せる仕組みではありません
+- public page には `noindex` を付与しており、検索エンジン掲載を意図していません
+- ただし、リンクを受け取った人が別の人へ転送する可能性はあります
+
+### 共有対象
+
+public sharing で公開されるのは、共有作成時点の **snapshot** です。
+元の `users/{uid}/nailItems` をそのまま公開するものではありません。
+
+共有対象フィールド:
+
+- `title`
+- `tags`
+- `createdAt`
+
+共有対象外:
+
+- `memo`
+- `imageUrl`
+- Storage image
+- `ownerUid`
+- owner email
+- owner displayName
+
+### Privacy note
+
+UI に表示する privacy note の基本文言は以下です。
+
+> 共有リンクを知っている人は、このコレクションを閲覧できます。MVPではメモと画像は共有対象に含まれません。個人情報を含む内容を共有しないよう確認してください。共有はいつでも停止できます。
+
+### 共有停止
+
+- 共有は `Disable share` で停止できます
+- 停止後、その share URL では閲覧できません
+- 停止は document delete ではなく、`isEnabled: false` による revoke です
+
+### 利用上の注意
+
+- タイトルやタグに個人情報を含めると、その情報は共有相手に見えます
+- MVP では memo と画像を共有しませんが、`title` と `tags` は共有されます
+- 不特定多数へ転送されても問題ない内容だけ共有してください
+
+---
+
+## 開発者向け設計メモ
+
+### Data model
+
+`publicShares/{shareId}` は以下の shape を想定します。
+
+```ts
+publicShares/{shareId} = {
+  ownerUid: string, // rules用。UIには表示しない
+  isEnabled: boolean,
+  createdAt: Timestamp,
+  updatedAt: Timestamp,
+  title: string,
+  source: "snapshot",
+  items: [
+    {
+      id: string,
+      title: string,
+      tags: string[],
+      createdAt?: string
+    }
+  ]
+}
+```
+
+実装上の TypeScript では `createdAt` は `Timestamp | null` を扱います。
+
+### Snapshot方式を採用する理由
+
+- `users/{uid}/nailItems` を直接公開すると private collection と public view の境界が曖昧になる
+- 共有時点の内容を固定しやすく、公開対象フィールドを明示的に絞れる
+- public page を read-only にしやすい
+- revoke を `isEnabled: false` で扱いやすい
+
+### `users/{uid}/nailItems` を直接公開しない理由
+
+- private collection の owner-only rules を壊したくない
+- 共有対象外の field が将来増えた場合に漏洩リスクが高い
+- 通常アプリ用の CRUD / upload / summary / export と公開ページの責務を分離したい
+
+### 除外フィールドの理由
+
+`memo` を除外する理由:
+
+- サロン名、価格、個人メモなど privacy risk が高い情報を含みやすいため
+
+`imageUrl` / Storage image を除外する理由:
+
+- 画像URLや Storage object を共有すると、意図しない二次利用や URL 拡散のリスクが上がるため
+- MVP では Storage Rules を変更せず、画像共有の要件も切り離したいため
+
+owner email / displayName を除外する理由:
+
+- owner identity を public page に出さないため
+- unlisted share link は collection の共有であり、owner profile 公開ではないため
+
+### Firestore Rules の公開範囲
+
+Firestore Rules は `publicShares/{shareId}` に対して次を許可します。
+
+- `isEnabled == true` の document に対する未認証 read
+- owner による create
+- owner による update
+
+禁止するもの:
+
+- client-side delete
+- 未認証 write
+- 別ユーザーによる update
+
+### revoke に delete ではなく disable を使う理由
+
+- share URL を無効化する責務を `isEnabled` に集約できる
+- audit 的に share document を残せる
+- disabled state の safe UI を実装しやすい
+- 将来、期限付きリンクや状態遷移を追加しやすい
+
+### Public page の制約
+
+- public page は read-only
+- owner controls は表示しない
+- auth UI、CRUD form、upload、export、share creation UI は public mode で表示しない
+- `ownerUid` は rules 用 field として保持するが、UI では使用しない
+
+### Future work
+
+MVP の scope 外で、別 Issue / 別設計として検討する項目:
+
+- 画像共有
+- memo 共有
+- 期限付き URL
+- abuse / report 導線
+- analytics
+- owner-visible audit trail
+
+---
+
+## 関連ファイル
+
+- [FIRESTORE_SECURITY_RULES.md](./FIRESTORE_SECURITY_RULES.md)
+- [ROADMAP.md](../product/ROADMAP.md)
+- [publicShares.ts](../../src/lib/publicShares.ts)
+- [firestore.rules](../../firestore.rules)

--- a/docs/product/ROADMAP.md
+++ b/docs/product/ROADMAP.md
@@ -17,7 +17,7 @@
 | Phase 2 | Data Persistence | ✅ 完了 |
 | Phase 3 | Authentication / User Management | ✅ 完了 |
 | Phase 4 | AI-Assisted Features | 🔲 未着手 |
-| Phase 5 | Review / Export / Sharing | 🔲 未着手 |
+| Phase 5 | Review / Export / Sharing | 🟡 進行中 |
 | Phase 6 | Security / Operations Hardening | 🔲 未着手 |
 | Phase 7 | Release Preparation | 🔲 未着手 |
 | Phase 8 | 3D Preview / Modeling Foundation | 🔲 未着手 |
@@ -174,6 +174,15 @@
 - [ ] CSV / JSON エクスポート
 - [ ] コレクション振り返り画面（月別・タグ別）
 - [ ] 共有 URL / 公開コレクション機能
+
+### 完了済みサブセット
+
+- [x] CSV / JSON エクスポート
+- [x] コレクション概要（タグ別 / 月別 / 最近の更新）
+- [x] 共有 URL 作成 UI
+- [x] `/share/{shareId}` 公開閲覧ページ
+- [x] public sharing browser QA
+- [x] public sharing privacy notes
 
 ### Human Gates
 


### PR DESCRIPTION
## Summary
- Add a dedicated public sharing privacy note document for users and developers
- Document the unlisted share link behavior, shared fields, excluded fields, and revoke flow
- Update Firestore rules and roadmap docs to reflect the current deployed and QA-verified public sharing MVP state

## Scope
- docs/operations/PUBLIC_SHARING_PRIVACY.md
- docs/operations/FIRESTORE_SECURITY_RULES.md
- docs/product/ROADMAP.md

## Out of Scope
- Code changes
- Firebase Rules changes
- Firebase deploy
- Storage Rules changes

## Test plan
- [x] npm run build
- [x] npm run lint
- [x] .\commands\check-css-guard.ps1

Closes #65
