### PR TITLE
feat(camera): add browser capture option

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -268,7 +268,31 @@
 .nail-file-area {
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: 8px;
+}
+
+.nail-file-options {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.nail-file-option {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  flex: 1 1 180px;
+  padding: 10px 12px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  color: var(--text-h);
+  font-size: 0.84rem;
+  font-weight: 600;
+}
+
+.nail-file-option:focus-within {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
 }
 
 .nail-file-input {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -193,7 +193,8 @@ function App() {
   const [publicShareState, setPublicShareState] = useState<PublicShareViewState>(
     isPublicSharePage ? 'loading' : 'idle'
   )
-  const fileInputRef = useRef<HTMLInputElement>(null)
+  const uploadInputRef = useRef<HTMLInputElement>(null)
+  const cameraInputRef = useRef<HTMLInputElement>(null)
   const detailCloseButtonRef = useRef<HTMLButtonElement>(null)
   const previewUrlRef = useRef<string | null>(null)
 
@@ -339,6 +340,11 @@ function App() {
     setNailImagePreview(null)
   }
 
+  const clearImageInputs = () => {
+    if (uploadInputRef.current) uploadInputRef.current.value = ''
+    if (cameraInputRef.current) cameraInputRef.current.value = ''
+  }
+
   const handleNailFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0] ?? null
     if (!file) { setNailImageFile(null); clearPreview(); setNailError(''); return }
@@ -347,7 +353,7 @@ function App() {
       setNailError(err)
       setNailImageFile(null)
       clearPreview()
-      if (fileInputRef.current) fileInputRef.current.value = ''
+      clearImageInputs()
       return
     }
     setNailError('')
@@ -362,7 +368,7 @@ function App() {
     setNailImageFile(null)
     clearPreview()
     setNailError('')
-    if (fileInputRef.current) fileInputRef.current.value = ''
+    clearImageInputs()
   }
 
   const parseTags = (s: string): string[] =>
@@ -374,7 +380,7 @@ function App() {
     setNailMemo('')
     setNailImageFile(null)
     clearPreview()
-    if (fileInputRef.current) fileInputRef.current.value = ''
+    clearImageInputs()
     setEditingId(null)
     setNailError('')
   }
@@ -424,7 +430,7 @@ function App() {
     setNailMemo(item.memo ?? '')
     setNailImageFile(null)
     clearPreview()
-    if (fileInputRef.current) fileInputRef.current.value = ''
+    clearImageInputs()
     setNailError('')
   }
 
@@ -865,13 +871,30 @@ function App() {
               maxLength={500}
             />
             <div className="nail-file-area">
-              <input
-                ref={fileInputRef}
-                type="file"
-                accept="image/jpeg,image/png,image/webp"
-                onChange={handleNailFileChange}
-                className="nail-file-input"
-              />
+              <div className="nail-file-options">
+                <label className="nail-file-option">
+                  <span>画像を選択</span>
+                  <input
+                    ref={uploadInputRef}
+                    type="file"
+                    accept="image/jpeg,image/png,image/webp"
+                    onChange={handleNailFileChange}
+                    className="nail-file-input"
+                  />
+                </label>
+                <label className="nail-file-option">
+                  <span>写真を撮る</span>
+                  <input
+                    ref={cameraInputRef}
+                    type="file"
+                    accept="image/*"
+                    capture="environment"
+                    onChange={handleNailFileChange}
+                    className="nail-file-input"
+                  />
+                </label>
+              </div>
+              <p className="nail-file-note">カメラが使えない場合は画像を選択してください。</p>
               {nailImageFile && nailImagePreview && (
                 <div className="nail-file-preview-area">
                   <img


### PR DESCRIPTION
## Summary

Closes #92.

Added a browser/PWA-friendly camera capture option to the existing NailItem image input flow.

- Preserve existing image upload behavior
- Label existing upload option as 「画像を選択」
- Add separate camera-oriented input labeled 「写真を撮る」
- Add `accept="image/*"` and `capture="environment"` to the camera input
- Reuse the existing validate/preview/upload/storage flow
- Add fallback note: 「カメラが使えない場合は画像を選択してください。」

## Preserved Behavior

- Existing upload flow remains unchanged
- Existing validation/preview/upload/storage flow is reused
- No data model changes
- No Firestore Rules changes
- No Storage Rules changes
- No dependency changes

## Validation

- [x] `npm run build`
- [x] `npm run lint`
- [x] `git diff --check`
- [ ] Authenticated form/capture smoke blocked by local Firebase Auth config / popup flow
- [ ] Real mobile/iOS camera picker smoke not yet completed

## CSS Guard Note

Formal CSS guard was not run because `pwsh` is unavailable / no package script exists.

Equivalent added-line checks were run:

- Markdown code fences: no matches
- CSS nesting selector syntax `&:...`: no matches
- JavaScript template expressions: no matches

## Smoke Test Notes

Unauthenticated render passed.

Authenticated form/capture smoke is currently blocked by the known local Firebase Auth issue:

- Browser console still shows Firebase `auth/invalid-api-key`
- This appears consistent with the known local Firebase Auth / popup-flow blocker, not this PR’s source changes

Static implementation check confirmed:

- Upload input uses `accept="image/jpeg,image/png,image/webp"`
- Camera input uses `accept="image/*"` and `capture="environment"`

Follow-up needed outside this PR:

- Complete authenticated normal-browser smoke test once local Firebase Auth config / popup flow is confirmed
- Complete real mobile/iOS smoke test to confirm camera picker behavior

## Notes

- No Firebase deploy performed
- No Firestore Rules changes
- No Storage Rules changes
- No dependency changes
- No data model changes
