### PR TITLE
fix: update Gemini model to gemini-2.5-flash (2.0-flash deprecated)

### DIFF
--- a/scripts/ai-loop/generate-next-task.sh
+++ b/scripts/ai-loop/generate-next-task.sh
@@ -48,11 +48,11 @@ PAYLOAD=$(jq -n \
     }
   }')
 
-echo "Calling Gemini API (gemini-2.0-flash)..."
+echo "Calling Gemini API (gemini-2.5-flash)..."
 
 RESPONSE_FILE=$(mktemp)
 HTTP_RESPONSE=$(curl -s -w "%{http_code}" -o "$RESPONSE_FILE" \
-  "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent?key=$GOOGLE_API_KEY" \
+  "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent?key=$GOOGLE_API_KEY" \
   -H "content-type: application/json" \
   -d "$PAYLOAD")
 


### PR DESCRIPTION
gemini-2.0-flash が廃止されて404エラーになっていたため gemini-2.5-flash に更新。🤖 Generated with [Claude Code](https://claude.com/claude-code)