### PR TITLE
fix(ai-loop): prevent duplicate Issue creation

### DIFF
--- a/.github/workflows/ai-loop-controller.yml
+++ b/.github/workflows/ai-loop-controller.yml
@@ -44,6 +44,24 @@ jobs:
           echo "dry_run=${{ github.event.inputs.dry_run || 'false' }}"
           echo "task_source=${{ github.event.inputs.task_source || 'docs' }}"
 
+      - name: Fetch open jules-ready issues for context
+        id: open_issues
+        env:
+          GH_TOKEN: ${{ secrets.GH_AW_AGENT_TOKEN || github.token }}
+        run: |
+          OPEN_ISSUES=$(gh issue list \
+            --repo "${{ github.repository }}" \
+            --label "jules-ready" \
+            --state open \
+            --limit 20 \
+            --json number,title \
+            --jq '[.[] | "#\(.number) \(.title)"] | join("\n")' 2>/dev/null || echo "")
+          echo "open_issues<<EOF" >> $GITHUB_OUTPUT
+          echo "$OPEN_ISSUES" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+          echo "Open jules-ready issues:"
+          echo "$OPEN_ISSUES"
+
       - name: Generate next task
         env:
           CTRL_ITERATIONS: ${{ github.event.inputs.iterations || '1' }}
@@ -51,14 +69,17 @@ jobs:
           CTRL_DRY_RUN: ${{ github.event.inputs.dry_run || 'false' }}
           CTRL_TASK_SOURCE: ${{ github.event.inputs.task_source || 'docs' }}
           GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
+          OPEN_ISSUES_CONTEXT: ${{ steps.open_issues.outputs.open_issues }}
         run: |
           ./scripts/ai-loop/generate-next-task.sh \
             "$CTRL_ITERATIONS" \
             "$CTRL_MODE" \
             "$CTRL_DRY_RUN" \
-            "$CTRL_TASK_SOURCE"
+            "$CTRL_TASK_SOURCE" \
+            "$OPEN_ISSUES_CONTEXT"
 
       - name: Commit and push NEXT_TASK.md
+        id: commit_task
         if: github.event_name == 'schedule' || github.event.inputs.dry_run == 'false'
         run: |
           git config --local user.email "action@github.com"
@@ -67,12 +88,16 @@ jobs:
           if ! git diff --cached --quiet; then
             git commit -m "docs: update NEXT_TASK.md via AI Loop Controller"
             git push
+            echo "changed=true" >> $GITHUB_OUTPUT
           else
-            echo "No changes to commit"
+            echo "No changes to NEXT_TASK.md — skipping issue creation"
+            echo "changed=false" >> $GITHUB_OUTPUT
           fi
 
       - name: Create GitHub Issue for Jules
-        if: github.event_name == 'schedule' || github.event.inputs.dry_run == 'false'
+        if: |
+          (github.event_name == 'schedule' || github.event.inputs.dry_run == 'false') &&
+          steps.commit_task.outputs.changed == 'true'
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GH_AW_AGENT_TOKEN || github.token }}
@@ -84,6 +109,20 @@ jobs:
               ? headingLine.replace(/^#+\s*/, '').replace(/^NEXT TASK:\s*/i, '')
               : 'AI Loop auto-task';
             const title = `[AI Loop] ${rawTitle}`;
+
+            // Dedup: skip if an open issue with the same title already exists
+            const { data: existing } = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              labels: 'jules-ready',
+              per_page: 50,
+            });
+            const duplicate = existing.find(i => i.title === title);
+            if (duplicate) {
+              core.info(`Skipping: open issue already exists — #${duplicate.number} "${title}"`);
+              return;
+            }
 
             const { data: issue } = await github.rest.issues.create({
               owner: context.repo.owner,

--- a/docs/ai-loop/AI_STATE.json
+++ b/docs/ai-loop/AI_STATE.json
@@ -2,8 +2,14 @@
   "current_phase": "2.0",
   "max_iterations": 3,
   "human_review_every": 1,
-  "completed_tasks": [],
+  "completed_tasks": [
+    "AI-LOOP setup: gemini-2.0-flash → gemini-2.5-flash migration (PR #121)",
+    "AI-LOOP setup: branch protection bypass for push (PR #122)"
+  ],
   "failed_tasks": [],
+  "in_progress_tasks": [
+    "First substantive task pending (Issue #135)"
+  ],
   "constraints": [
     "no-new-npm-deps",
     "small-PRs",

--- a/scripts/ai-loop/generate-next-task.sh
+++ b/scripts/ai-loop/generate-next-task.sh
@@ -6,6 +6,7 @@ ITERATIONS="${1:-1}"
 MODE="${2:-code}"
 DRY_RUN="${3:-true}"
 TASK_SOURCE="${4:-docs}"
+OPEN_ISSUES="${5:-}"  # Newline-separated list of open jules-ready issue titles
 
 ROADMAP_PATH="docs/ai-loop/ROADMAP.md"
 STATE_PATH="docs/ai-loop/AI_STATE.json"
@@ -26,6 +27,11 @@ if [ ! -f "$TEMPLATE_PATH" ]; then echo "Error: Template not found at $TEMPLATE_
 
 SYSTEM_PROMPT="You are an AI Loop Controller for a React + TypeScript + Firebase web application (nail-report). Your goal is to read the product roadmap and current state, then generate exactly one bounded task for a worker agent (Jules). The task must be small enough for one PR (≤150 line diff), must not require macOS or PowerShell, and must not add npm dependencies. The output must be a Markdown document saved to docs/ai-loop/NEXT_TASK.md. Follow the structure of the provided template exactly."
 
+OPEN_ISSUES_SECTION=""
+if [ -n "$OPEN_ISSUES" ]; then
+  OPEN_ISSUES_SECTION="\n\n### Already Open Jules Tasks (DO NOT duplicate these)\nThe following tasks are already open and assigned to Jules. Do NOT generate a task that overlaps with any of these:\n${OPEN_ISSUES}"
+fi
+
 PAYLOAD=$(jq -n \
   --arg system "$SYSTEM_PROMPT" \
   --rawfile roadmap "$ROADMAP_PATH" \
@@ -33,6 +39,7 @@ PAYLOAD=$(jq -n \
   --rawfile template "$TEMPLATE_PATH" \
   --arg mode "$MODE" \
   --arg task_source "$TASK_SOURCE" \
+  --arg open_issues_section "$OPEN_ISSUES_SECTION" \
   '{
     system_instruction: {
       parts: [{text: $system}]
@@ -40,7 +47,7 @@ PAYLOAD=$(jq -n \
     contents: [{
       role: "user",
       parts: [{
-        text: ("Please generate the next task for the AI Loop.\n\n### Current Roadmap\n" + $roadmap + "\n\n### Current State\n" + $state + "\n\n### NEXT_TASK.md Template\n" + $template + "\n\n### Execution Context\n- Mode: " + $mode + "\n- Task Source: " + $task_source + "\n- Objective: Determine the single most appropriate next step based on the roadmap and current state.\n\n### Requirements for NEXT_TASK.md\n- Use Markdown format.\n- Objective must be clear and bounded (1 PR size, ≤150 lines diff).\n- List Allowed and Forbidden files explicitly.\n- Include Acceptance criteria and Required test commands (npm run build && npm run lint).\n- The \"Worker prompt\" section should contain the detailed instructions for the worker agent.")
+        text: ("Please generate the next task for the AI Loop.\n\n### Current Roadmap\n" + $roadmap + "\n\n### Current State\n" + $state + "\n\n### NEXT_TASK.md Template\n" + $template + "\n\n### Execution Context\n- Mode: " + $mode + "\n- Task Source: " + $task_source + "\n- Objective: Determine the single most appropriate next step based on the roadmap and current state." + $open_issues_section + "\n\n### Requirements for NEXT_TASK.md\n- Use Markdown format.\n- Objective must be clear and bounded (1 PR size, ≤150 lines diff).\n- List Allowed and Forbidden files explicitly.\n- Include Acceptance criteria and Required test commands (npm run build && npm run lint).\n- The \"Worker prompt\" section should contain the detailed instructions for the worker agent.\n- IMPORTANT: The generated task MUST be different from any already-open Jules tasks listed above.")
       }]
     }],
     generationConfig: {


### PR DESCRIPTION
## 問題
AI Loop が2時間ごとに同じタスクの Issue を作り続けていた（重複 Issue が大量発生）。

## 根本原因
1. NEXT_TASK.md が変わっていなくても Issue 作成ステップが毎回実行される
2. 同名の open Issue が既存でも重複チェックなし
3. Gemini への入力に「今オープン中のタスク」が渡されていないため同じタスクを繰り返し提案

## 修正（3層防御）
1. **NEXT_TASK.md 変化ゲート** — 内容が前回から変わっていない場合は Issue 作成をスキップ
2. **open Issue 重複チェック** — 同タイトルの open jules-ready Issue が存在したらスキップ
3. **Gemini コンテキスト注入** — open issues リストを第5引数で渡し「これらと被らないタスクを生成せよ」を追加

`AI_STATE.json` の `completed_tasks` も現状に更新。

🤖 Generated with [Claude Code](https://claude.com/claude-code)