### PR TITLE
feat(nail-view): add image detail viewer

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -501,10 +501,163 @@
 
 .nail-item-actions {
   display: flex;
+  flex-wrap: wrap;
   gap: 6px;
   justify-content: flex-end;
   padding: 8px 12px;
   border-top: 1px solid var(--border);
+}
+
+.nail-detail-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 20;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 20px;
+  box-sizing: border-box;
+  background: rgba(0, 0, 0, 0.5);
+}
+
+.nail-detail-dialog {
+  width: min(720px, 100%);
+  max-height: calc(100vh - 40px);
+  overflow: auto;
+  background: var(--social-bg);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  box-shadow: var(--shadow);
+}
+
+.nail-detail-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 14px 16px;
+  border-bottom: 1px solid var(--border);
+}
+
+.nail-detail-kicker {
+  margin: 0;
+  font-size: 0.78rem;
+  font-weight: 700;
+  color: var(--accent);
+}
+
+.nail-detail-close {
+  padding: 6px 12px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  font-size: 0.84rem;
+  cursor: pointer;
+}
+
+.nail-detail-close:hover {
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.nail-detail-close:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.nail-detail-image-frame {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 220px;
+  max-height: 58vh;
+  background: var(--border);
+}
+
+.nail-detail-image {
+  display: block;
+  width: 100%;
+  height: auto;
+  max-height: 58vh;
+  object-fit: contain;
+}
+
+.nail-detail-no-image {
+  min-height: 220px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #888;
+  font-size: 0.92rem;
+}
+
+.nail-detail-body {
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.nail-detail-title {
+  margin: 0;
+  color: var(--text-h);
+  font-size: 1.24rem;
+  line-height: 1.35;
+  overflow-wrap: anywhere;
+}
+
+.nail-detail-section {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.nail-detail-label {
+  margin: 0;
+  color: var(--text-h);
+  font-size: 0.82rem;
+  font-weight: 700;
+}
+
+.nail-detail-memo,
+.nail-detail-empty {
+  margin: 0;
+  color: var(--text);
+  font-size: 0.9rem;
+  line-height: 1.7;
+  overflow-wrap: anywhere;
+}
+
+.nail-detail-empty {
+  color: #888;
+}
+
+.nail-detail-meta {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 10px;
+  margin: 0;
+}
+
+.nail-detail-meta div {
+  padding: 10px 12px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.04);
+}
+
+.nail-detail-meta dt {
+  margin: 0 0 4px;
+  color: #888;
+  font-size: 0.74rem;
+}
+
+.nail-detail-meta dd {
+  margin: 0;
+  color: var(--text-h);
+  font-size: 0.86rem;
 }
 
 #nail-list li {
@@ -541,6 +694,26 @@
   }
   #nail-list li:hover .nail-thumb-img {
     transform: none;
+  }
+}
+
+@media (max-width: 480px) {
+  .nail-detail-backdrop {
+    align-items: flex-start;
+    padding: 12px;
+  }
+
+  .nail-detail-dialog {
+    max-height: calc(100vh - 24px);
+  }
+
+  .nail-detail-image-frame,
+  .nail-detail-no-image {
+    min-height: 180px;
+  }
+
+  .nail-detail-meta {
+    grid-template-columns: 1fr;
   }
 }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -173,6 +173,7 @@ function App() {
   const [nailImageFile, setNailImageFile] = useState<File | null>(null)
   const [nailImagePreview, setNailImagePreview] = useState<string | null>(null)
   const [editingId, setEditingId] = useState<string | null>(null)
+  const [detailItemId, setDetailItemId] = useState<string | null>(null)
   const [nailLoading, setNailLoading] = useState(false)
   const [nailError, setNailError] = useState('')
   const [nailItemsUserId, setNailItemsUserId] = useState<string | null>(null)
@@ -192,6 +193,7 @@ function App() {
     isPublicSharePage ? 'loading' : 'idle'
   )
   const fileInputRef = useRef<HTMLInputElement>(null)
+  const detailCloseButtonRef = useRef<HTMLButtonElement>(null)
   const previewUrlRef = useRef<string | null>(null)
 
   useEffect(() => () => {
@@ -266,8 +268,19 @@ function App() {
       setNailItemsUserId(null)
       setPublicShares([])
       setPublicSharesUserId(null)
+      setDetailItemId(null)
     }
   }), [isPublicSharePage])
+
+  useEffect(() => {
+    if (!detailItemId) return
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setDetailItemId(null)
+    }
+    document.addEventListener('keydown', handleKeyDown)
+    detailCloseButtonRef.current?.focus()
+    return () => document.removeEventListener('keydown', handleKeyDown)
+  }, [detailItemId])
 
   useEffect(() => {
     if (isPublicSharePage) return
@@ -436,6 +449,7 @@ function App() {
   }
 
   const editingItem = editingId ? nailItems.find(i => i.id === editingId) : null
+  const detailItem = detailItemId ? nailItems.find(i => i.id === detailItemId) : null
   const isFetching = Boolean(user && nailItemsUserId !== user.uid)
   const summary = useMemo(() => getNailSummary(nailItems), [nailItems])
 
@@ -657,6 +671,87 @@ function App() {
   return (
     <section id="center">
       <h1 id="app-title">Nailous</h1>
+      {detailItem && (() => {
+        const createdDate = formatDate(detailItem.createdAt)
+        const updatedDate = (detailItem.updatedAt && detailItem.createdAt &&
+          detailItem.updatedAt.seconds !== detailItem.createdAt.seconds)
+          ? formatDate(detailItem.updatedAt)
+          : null
+        return (
+          <div
+            className="nail-detail-backdrop"
+            role="presentation"
+            onClick={() => setDetailItemId(null)}
+          >
+            <div
+              className="nail-detail-dialog"
+              role="dialog"
+              aria-modal="true"
+              aria-labelledby="nail-detail-title"
+              onClick={e => e.stopPropagation()}
+            >
+              <div className="nail-detail-header">
+                <p className="nail-detail-kicker">ネイル詳細</p>
+                <button
+                  ref={detailCloseButtonRef}
+                  type="button"
+                  className="nail-detail-close"
+                  onClick={() => setDetailItemId(null)}
+                  aria-label="ネイル詳細を閉じる"
+                >
+                  閉じる
+                </button>
+              </div>
+              <div className="nail-detail-image-frame">
+                {detailItem.imageUrl ? (
+                  <img
+                    className="nail-detail-image"
+                    src={detailItem.imageUrl}
+                    alt={detailItem.title + ' のネイル画像'}
+                  />
+                ) : (
+                  <div className="nail-detail-no-image">画像なし</div>
+                )}
+              </div>
+              <div className="nail-detail-body">
+                <h2 id="nail-detail-title" className="nail-detail-title">{detailItem.title}</h2>
+                <div className="nail-detail-section">
+                  <h3 className="nail-detail-label">タグ</h3>
+                  {detailItem.tags.length > 0 ? (
+                    <div className="nail-item-tags">
+                      {detailItem.tags.map(t => (
+                        <span key={t} className="nail-tag">#{t}</span>
+                      ))}
+                    </div>
+                  ) : (
+                    <p className="nail-detail-empty">タグなし</p>
+                  )}
+                </div>
+                {detailItem.memo && (
+                  <div className="nail-detail-section">
+                    <h3 className="nail-detail-label">メモ</h3>
+                    <p className="nail-detail-memo">{detailItem.memo}</p>
+                  </div>
+                )}
+                <dl className="nail-detail-meta">
+                  {createdDate && (
+                    <div>
+                      <dt>作成日</dt>
+                      <dd>{createdDate}</dd>
+                    </div>
+                  )}
+                  {updatedDate && (
+                    <div>
+                      <dt>更新日</dt>
+                      <dd>{updatedDate}</dd>
+                    </div>
+                  )}
+                </dl>
+              </div>
+            </div>
+          </div>
+        )
+      })()}
       <div id="auth-bar">
         {user === undefined ? null : user ? (
           <div className="auth-user">
@@ -1034,6 +1129,10 @@ function App() {
                       )}
                     </div>
                     <div className="nail-item-actions">
+                      <button
+                        type="button"
+                        onClick={() => setDetailItemId(item.id)}
+                      >詳しく見る</button>
                       <button
                         type="button"
                         onClick={() => handleStartEdit(item)}


### PR DESCRIPTION
## Summary

Closes #86.

Added an MVP Nail image detail viewer.

- Add 「詳しく見る」 to NailItem cards
- Add a detail dialog for existing NailItems
- Show a larger nail image
- Show title, tags, memo, createdAt, and updatedAt
- Show 「画像なし」 for items without an image
- Support close button, backdrop click, and Escape key
- Keep existing edit/delete/share behavior unchanged
- No Firestore Rules changes
- No data model changes

## Accessibility / Responsive

- Add `role="dialog"` and `aria-modal`
- Add heading label for the dialog
- Add clear close button label/focus
- Use item title based image alt text
- Adjust dialog/image/metadata layout for mobile viewports

## Validation

- [x] `npm run build`
- [x] `npm run lint`
- [x] `git diff --check`
- [ ] Authenticated browser smoke test blocked by local Firebase Auth config / popup flow

## CSS Guard Note

Formal repository CSS guard could not be run because `pwsh` is unavailable or no repository CSS guard script was available.

Equivalent added-line checks were run:

- Markdown code fences: no matches
- CSS nesting selector syntax `&:...`: no matches
- JavaScript template expressions: no matches

## Smoke Test Notes

Unauthenticated render passed.

Authenticated NailItem/detail viewer smoke test is currently blocked by local Firebase Auth behavior:

- Browser console shows `FirebaseError: Firebase: Error (auth/invalid-api-key)` at `src/lib/firebase.ts:14`
- `.env.local` exists and is ignored by git
- all required env keys are present
- `VITE_FIREBASE_PROJECT_ID` is `nail-report-dev-ksc0000`
- `.env.local` values match Firebase CLI Web app config
- Vite-served module contains the same config
- API key REST sanity check suggests the key itself is valid
- blocker likely relates to local Firebase Auth authorized domain / API key restrictions / popup flow, not this PR’s source changes
- Codex In-app Browser single-tab mode cannot reliably complete `signInWithPopup`

Follow-up needed outside this PR:

- Check Firebase Auth authorized domains for `localhost` and possibly `127.0.0.1`
- Check Google Cloud API key restrictions for Firebase Auth / Identity Toolkit and local dev origins
- Complete authenticated smoke test in a normal browser after local auth config is confirmed

## Notes

- No Firebase deploy performed.
- No Firestore Rules changes.
- No dependency changes.
- No data model changes.
