### PR TITLE
chore(ci): pause AI Loop Controller schedule — cost control

### DIFF
--- a/.github/workflows/ai-loop-controller.yml
+++ b/.github/workflows/ai-loop-controller.yml
@@ -19,9 +19,9 @@ on:
         description: "Roadmap or issue reference"
         required: true
         default: "docs"
-  schedule:
-    - cron: "0 */2 * * *"
-    - cron: "0 1,11 * * *"
+  # schedule: # PAUSED — Claude API cost control. Re-enable when ready.
+  #   - cron: "0 */2 * * *"
+  #   - cron: "0 1,11 * * *"
 
 jobs:
   controller:


### PR DESCRIPTION
## Summary

AI Loop Controller の自動スケジュール実行を一時停止する。

- `0 */2 * * *`（2時間ごと）と `0 1,11 * * *`（1:00/11:00 UTC）のcronをコメントアウト
- `workflow_dispatch` は残してあるので手動実行は引き続き可能

## 背景

複数リポジトリでAI Loopが走っており、Claude APIの従量課金が予想以上に発生しているため一時停止。

## 再開方法

scheduleブロックのコメントアウトを外してマージするだけ。

🤖 Generated with [Claude Code](https://claude.com/claude-code)