### PR TITLE
feat(sharing): add public share management UI

### DIFF
--- a/docs/operations/FIRESTORE_SECURITY_RULES.md
+++ b/docs/operations/FIRESTORE_SECURITY_RULES.md
@@ -78,6 +78,7 @@ Firestore (default)
 
 **アクセスルール:**
 - `isEnabled == true` の publicShares のみ未認証 read 可
+- owner は自分の publicShares を read 可（管理 UI で disabled share も表示するため）
 - owner のみ create 可
 - owner の update は revoke 用途に限定し、変更可能フィールドは `isEnabled` / `updatedAt` のみ
 - disabled share の再有効化（`isEnabled:false` から `true`）は不可
@@ -199,8 +200,9 @@ service cloud.firestore {
 
     // Public share links — unlisted snapshot sharing MVP
     match /publicShares/{shareId} {
-      // Anyone can read a share that is explicitly enabled
-      allow read: if resource.data.isEnabled == true;
+      // Anyone can read enabled shares; owners can also read their disabled shares.
+      allow read: if resource.data.isEnabled == true
+                  || isPublicShareOwner();
 
       // Authenticated owner can create a share
       allow create: if request.auth != null
@@ -279,22 +281,24 @@ Firebase Console の Rules Playground で以下を確認してから deploy し�
 |---|--------|---------|------|------|-----------|---------|
 | 1 | 有効な share を未認証で read | 未認証 | `publicShares/{shareId}` | get | true | **ALLOW** |
 | 2 | 無効な share を未認証で read | 未認証 | `publicShares/{shareId}` | get | false | **DENY** |
-| 3 | 未認証で publicShares create | 未認証 | `publicShares/{shareId}` | create | — | **DENY** |
-| 4 | 未認証で publicShares update | 未認証 | `publicShares/{shareId}` | update | — | **DENY** |
-| 5 | owner が share を create | 認証済み (ownerUid 一致) | `publicShares/{shareId}` | create | true | **ALLOW** |
-| 6 | owner が source 不正で create | 認証済み (ownerUid 一致) | `publicShares/{shareId}` | create (`source:"invalid"`) | true | **DENY** |
-| 7 | owner が `isEnabled:false` で revoke | 認証済み (ownerUid 一致) | `publicShares/{shareId}` | update | false | **ALLOW** |
-| 8 | owner が `updatedAt` のみ更新 | 認証済み (ownerUid 一致) | `publicShares/{shareId}` | update | unchanged | **ALLOW** |
-| 9 | owner が disabled share を再有効化 | 認証済み (ownerUid 一致) | `publicShares/{shareId}` | update | true | **DENY** |
-| 10 | owner が `ownerUid` を変更 | 認証済み (ownerUid 一致) | `publicShares/{shareId}` | update | unchanged | **DENY** |
-| 11 | owner が `source` を変更 | 認証済み (ownerUid 一致) | `publicShares/{shareId}` | update | unchanged | **DENY** |
-| 12 | owner が `createdAt` を変更 | 認証済み (ownerUid 一致) | `publicShares/{shareId}` | update | unchanged | **DENY** |
-| 13 | owner が `title` を変更 | 認証済み (ownerUid 一致) | `publicShares/{shareId}` | update | unchanged | **DENY** |
-| 14 | owner が `items` を変更 | 認証済み (ownerUid 一致) | `publicShares/{shareId}` | update | unchanged | **DENY** |
-| 15 | 別ユーザーが update | 認証済み (ownerUid 不一致) | `publicShares/{shareId}` | update | — | **DENY** |
-| 16 | owner が delete | 認証済み (ownerUid 一致) | `publicShares/{shareId}` | delete | — | **DENY** |
-| 17 | 未認証で users/{uid}/nailItems read | 未認証 | `users/{uid}/nailItems/{itemId}` | get | — | **DENY** |
-| 18 | 他人が users/{uid}/nailItems read | 認証済み (uid 不一致) | `users/{uid}/nailItems/{itemId}` | get | — | **DENY** |
+| 3 | owner が自分の無効な share を read | 認証済み (ownerUid 一致) | `publicShares/{shareId}` | get | false | **ALLOW** |
+| 4 | 他人が無効な share を read | 認証済み (ownerUid 不一致) | `publicShares/{shareId}` | get | false | **DENY** |
+| 5 | 未認証で publicShares create | 未認証 | `publicShares/{shareId}` | create | — | **DENY** |
+| 6 | 未認証で publicShares update | 未認証 | `publicShares/{shareId}` | update | — | **DENY** |
+| 7 | owner が share を create | 認証済み (ownerUid 一致) | `publicShares/{shareId}` | create | true | **ALLOW** |
+| 8 | owner が source 不正で create | 認証済み (ownerUid 一致) | `publicShares/{shareId}` | create (`source:"invalid"`) | true | **DENY** |
+| 9 | owner が `isEnabled:false` で revoke | 認証済み (ownerUid 一致) | `publicShares/{shareId}` | update | false | **ALLOW** |
+| 10 | owner が `updatedAt` のみ更新 | 認証済み (ownerUid 一致) | `publicShares/{shareId}` | update | unchanged | **ALLOW** |
+| 11 | owner が disabled share を再有効化 | 認証済み (ownerUid 一致) | `publicShares/{shareId}` | update | true | **DENY** |
+| 12 | owner が `ownerUid` を変更 | 認証済み (ownerUid 一致) | `publicShares/{shareId}` | update | unchanged | **DENY** |
+| 13 | owner が `source` を変更 | 認証済み (ownerUid 一致) | `publicShares/{shareId}` | update | unchanged | **DENY** |
+| 14 | owner が `createdAt` を変更 | 認証済み (ownerUid 一致) | `publicShares/{shareId}` | update | unchanged | **DENY** |
+| 15 | owner が `title` を変更 | 認証済み (ownerUid 一致) | `publicShares/{shareId}` | update | unchanged | **DENY** |
+| 16 | owner が `items` を変更 | 認証済み (ownerUid 一致) | `publicShares/{shareId}` | update | unchanged | **DENY** |
+| 17 | 別ユーザーが update | 認証済み (ownerUid 不一致) | `publicShares/{shareId}` | update | — | **DENY** |
+| 18 | owner が delete | 認証済み (ownerUid 一致) | `publicShares/{shareId}` | delete | — | **DENY** |
+| 19 | 未認証で users/{uid}/nailItems read | 未認証 | `users/{uid}/nailItems/{itemId}` | get | — | **DENY** |
+| 20 | 他人が users/{uid}/nailItems read | 認証済み (uid 不一致) | `users/{uid}/nailItems/{itemId}` | get | — | **DENY** |
 
 ---
 

--- a/firestore.rules
+++ b/firestore.rules
@@ -75,8 +75,9 @@ service cloud.firestore {
     // ================================================================
     //
     match /publicShares/{shareId} {
-      // Anyone can read a share that is explicitly enabled
-      allow read: if resource.data.isEnabled == true;
+      // Anyone can read enabled shares; owners can also read their disabled shares.
+      allow read: if resource.data.isEnabled == true
+                  || isPublicShareOwner();
 
       // Authenticated owner can create a share
       allow create: if request.auth != null

--- a/src/App.css
+++ b/src/App.css
@@ -805,6 +805,98 @@
   color: #c00;
 }
 
+.share-management {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding-top: 12px;
+  border-top: 1px solid var(--border);
+}
+
+.share-management-list {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  margin: 0;
+  padding: 0;
+}
+
+.share-management-item {
+  display: flex;
+  gap: 12px;
+  justify-content: space-between;
+  padding: 10px 0;
+  border-bottom: 1px solid var(--border);
+}
+
+.share-management-main {
+  min-width: 0;
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.share-management-title-row,
+.share-management-dates,
+.share-management-actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+}
+
+.share-management-title {
+  min-width: 0;
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: var(--text-h);
+  overflow-wrap: anywhere;
+}
+
+.share-state {
+  border: 1px solid var(--border);
+  border-radius: 9999px;
+  padding: 2px 8px;
+  font-size: 0.72rem;
+  font-weight: 600;
+}
+
+.share-state--enabled {
+  color: var(--accent);
+  border-color: var(--accent-border);
+  background: var(--accent-bg);
+}
+
+.share-state--disabled {
+  color: #888;
+  background: rgba(255, 255, 255, 0.04);
+}
+
+.share-management-dates {
+  font-size: 0.74rem;
+  color: #888;
+}
+
+.share-management-url {
+  display: block;
+  font-size: 0.74rem;
+  color: var(--text);
+  overflow-wrap: anywhere;
+}
+
+.share-management-actions {
+  justify-content: flex-end;
+  align-content: flex-start;
+  flex: 0 0 176px;
+}
+
+.share-open-link {
+  text-decoration: none;
+  text-align: center;
+}
+
 .btn-export {
   padding: 7px 16px;
   border: 1px solid var(--accent-border);
@@ -908,6 +1000,16 @@
 @media (max-width: 480px) {
   .share-actions .btn-export {
     width: 100%;
+  }
+
+  .share-management-item,
+  .share-management-actions {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .share-management-actions {
+    flex-basis: auto;
   }
 
   #public-share-list {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,13 +3,25 @@ import { auth, signInWithGoogle, signOutUser, onAuthStateChanged } from './lib/a
 import type { User } from './lib/auth'
 import { addNailItem, updateNailItem, deleteNailItem, fetchNailItems } from './lib/firestore'
 import type { NailItemDoc } from './lib/firestore'
-import { createPublicShare, disablePublicShare, getPublicShare } from './lib/publicShares'
+import {
+  createPublicShare,
+  disablePublicShare,
+  fetchPublicSharesForOwner,
+  getPublicShare,
+} from './lib/publicShares'
 import type { PublicShareDocWithId, PublicShareItemSnapshot } from './lib/publicShares'
 import { uploadNailImage, deleteNailImage } from './lib/storage'
 import './App.css'
 
 const sortByDate = (items: NailItemDoc[]): NailItemDoc[] =>
   [...items].sort((a, b) => {
+    const ta = (a.updatedAt ?? a.createdAt)?.seconds ?? 0
+    const tb = (b.updatedAt ?? b.createdAt)?.seconds ?? 0
+    return tb - ta
+  })
+
+const sortPublicShares = (shares: PublicShareDocWithId[]): PublicShareDocWithId[] =>
+  [...shares].sort((a, b) => {
     const ta = (a.updatedAt ?? a.createdAt)?.seconds ?? 0
     const tb = (b.updatedAt ?? b.createdAt)?.seconds ?? 0
     return tb - ta
@@ -172,6 +184,9 @@ function App() {
   const [isCreatingShare, setIsCreatingShare] = useState(false)
   const [shareError, setShareError] = useState('')
   const [shareStatusMessage, setShareStatusMessage] = useState('')
+  const [publicShares, setPublicShares] = useState<PublicShareDocWithId[]>([])
+  const [publicSharesUserId, setPublicSharesUserId] = useState<string | null>(null)
+  const [shareActionId, setShareActionId] = useState<string | null>(null)
   const [publicShare, setPublicShare] = useState<PublicShareDocWithId | null>(null)
   const [publicShareState, setPublicShareState] = useState<PublicShareViewState>(
     isPublicSharePage ? 'loading' : 'idle'
@@ -249,6 +264,8 @@ function App() {
     if (!nextUser) {
       setNailItems([])
       setNailItemsUserId(null)
+      setPublicShares([])
+      setPublicSharesUserId(null)
     }
   }), [isPublicSharePage])
 
@@ -267,6 +284,26 @@ function App() {
         if (didCancel) return
         setNailItems([])
         setNailItemsUserId(user.uid)
+      })
+    return () => { didCancel = true }
+  }, [isPublicSharePage, user])
+
+  useEffect(() => {
+    if (isPublicSharePage) return
+    if (!user) return
+    let didCancel = false
+    fetchPublicSharesForOwner(user.uid)
+      .then(shares => {
+        if (didCancel) return
+        setPublicShares(sortPublicShares(shares))
+        setPublicSharesUserId(user.uid)
+      })
+      .catch((e: unknown) => {
+        console.error('public shares fetch failed', e)
+        if (didCancel) return
+        setPublicShares([])
+        setPublicSharesUserId(user.uid)
+        setShareError('共有リンクの取得に失敗しました。')
       })
     return () => { didCancel = true }
   }, [isPublicSharePage, user])
@@ -412,6 +449,15 @@ function App() {
     return true
   })
 
+  const getShareUrl = (id: string): string =>
+    typeof window === 'undefined' ? `/share/${id}` : `${window.location.origin}/share/${id}`
+
+  const refreshPublicShares = async (uid: string): Promise<void> => {
+    const shares = await fetchPublicSharesForOwner(uid)
+    setPublicShares(sortPublicShares(shares))
+    setPublicSharesUserId(uid)
+  }
+
   const handleCreateShareLink = async () => {
     if (!user || filteredItems.length === 0) return
 
@@ -430,10 +476,11 @@ function App() {
           createdAt: item.createdAt ?? null,
         }))
       )
-      const nextShareUrl = `${window.location.origin}/share/${nextShareId}`
+      const nextShareUrl = getShareUrl(nextShareId)
       setShareId(nextShareId)
       setShareUrl(nextShareUrl)
       setShareStatusMessage('Share link created. Copy it to share this snapshot.')
+      await refreshPublicShares(user.uid)
     } catch (e: unknown) {
       const message = e instanceof Error ? e.message : 'Failed to create share link.'
       setShareError(message)
@@ -462,6 +509,24 @@ function App() {
     }
   }
 
+  const handleCopyManagedShareLink = async (managedShareId: string) => {
+    setShareError('')
+    setShareStatusMessage('')
+
+    if (!navigator.clipboard?.writeText) {
+      setShareError('Clipboard API is not available in this browser.')
+      return
+    }
+
+    try {
+      await navigator.clipboard.writeText(getShareUrl(managedShareId))
+      setShareStatusMessage('リンクをコピーしました。')
+    } catch (e: unknown) {
+      const message = e instanceof Error ? e.message : '共有リンクのコピーに失敗しました。'
+      setShareError(message)
+    }
+  }
+
   const handleDisableShare = async () => {
     if (!shareId) return
 
@@ -474,11 +539,36 @@ function App() {
       setShareId('')
       setShareUrl('')
       setShareStatusMessage('Share link disabled.')
+      if (user) await refreshPublicShares(user.uid)
     } catch (e: unknown) {
       const message = e instanceof Error ? e.message : 'Failed to disable share link.'
       setShareError(message)
     } finally {
       setIsCreatingShare(false)
+    }
+  }
+
+  const handleDisableManagedShare = async (managedShare: PublicShareDocWithId) => {
+    if (!user || !managedShare.isEnabled) return
+    if (!window.confirm(`「${managedShare.title}」の共有を停止しますか？\n停止した共有リンクは再有効化できません。`)) return
+
+    setShareActionId(managedShare.id)
+    setShareError('')
+    setShareStatusMessage('')
+
+    try {
+      await disablePublicShare(managedShare.id)
+      if (shareId === managedShare.id) {
+        setShareId('')
+        setShareUrl('')
+      }
+      await refreshPublicShares(user.uid)
+      setShareStatusMessage('共有を停止しました。')
+    } catch (e: unknown) {
+      const message = e instanceof Error ? e.message : '共有の停止に失敗しました。'
+      setShareError(message)
+    } finally {
+      setShareActionId(null)
     }
   }
 
@@ -799,6 +889,64 @@ function App() {
               )}
               {shareStatusMessage && <p className="share-status">{shareStatusMessage}</p>}
               {shareError && <p className="share-error">{shareError}</p>}
+              <div className="share-management">
+                <h4 className="summary-section-title">共有リンク管理</h4>
+                {user && publicSharesUserId !== user.uid ? (
+                  <p className="share-description">共有リンクを読み込んでいます...</p>
+                ) : publicShares.length === 0 ? (
+                  <p className="share-description">共有リンクはまだありません</p>
+                ) : (
+                  <ul className="share-management-list">
+                    {publicShares.map(managedShare => {
+                      const managedShareUrl = getShareUrl(managedShare.id)
+                      const createdDate = formatDate(managedShare.createdAt)
+                      const updatedDate = formatDate(managedShare.updatedAt)
+                      return (
+                        <li key={managedShare.id} className="share-management-item">
+                          <div className="share-management-main">
+                            <div className="share-management-title-row">
+                              <span className="share-management-title">{managedShare.title}</span>
+                              <span className={`share-state ${managedShare.isEnabled ? 'share-state--enabled' : 'share-state--disabled'}`}>
+                                {managedShare.isEnabled ? '有効' : '無効'}
+                              </span>
+                            </div>
+                            <div className="share-management-dates">
+                              {createdDate && <span>作成: {createdDate}</span>}
+                              {updatedDate && <span>更新: {updatedDate}</span>}
+                            </div>
+                            <code className="share-management-url">{managedShareUrl}</code>
+                          </div>
+                          <div className="share-management-actions">
+                            <a
+                              className="btn-export share-open-link"
+                              href={managedShareUrl}
+                              target="_blank"
+                              rel="noreferrer"
+                            >
+                              開く
+                            </a>
+                            <button
+                              type="button"
+                              className="btn-export"
+                              onClick={() => { void handleCopyManagedShareLink(managedShare.id) }}
+                            >
+                              リンクをコピー
+                            </button>
+                            <button
+                              type="button"
+                              className="btn-export btn-export-danger"
+                              onClick={() => { void handleDisableManagedShare(managedShare) }}
+                              disabled={!managedShare.isEnabled || shareActionId === managedShare.id}
+                            >
+                              {shareActionId === managedShare.id ? '停止中...' : '共有を停止'}
+                            </button>
+                          </div>
+                        </li>
+                      )
+                    })}
+                  </ul>
+                )}
+              </div>
             </div>
           )}
           {!isFetching && nailItems.length > 0 && (activeTagFilter !== null || activeMonthFilter !== null) && (

--- a/src/lib/publicShares.ts
+++ b/src/lib/publicShares.ts
@@ -1,5 +1,5 @@
 import {
-  collection, addDoc, doc, updateDoc, getDoc,
+  collection, addDoc, doc, updateDoc, getDoc, getDocs, query, where,
   serverTimestamp,
 } from 'firebase/firestore'
 import type { Timestamp } from 'firebase/firestore'
@@ -55,6 +55,16 @@ export const disablePublicShare = async (shareId: string): Promise<void> => {
     isEnabled: false,
     updatedAt: serverTimestamp(),
   })
+}
+
+export const fetchPublicSharesForOwner = async (ownerUid: string): Promise<PublicShareDocWithId[]> => {
+  const ref = collection(db, 'publicShares')
+  const q = query(ref, where('ownerUid', '==', ownerUid))
+  const snapshot = await getDocs(q)
+  return snapshot.docs.map(snap => ({
+    id: snap.id,
+    ...(snap.data() as PublicShareDoc),
+  }))
 }
 
 export const getPublicShare = async (shareId: string): Promise<PublicShareDocWithId | null> => {


### PR DESCRIPTION
## Summary

Closes #78.

Added MVP public share management UI for the current user.

- Add 「共有リンク管理」 inside the existing share section
- List current user’s public shares
- Show title, enabled/disabled status, created/updated dates, and share URL
- Add open/copy actions for share URLs
- Allow revoking enabled shares
- Keep disabled shares disabled with no re-enable action
- Keep revoke writes limited to isEnabled:false and updatedAt
- Add owner share query using where('ownerUid', '==', currentUser.uid)

## Firestore Rules

Updated Firestore Rules to support owner management reads.

- Public unauthenticated read remains allowed only when isEnabled == true
- Authenticated owners can read their own shares, including disabled shares
- Non-owners cannot read disabled shares
- Owner update remains restricted to isEnabled / updatedAt
- Disabled shares cannot be re-enabled
- Delete remains denied

## Validation

- [x] npm run build
- [x] npm run lint
- [x] firebase deploy --only firestore:rules --dry-run --project nail-report-dev-ksc0000
- [x] git diff --check
- [ ] Repository CSS guard not run because pwsh is unavailable

## CSS Guard Note

CSS changed in this PR.

Because pwsh is unavailable, the repository CSS guard could not be run.  
As a substitute, equivalent added-line checks were run for:

- Markdown code fences
- CSS nesting selector syntax: `&:...`
- JavaScript template expressions: `${...}`

No matches were found.

## Browser Smoke Test

Browser smoke test was blocked by local Firebase `auth/invalid-api-key`, likely due to missing or invalid local env configuration.

No browser UI regression could be confirmed locally because app initialization stops before rendering.

## Deployment Notes

- No real Firebase deploy was performed.
- Hosting was not deployed.
- Storage Rules were not deployed.
- Because Firestore Rules changed, Rules Playground human verification is required before real Firebase deploy.
