### PR TITLE
[codex] Add dependency-free Firestore model tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
+    "test": "node --experimental-strip-types --test tests/firestoreModel.test.ts",
     "preview": "vite preview"
   },
   "dependencies": {

--- a/src/lib/firestore.ts
+++ b/src/lib/firestore.ts
@@ -3,50 +3,26 @@ import {
   doc, updateDoc, deleteDoc,
   serverTimestamp,
 } from 'firebase/firestore'
-import type { Timestamp } from 'firebase/firestore'
 import { db } from './firebase'
+import {
+  buildCreateNailItemData,
+  buildUpdateNailItemData,
+  toNailItemDoc,
+} from './firestoreModel'
+import type { NailItem, NailItemDoc, NailItemInput } from './firestoreModel'
 
-export interface NailItem {
-  title: string
-  imageUrl: string
-  thumbnailUrl: string
-  tags: string[]
-  memo: string
-  createdAt: Timestamp | null
-  updatedAt: Timestamp | null
-}
-
-export interface NailItemDoc extends NailItem {
-  id: string
-}
-
-export interface NailItemInput {
-  title: string
-  imageUrl: string
-  tags: string[]
-  memo: string
-}
+export type { NailItem, NailItemDoc, NailItemInput } from './firestoreModel'
 
 export const fetchNailItems = async (userId: string): Promise<NailItemDoc[]> => {
   const ref = collection(db, 'users', userId, 'nailItems')
   const snapshot = await getDocs(ref)
-  return snapshot.docs.map(snap => ({
-    id: snap.id,
-    ...(snap.data() as NailItem),
-  }))
+  return snapshot.docs.map(snap => toNailItemDoc(snap.id, snap.data() as NailItem))
 }
 
 export const addNailItem = async (userId: string, input: NailItemInput): Promise<string> => {
   const ref = collection(db, 'users', userId, 'nailItems')
-  const snap = await addDoc(ref, {
-    title: input.title,
-    imageUrl: input.imageUrl,
-    thumbnailUrl: input.imageUrl,
-    tags: input.tags,
-    memo: input.memo,
-    createdAt: serverTimestamp(),
-    updatedAt: serverTimestamp(),
-  })
+  const timestamp = serverTimestamp()
+  const snap = await addDoc(ref, buildCreateNailItemData(input, timestamp))
   return snap.id
 }
 
@@ -56,14 +32,7 @@ export const updateNailItem = async (
   input: NailItemInput,
 ): Promise<void> => {
   const ref = doc(db, 'users', userId, 'nailItems', itemId)
-  await updateDoc(ref, {
-    title: input.title,
-    imageUrl: input.imageUrl,
-    thumbnailUrl: input.imageUrl,
-    tags: input.tags,
-    memo: input.memo,
-    updatedAt: serverTimestamp(),
-  })
+  await updateDoc(ref, buildUpdateNailItemData(input, serverTimestamp()))
 }
 
 export const deleteNailItem = async (userId: string, itemId: string): Promise<void> => {

--- a/src/lib/firestoreModel.ts
+++ b/src/lib/firestoreModel.ts
@@ -1,0 +1,46 @@
+import type { Timestamp } from 'firebase/firestore'
+
+export interface NailItem {
+  title: string
+  imageUrl: string
+  thumbnailUrl: string
+  tags: string[]
+  memo: string
+  createdAt: Timestamp | null
+  updatedAt: Timestamp | null
+}
+
+export interface NailItemDoc extends NailItem {
+  id: string
+}
+
+export interface NailItemInput {
+  title: string
+  imageUrl: string
+  tags: string[]
+  memo: string
+}
+
+export const toNailItemDoc = (id: string, data: NailItem): NailItemDoc => ({
+  id,
+  ...data,
+})
+
+export const buildCreateNailItemData = (input: NailItemInput, timestamp: unknown) => ({
+  title: input.title,
+  imageUrl: input.imageUrl,
+  thumbnailUrl: input.imageUrl,
+  tags: input.tags,
+  memo: input.memo,
+  createdAt: timestamp,
+  updatedAt: timestamp,
+})
+
+export const buildUpdateNailItemData = (input: NailItemInput, timestamp: unknown) => ({
+  title: input.title,
+  imageUrl: input.imageUrl,
+  thumbnailUrl: input.imageUrl,
+  tags: input.tags,
+  memo: input.memo,
+  updatedAt: timestamp,
+})

--- a/tests/firestoreModel.test.ts
+++ b/tests/firestoreModel.test.ts
@@ -1,0 +1,49 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import {
+  buildCreateNailItemData,
+  buildUpdateNailItemData,
+  toNailItemDoc,
+} from '../src/lib/firestoreModel.ts'
+import type { NailItem, NailItemInput } from '../src/lib/firestoreModel.ts'
+const input: NailItemInput = {
+  title: 'Spring rose',
+  imageUrl: 'https://example.com/nail.jpg',
+  tags: ['pink', 'gel'],
+  memo: 'soft gradient',
+}
+test('buildCreateNailItemData creates the Firestore write payload', () => {
+  const timestamp = Symbol('serverTimestamp')
+  assert.deepEqual(buildCreateNailItemData(input, timestamp), {
+    title: input.title,
+    imageUrl: input.imageUrl,
+    thumbnailUrl: input.imageUrl,
+    tags: input.tags,
+    memo: input.memo,
+    createdAt: timestamp,
+    updatedAt: timestamp,
+  })
+})
+test('buildUpdateNailItemData omits createdAt and refreshes updatedAt', () => {
+  const timestamp = Symbol('serverTimestamp')
+  assert.deepEqual(buildUpdateNailItemData(input, timestamp), {
+    title: input.title,
+    imageUrl: input.imageUrl,
+    thumbnailUrl: input.imageUrl,
+    tags: input.tags,
+    memo: input.memo,
+    updatedAt: timestamp,
+  })
+})
+test('toNailItemDoc keeps Firestore document fields and attaches id', () => {
+  const data: NailItem = {
+    ...input,
+    thumbnailUrl: input.imageUrl,
+    createdAt: null,
+    updatedAt: null,
+  }
+  assert.deepEqual(toNailItemDoc('nail-1', data), {
+    id: 'nail-1',
+    ...data,
+  })
+})


### PR DESCRIPTION
## Summary
- Extract Firestore item mapping and write payload creation into testable pure helpers.
- Add dependency-free Node test coverage for create/update payloads and document mapping.
- Add an npm test script using Node's built-in test runner and TypeScript strip support.

Fixes #135

## Validation
- npm test
- npm run build
- npm run lint

## Notes
- No npm dependencies were added.
- Replaces the closed duplicate Vitest-based Draft PRs with a smaller implementation under the 150-line diff limit.