### PR TITLE
docs: add public sharing privacy docs link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ export default defineConfig([
 |----------|-------------|
 | [docs/operations/LOCAL_DEVELOPMENT_MANUAL.md](docs/operations/LOCAL_DEVELOPMENT_MANUAL.md) | Step-by-step local development guide including VS Code Tunnel |
 | [docs/operations/FIRESTORE_SECURITY_RULES.md](docs/operations/FIRESTORE_SECURITY_RULES.md) | Firestore Security Rules design, phase plan, and deploy checklist |
+| [docs/operations/PUBLIC_SHARING_PRIVACY.md](docs/operations/PUBLIC_SHARING_PRIVACY.md) | Public share links, shared/excluded fields, revoke behavior, and privacy notes |
 | [docs/operations/FIREBASE_SETUP.md](docs/operations/FIREBASE_SETUP.md) | Firebase Auth setup and verification steps |
 | [docs/operations/FIREBASE_STORAGE_RULES.md](docs/operations/FIREBASE_STORAGE_RULES.md) | Storage Security Rules design, allowed types/sizes, and deploy checklist |
 | [docs/operations/IMAGE_UPLOAD_QA.md](docs/operations/IMAGE_UPLOAD_QA.md) | QA checklist for image upload — normal, error, edit, delete, and pre-merge checks |


### PR DESCRIPTION
## Summary
- Add README link to public sharing privacy notes
- Resolve the non-blocking docs gap found in Issue #73 MVP readiness audit

## Scope
- README.md only

## Out of Scope
- App code changes
- Firebase Rules changes
- Storage Rules changes
- Firebase deploy
- Public sharing behavior changes

## Test plan
- [x] npm run build
- [x] npm run lint
- [x] .\commands\check-css-guard.ps1
- [x] Confirm README link target exists

Closes #74
Related: #73
