### PR TITLE
feat(nail-view): add image comparison view

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -423,6 +423,10 @@
   box-shadow: 0 0 0 2px var(--accent-border);
 }
 
+#nail-list li.comparison-selected {
+  border-color: var(--accent);
+}
+
 .nail-card-thumb {
   position: relative;
   aspect-ratio: 4 / 3;
@@ -676,6 +680,10 @@
   border-color: var(--accent);
 }
 
+#nail-list li.comparison-selected:hover {
+  border-color: var(--accent);
+}
+
 .nail-thumb-img {
   transition: transform 0.3s ease;
 }
@@ -726,6 +734,140 @@
   display: flex;
   flex-direction: column;
   gap: 16px;
+}
+
+.comparison-panel {
+  background: var(--social-bg);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 16px;
+  margin-bottom: 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.comparison-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.comparison-prompt {
+  margin: 8px 0 0;
+  color: var(--text);
+  font-size: 0.84rem;
+  line-height: 1.6;
+}
+
+.comparison-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.comparison-card {
+  min-width: 0;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  overflow: hidden;
+  background: rgba(255, 255, 255, 0.03);
+}
+
+.comparison-side-label {
+  margin: 0;
+  padding: 10px 12px;
+  color: var(--accent);
+  font-size: 0.76rem;
+  font-weight: 700;
+  border-bottom: 1px solid var(--border);
+}
+
+.comparison-image-frame {
+  min-height: 180px;
+  aspect-ratio: 4 / 3;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--border);
+}
+
+.comparison-image {
+  display: block;
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+}
+
+.comparison-no-image {
+  color: #888;
+  font-size: 0.88rem;
+}
+
+.comparison-card-body {
+  padding: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.comparison-title {
+  margin: 0;
+  color: var(--text-h);
+  font-size: 1rem;
+  line-height: 1.35;
+  overflow-wrap: anywhere;
+}
+
+.comparison-section {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.comparison-label {
+  color: var(--text-h);
+  font-size: 0.78rem;
+  font-weight: 700;
+}
+
+.comparison-memo,
+.comparison-empty {
+  margin: 0;
+  color: var(--text);
+  font-size: 0.84rem;
+  line-height: 1.65;
+  overflow-wrap: anywhere;
+}
+
+.comparison-empty {
+  color: #888;
+}
+
+.comparison-meta {
+  margin: 0;
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 8px;
+}
+
+.comparison-meta div {
+  padding: 9px 10px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+}
+
+.comparison-meta dt {
+  margin: 0 0 4px;
+  color: #888;
+  font-size: 0.72rem;
+}
+
+.comparison-meta dd {
+  margin: 0;
+  color: var(--text-h);
+  font-size: 0.82rem;
 }
 
 .summary-heading {
@@ -1171,6 +1313,15 @@
 }
 
 @media (max-width: 480px) {
+  .comparison-header {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .comparison-grid {
+    grid-template-columns: 1fr;
+  }
+
   .share-actions .btn-export {
     width: 100%;
   }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -174,6 +174,7 @@ function App() {
   const [nailImagePreview, setNailImagePreview] = useState<string | null>(null)
   const [editingId, setEditingId] = useState<string | null>(null)
   const [detailItemId, setDetailItemId] = useState<string | null>(null)
+  const [comparisonItemIds, setComparisonItemIds] = useState<string[]>([])
   const [nailLoading, setNailLoading] = useState(false)
   const [nailError, setNailError] = useState('')
   const [nailItemsUserId, setNailItemsUserId] = useState<string | null>(null)
@@ -269,6 +270,7 @@ function App() {
       setPublicShares([])
       setPublicSharesUserId(null)
       setDetailItemId(null)
+      setComparisonItemIds([])
     }
   }), [isPublicSharePage])
 
@@ -432,6 +434,7 @@ function App() {
     if (!window.confirm(`「${item?.title ?? 'このアイテム'}」を削除しますか？\nこの操作は取り消せません。`)) return
     const uid = user.uid
     if (editingId === itemId) resetForm()
+    setComparisonItemIds(prev => prev.filter(id => id !== itemId))
     setNailLoading(true)
     setNailError('')
     try {
@@ -450,6 +453,9 @@ function App() {
 
   const editingItem = editingId ? nailItems.find(i => i.id === editingId) : null
   const detailItem = detailItemId ? nailItems.find(i => i.id === detailItemId) : null
+  const comparisonItems = comparisonItemIds
+    .map(id => nailItems.find(item => item.id === id))
+    .filter((item): item is NailItemDoc => Boolean(item))
   const isFetching = Boolean(user && nailItemsUserId !== user.uid)
   const summary = useMemo(() => getNailSummary(nailItems), [nailItems])
 
@@ -462,6 +468,70 @@ function App() {
     if (activeMonthFilter !== null && getItemMonth(item) !== activeMonthFilter) return false
     return true
   })
+
+  const handleToggleComparisonItem = (itemId: string) => {
+    setComparisonItemIds(prev => {
+      if (prev.includes(itemId)) return prev.filter(id => id !== itemId)
+      if (prev.length < 2) return [...prev, itemId]
+      return [prev[1], itemId]
+    })
+  }
+
+  const renderComparisonItem = (item: NailItemDoc, label: string) => {
+    const createdDate = formatDate(item.createdAt)
+    const updatedDate = formatDate(item.updatedAt)
+    return (
+      <article className="comparison-card">
+        <p className="comparison-side-label">{label}</p>
+        <div className="comparison-image-frame">
+          {item.imageUrl ? (
+            <img
+              className="comparison-image"
+              src={item.imageUrl}
+              alt={item.title + ' の比較用ネイル画像'}
+            />
+          ) : (
+            <div className="comparison-no-image">画像なし</div>
+          )}
+        </div>
+        <div className="comparison-card-body">
+          <h4 className="comparison-title">{item.title}</h4>
+          <div className="comparison-section">
+            <span className="comparison-label">タグ</span>
+            {item.tags.length > 0 ? (
+              <div className="nail-item-tags">
+                {item.tags.map(t => (
+                  <span key={t} className="nail-tag">#{t}</span>
+                ))}
+              </div>
+            ) : (
+              <p className="comparison-empty">タグなし</p>
+            )}
+          </div>
+          {item.memo && (
+            <div className="comparison-section">
+              <span className="comparison-label">メモ</span>
+              <p className="comparison-memo">{item.memo}</p>
+            </div>
+          )}
+          <dl className="comparison-meta">
+            {createdDate && (
+              <div>
+                <dt>作成日</dt>
+                <dd>{createdDate}</dd>
+              </div>
+            )}
+            {updatedDate && (
+              <div>
+                <dt>更新日</dt>
+                <dd>{updatedDate}</dd>
+              </div>
+            )}
+          </dl>
+        </div>
+      </article>
+    )
+  }
 
   const getShareUrl = (id: string): string =>
     typeof window === 'undefined' ? `/share/${id}` : `${window.location.origin}/share/${id}`
@@ -1044,6 +1114,31 @@ function App() {
               </div>
             </div>
           )}
+          {!isFetching && comparisonItems.length > 0 && (
+            <section className="comparison-panel" aria-labelledby="comparison-heading">
+              <div className="comparison-header">
+                <div>
+                  <h3 id="comparison-heading" className="summary-heading">ネイル比較</h3>
+                  {comparisonItems.length === 1 && (
+                    <p className="comparison-prompt">比較するネイルをもう1つ選択してください</p>
+                  )}
+                </div>
+                <button
+                  type="button"
+                  className="btn-export"
+                  onClick={() => setComparisonItemIds([])}
+                >
+                  比較をクリア
+                </button>
+              </div>
+              {comparisonItems.length === 2 && (
+                <div className="comparison-grid">
+                  {renderComparisonItem(comparisonItems[0], '左')}
+                  {renderComparisonItem(comparisonItems[1], '右')}
+                </div>
+              )}
+            </section>
+          )}
           {!isFetching && nailItems.length > 0 && (activeTagFilter !== null || activeMonthFilter !== null) && (
             <div className="filter-bar">
               {activeTagFilter !== null && (
@@ -1097,8 +1192,15 @@ function App() {
                   item.updatedAt.seconds !== item.createdAt.seconds)
                   ? formatDate(item.updatedAt)
                   : null
+                const isCompareSelected = comparisonItemIds.includes(item.id)
                 return (
-                  <li key={item.id} className={editingId === item.id ? 'editing' : ''}>
+                  <li
+                    key={item.id}
+                    className={[
+                      editingId === item.id ? 'editing' : '',
+                      isCompareSelected ? 'comparison-selected' : '',
+                    ].filter(Boolean).join(' ')}
+                  >
                     <div className="nail-card-thumb">
                       <div className="nail-thumb-placeholder">No image</div>
                       {item.imageUrl && (
@@ -1133,6 +1235,10 @@ function App() {
                         type="button"
                         onClick={() => setDetailItemId(item.id)}
                       >詳しく見る</button>
+                      <button
+                        type="button"
+                        onClick={() => handleToggleComparisonItem(item.id)}
+                      >{isCompareSelected ? '比較から外す' : '比較に追加'}</button>
                       <button
                         type="button"
                         onClick={() => handleStartEdit(item)}


### PR DESCRIPTION
## Summary

Closes #88.

Added an MVP Nail image comparison view.

- Add 「比較に追加 / 比較から外す」 to NailItem cards
- Show a prompt when one item is selected
- Show a `ネイル比較` panel when two items are selected
- Compare two NailItems side by side on desktop
- Stack comparison cards vertically on mobile
- Show image or 「画像なし」
- Show title, tags, memo, createdAt, and updatedAt
- Add 「比較をクリア」 to reset comparison
- Preserve existing detail viewer, edit/delete/share, auth, Firestore Rules, and data model behavior

## Selected Item Behavior

- Clicking the same item again removes it from comparison
- At most two items are selected
- Selecting a third item removes the oldest selected item and adds the new item

## Accessibility / Responsive

- Comparison panel has a heading and `aria-labelledby`
- Buttons use clear Japanese text
- Selected cards are visually distinguished
- Desktop uses two columns
- Mobile stacks comparison cards vertically
- Images use `object-fit: contain` and stay within containers

## Validation

- [x] `npm run build`
- [x] `npm run lint`
- [x] `git diff --check`
- [ ] Authenticated browser smoke test blocked by local Firebase Auth config / popup flow

## CSS Guard Note

Formal CSS guard was not run because `pwsh` is unavailable / no package script exists.

Equivalent added-line checks were run:

- Markdown code fences: no matches
- CSS nesting selector syntax `&:...`: no matches
- JavaScript template expressions: no matches

## Smoke Test Notes

Unauthenticated render passed.

Authenticated comparison behavior is currently blocked by the known local Firebase Auth issue:

- Codex browser console still shows Firebase `auth/invalid-api-key`
- This appears consistent with the known local Firebase Auth / popup-flow blocker, not this PR’s source changes
- No test data was created

Follow-up needed outside this PR:

- Complete authenticated normal-browser smoke test once local Firebase Auth config / popup flow is confirmed

## Notes

- No Firebase deploy performed
- No Firestore Rules changes
- No dependency changes
- No data model changes
