### PR TITLE
Implement loading skeleton for nail item list

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1364,3 +1364,83 @@
     grid-template-columns: 1fr;
   }
 }
+
+/* Loading Skeleton */
+.nail-skeleton-card {
+  display: flex;
+  flex-direction: column;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  overflow: hidden;
+  background: var(--social-bg);
+  min-height: 280px;
+}
+
+.nail-skeleton-thumb {
+  aspect-ratio: 4 / 3;
+  background: var(--border);
+}
+
+.nail-skeleton-body {
+  padding: 10px 12px;
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.nail-skeleton-title {
+  height: 1.2rem;
+  width: 70%;
+  background: var(--border);
+  border-radius: 4px;
+}
+
+.nail-skeleton-tags {
+  display: flex;
+  gap: 6px;
+}
+
+.nail-skeleton-tag {
+  height: 1rem;
+  width: 40px;
+  background: var(--accent-bg);
+  border-radius: 9999px;
+}
+
+.nail-skeleton-date {
+  height: 0.8rem;
+  width: 50%;
+  background: var(--border);
+  border-radius: 4px;
+  margin-top: auto;
+}
+
+.shimmer {
+  position: relative;
+  overflow: hidden;
+}
+
+.shimmer::after {
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  transform: translateX(-100%);
+  background-image: linear-gradient(
+    90deg,
+    rgba(255, 255, 255, 0) 0,
+    rgba(255, 255, 255, 0.2) 20%,
+    rgba(255, 255, 255, 0.5) 60%,
+    rgba(255, 255, 255, 0)
+  );
+  animation: shimmer 2s infinite;
+  content: '';
+}
+
+@keyframes shimmer {
+  100% {
+    transform: translateX(100%);
+  }
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1189,7 +1189,21 @@ function App() {
             </div>
           )}
           {isFetching ? (
-            <p className="nail-loading">Loading...</p>
+            <ul id="nail-list" className="nail-skeleton-list">
+              {[...Array(4)].map((_, i) => (
+                <li key={i} className="nail-skeleton-card">
+                  <div className="nail-skeleton-thumb shimmer" />
+                  <div className="nail-skeleton-body">
+                    <div className="nail-skeleton-title shimmer" />
+                    <div className="nail-skeleton-tags">
+                      <div className="nail-skeleton-tag shimmer" />
+                      <div className="nail-skeleton-tag shimmer" />
+                    </div>
+                    <div className="nail-skeleton-date shimmer" />
+                  </div>
+                </li>
+              ))}
+            </ul>
           ) : nailItems.length === 0 ? (
             <div className="nail-empty">
               <svg className="nail-empty-icon" aria-hidden="true" width="44" height="44" viewBox="0 0 44 44" fill="none">


### PR DESCRIPTION
Implemented a loading skeleton for the nail item list to improve the user experience during data fetching. This addresses Phase 2.3 of the roadmap.

Key changes:
- Modified `src/App.tsx` to render a list of 4 skeleton cards when `isFetching` is true.
- Appended skeleton and shimmer animation styles to `src/App.css`.
- Ensured the skeleton layout matches the actual item cards by utilizing the existing `#nail-list` container and similar internal structure.
- Verified that `npm run build` and `npm run lint` pass.
- Visually verified the skeleton appearance using a Playwright script with manual DOM injection (due to missing Firebase env vars in sandbox).

Fixes #131

---
*PR created automatically by Jules for task [7358560237648138908](https://jules.google.com/task/7358560237648138908) started by @ksc0000*