### PR TITLE
docs: plan nail view and camera foundation

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ export default defineConfig([
 |----------|-------------|
 | [docs/product/PRODUCT_SPEC.md](docs/product/PRODUCT_SPEC.md) | Product vision, MVP scope, data model, open questions, future 3D/AR vision |
 | [docs/product/ROADMAP.md](docs/product/ROADMAP.md) | Phase-by-phase development roadmap (Phase 0–9; Phase 8–9 cover 3D Preview / Modeling / AR Try-on — not yet implemented) |
+| [docs/product/NAIL_VIEW_CAMERA_FOUNDATION_PLAN.md](docs/product/NAIL_VIEW_CAMERA_FOUNDATION_PLAN.md) | Phase 4.5 plan for nail image detail, camera/upload foundation, comparison, annotation, and iOS readiness |
 | [docs/product/ACCEPTANCE_CRITERIA.md](docs/product/ACCEPTANCE_CRITERIA.md) | Definition of done for each task type (includes 3D / Modeling / AR criteria) |
 
 ### AI Harness

--- a/docs/product/NAIL_VIEW_CAMERA_FOUNDATION_PLAN.md
+++ b/docs/product/NAIL_VIEW_CAMERA_FOUNDATION_PLAN.md
@@ -1,0 +1,259 @@
+# Nail View / Camera Foundation Plan
+
+> This document plans a near-term product slice: Phase 4.5 Nail View / Camera Foundation.
+> It is docs-only and does not implement camera, AI detection, AR, Firestore Rules, or schema changes.
+
+---
+
+## 1. Background
+
+The current app has:
+
+- NailItem CRUD
+- image upload
+- Google authentication
+- user-scoped Firestore persistence
+- public sharing
+- public share management
+- sharing/security/operations documentation
+
+Recent work strengthened sharing, security, and operations. That was necessary, but the next product step should move closer to a nail-specific experience before iOS release.
+
+Advanced 3D preview, modeling, and AR try-on remain later phases. The product should not jump directly to advanced AR before it has strong image viewing, camera/upload flow, nail detail review, comparison, and annotation foundations.
+
+---
+
+## 2. Why This Matters For iOS
+
+An iOS release likely needs:
+
+- strong camera/upload UX
+- native-feeling image review
+- clear nail image detail view
+- fast comparison of past designs
+- privacy-safe handling of user photos
+- future-ready data structure for AI detection and AR
+
+Even if the first implementation remains web-first, the product should start shaping the workflows that a mobile user expects: capture, inspect, compare, annotate, and later analyze.
+
+---
+
+## 3. Goals
+
+- Improve nail image viewing experience.
+- Prepare for camera-first workflows.
+- Create a foundation for AI tag suggestion.
+- Create a foundation for nail/hand detection.
+- Avoid jumping prematurely into full AR.
+- Keep scope incremental and testable.
+- Preserve existing NailItem CRUD, upload, auth, and sharing behavior.
+
+---
+
+## 4. Non-Goals
+
+- No AR try-on implementation yet.
+- No 3D modeling implementation yet.
+- No production iOS release in this phase.
+- No new AI API integration unless separately approved.
+- No automatic biometric or identity inference.
+- No broad app redesign.
+- No Firestore schema change in this docs task.
+
+---
+
+## 5. Proposed Implementation Slices
+
+### NVC-1: Nail Image Detail Viewer
+
+- Larger image preview.
+- Metadata panel.
+- Tags / memo / createdAt / updatedAt visibility.
+- Mobile-friendly layout.
+- No new schema required.
+
+### NVC-2: Image Comparison View
+
+- Compare two NailItems.
+- Support before/after or side-by-side review.
+- Mobile responsive behavior.
+- Keep comparison read-only for MVP.
+
+### NVC-3: Camera / Upload Source Foundation
+
+- Distinguish uploaded image vs camera-captured image.
+- Prepare capture metadata.
+- Avoid native iOS dependency initially.
+- Prefer browser/PWA-compatible capture before native-only work.
+
+### NVC-4: Manual Nail Area Annotation Prototype
+
+- Optional manual bounding box / region marker.
+- No AI required.
+- Creates evaluation data for later detection.
+- Keep annotations owner-only.
+
+### NVC-5: AI Nail Tag Suggestion Design
+
+- Identify possible tags: color, style, shape, season, mood.
+- Choose local/manual fallback.
+- Document privacy and API key considerations.
+- Require user confirmation before adding suggested tags.
+
+### NVC-6: Nail / Hand Detection Pipeline Design
+
+- Evaluate browser-based ML vs server/API approaches.
+- Compare privacy, cost, latency, accuracy, and iOS compatibility.
+- Avoid external image processing without explicit user consent.
+- Defer dependency selection until after design review.
+
+### NVC-7: iOS Readiness Review
+
+- Identify what needs to be native.
+- Identify what can remain web/PWA.
+- Plan camera permission UX.
+- Review image storage/privacy behavior.
+- Note App Store review considerations.
+
+---
+
+## 6. Recommended Immediate Next Implementation
+
+Recommended next issue:
+
+```text
+feature: add nail image detail viewer
+```
+
+Why this should come before camera detection:
+
+- Lower risk.
+- Directly improves current UX.
+- Works with existing data.
+- Creates a UI surface for later detection and AI metadata.
+- Can be smoke-tested without new permissions or ML dependencies.
+- Does not require Firestore Rules, camera APIs, external AI APIs, or new dependencies.
+
+The detail viewer can become the future home for:
+
+- detected regions
+- manual regions
+- suggested tags
+- dominant colors
+- image source metadata
+- comparison entry points
+
+---
+
+## 7. Data Model Considerations
+
+Potential future fields, not implemented in this phase:
+
+```text
+imageSource: "upload" | "camera" | "unknown"
+imageMetadata: {
+  width?: number
+  height?: number
+  capturedAt?: Timestamp
+  deviceType?: string
+}
+analysis: {
+  status?: "none" | "pending" | "complete" | "failed"
+  provider?: string
+  analyzedAt?: Timestamp
+}
+detectedRegions: Array<{
+  type: "nail" | "hand"
+  box: { x: number; y: number; width: number; height: number }
+  confidence?: number
+}>
+manualRegions: Array<{
+  type: "nail" | "hand"
+  box: { x: number; y: number; width: number; height: number }
+}>
+dominantColors: string[]
+suggestedTags: string[]
+confirmedTags: string[]
+```
+
+Any schema change should be a separate issue with:
+
+- backward compatibility review
+- Firestore Rules review
+- migration/backfill decision
+- UI fallback for missing fields
+- privacy review
+
+---
+
+## 8. Privacy And Security Considerations
+
+- User nail photos are personal data.
+- Camera/photo permissions must be explicit.
+- AI processing must be opt-in if external APIs are used.
+- Do not put secrets or API keys in client code.
+- Avoid sending images to external services without clear user consent.
+- Keep owner-only access for private NailItems.
+- Do not infer biometric identity or sensitive health information.
+- Keep public sharing exclusions for memo/image data unless separately approved.
+- Document all new image-processing data flows before implementation.
+
+---
+
+## 9. Validation Strategy
+
+For future implementation tasks:
+
+```text
+[ ] npm run build
+[ ] npm run lint
+[ ] git diff --check
+[ ] CSS guard if available
+[ ] manual browser smoke test
+[ ] mobile viewport smoke test
+[ ] authenticated user test
+[ ] no Firebase deploy unless rules/config changed
+```
+
+Additional checks for camera/image work:
+
+```text
+[ ] permission prompt copy is clear
+[ ] no capture starts before user action
+[ ] upload flow still works
+[ ] image preview fits mobile and desktop viewports
+[ ] console has no new relevant errors
+[ ] existing NailItem CRUD is not broken
+```
+
+---
+
+## 10. Proposed Next Issues
+
+- feature: add nail image detail viewer
+- feature: add nail image comparison view
+- design: plan camera capture flow
+- design: plan nail detection pipeline
+- design: plan iOS release readiness
+
+---
+
+## 11. Human Decisions Needed
+
+- Web-first vs iOS-native-first direction.
+- Whether to use PWA as an intermediate step.
+- Whether AI image analysis can use external APIs.
+- Whether camera capture should be browser-based first.
+- Which nail metadata matters most: color, shape, design, salon, date, mood, price.
+- Whether users should manually confirm AI-suggested tags.
+- Whether manual annotation is worth introducing before automated detection.
+
+---
+
+## Recommended Direction
+
+Proceed with Phase 4.5 before adding more sharing/security polish.
+
+The first implementation should be `feature: add nail image detail viewer`, because it improves the current product immediately and creates a stable UI surface for comparison, annotation, AI suggestion, and later detection work.
+
+Phase 8 and Phase 9 remain valid future phases for advanced 3D modeling and AR try-on. Phase 4.5 is the bridge that makes those later phases safer and more product-grounded.

--- a/docs/product/ROADMAP.md
+++ b/docs/product/ROADMAP.md
@@ -17,6 +17,7 @@
 | Phase 2 | Data Persistence | ✅ 完了 |
 | Phase 3 | Authentication / User Management | ✅ 完了 |
 | Phase 4 | AI-Assisted Features | 🔲 未着手 |
+| Phase 4.5 | Nail View / Camera Foundation | 🔲 推奨 next |
 | Phase 5 | Review / Export / Sharing | 🟡 進行中 |
 | Phase 6 | Security / Operations Hardening | 🔲 未着手 |
 | Phase 7 | Release Preparation | 🔲 未着手 |
@@ -160,6 +161,42 @@
 - [ ] AI 機能が指定された仕様通りに動作する
 - [ ] API キーがコードに含まれていない
 - [ ] フォールバック（API 障害時の動作）が定義されている
+
+---
+
+## Phase 4.5: Nail View / Camera Foundation
+
+**Goal:** iOS release に向けて、ネイル画像の閲覧・比較・撮影導線・将来の検出/AI/AR に必要な土台を先に整える
+
+> **Recommended next direction:** 共有・運用の追加 polish を続ける前に、NailItem の「ネイルらしい体験」を強化する。Phase 8 / 9 の 3D / AR は引き続き後続の advanced phase とし、この Phase 4.5 では画像閲覧・カメラ導線・手動 annotation・AI/検出の設計基盤までに絞る。
+
+### Example Issues
+
+- [ ] feature: add nail image detail viewer
+- [ ] feature: add nail image comparison view
+- [ ] design: plan camera capture flow
+- [ ] feature: add upload/camera source distinction
+- [ ] design: plan nail/hand detection pipeline
+- [ ] feature: add AI nail tag suggestion from image
+- [ ] design: plan iOS capture requirements
+
+### Human Gates
+
+- G1: iOS / Web / PWA の product direction 判断
+- G2: 画像 detail / comparison など UI/UX の主要変更
+- G3: `imageSource` / `manualRegions` / `analysis` 等の Firestore schema 追加
+- G6: カメラ・ユーザー写真・AI 画像解析のプライバシー方針
+- G7: 外部 AI API キーが必要な場合
+- G8: 画像処理 / ML / camera helper library 追加
+
+### Done Criteria
+
+- [ ] NailItem の画像 detail viewer が既存データで動作する
+- [ ] 画像比較の最小 UX がスマートフォン幅で破綻しない
+- [ ] カメラ/アップロード source の方針が docs にまとまっている
+- [ ] AI tag suggestion / nail detection / iOS capture の判断材料が docs にまとまっている
+- [ ] 既存の NailItem CRUD / upload / share 機能を壊していない
+- [ ] `npm run build` が成功している
 
 ---
 


### PR DESCRIPTION
## Summary

Closes #84.

Added a docs-only roadmap and planning update for Phase 4.5: Nail View / Camera Foundation.

- Add Phase 4.5 “Nail View / Camera Foundation” to `ROADMAP.md`
- Add `docs/product/NAIL_VIEW_CAMERA_FOUNDATION_PLAN.md`
- Link the new plan from `README.md`
- Define near-term product direction toward iOS-ready nail experiences
- Cover image detail viewer, comparison, camera/upload foundation, manual annotation, AI tag suggestion, nail/hand detection pipeline, and iOS readiness

## Validation

- [x] `npm run build`
- [x] `npm run lint`
- [x] `git diff --check`

## Notes

- Docs-only change.
- No Firebase deploy performed.
- No Firestore Rules changes.
- No application source changes.
- No dependency changes.
- Firebase dry-run was not run because Firestore Rules were unchanged.

## Open Decisions

- Web vs iOS direction
- PWA use
- External AI APIs
- Browser camera first
- Metadata priorities
- AI tag confirmation
- Manual annotation
