### PR TITLE
[codex] Add production release runbook

### DIFF
--- a/docs/operations/PRODUCTION_RELEASE_RUNBOOK.md
+++ b/docs/operations/PRODUCTION_RELEASE_RUNBOOK.md
@@ -1,0 +1,82 @@
+# Production Release Runbook
+
+This runbook is for the commercial MVP release of Nailous on Firebase Hosting.
+Do not run production deploy commands without explicit human approval.
+
+## Approved Release Direction
+
+- Hosting: Firebase Hosting
+- Firebase projects: separate development and production projects
+- Deploy owner: human operator
+- CI deploy automation: deferred for MVP
+- MVP scope: personal nail archive with Auth, CRUD, image upload, export, public sharing, and policy links
+- Post-launch: AI, OCR, 3D, AR, PWA install support, automated account deletion UI, and full analytics
+
+## Pre-Release Checks
+
+1. Confirm the target Firebase project is the production project.
+2. Confirm local `.env` or hosting environment values point to production Firebase config.
+3. Confirm no secrets, service account JSON, or `.env` files are staged.
+4. Run:
+
+```bash
+npm run build
+npm run lint
+```
+
+5. Confirm GitHub CI is passing on the release commit.
+6. Review open blocking issues for security, legal, privacy, and QA.
+7. Confirm the production smoke checklist is ready:
+   [PRODUCTION_SMOKE_TEST_CHECKLIST.md](./PRODUCTION_SMOKE_TEST_CHECKLIST.md)
+
+## Deploy Procedure
+
+Production deploy is a human-gated operation.
+
+```bash
+firebase use <production-project-alias>
+firebase projects:list
+firebase deploy --only hosting
+```
+
+Before running `firebase deploy`, the operator must verbally or in writing confirm:
+
+- the production Firebase project id
+- the release commit SHA
+- the production URL
+- rollback owner and communication channel
+
+## Post-Deploy Smoke Test
+
+Run the production smoke checklist immediately after deploy:
+
+- Auth
+- Nail CRUD
+- Image upload
+- CSV/JSON export
+- Public share create/view/revoke
+- Mobile Safari
+- Privacy/Terms links
+- Error fallback where practical
+
+Record go/no-go in the release notes or tracking issue.
+
+## Rollback
+
+If a blocking production issue is found:
+
+1. Stop further deploys.
+2. Identify the last known good Hosting version in Firebase Console.
+3. Roll back Hosting to the last known good version from Firebase Console, or redeploy the previous known-good commit.
+4. Re-run the smoke checklist.
+5. Open a blocking bug with impact, reproduction steps, and rollback status.
+
+## Emergency Stop
+
+If public sharing or data exposure is suspected:
+
+1. Disable or roll back the affected Hosting version.
+2. Revoke affected public shares if possible.
+3. Preserve logs and issue context.
+4. Do not change Firestore or Storage rules without a separate human approval.
+5. Record user-facing communication needs for human/legal review.

--- a/docs/operations/PRODUCTION_SMOKE_TEST_CHECKLIST.md
+++ b/docs/operations/PRODUCTION_SMOKE_TEST_CHECKLIST.md
@@ -1,0 +1,33 @@
+# Production Smoke Test Checklist
+
+Use this checklist before and after a production Firebase Hosting release.
+Record the tested URL, Firebase project, tester, date, and result in the PR or release notes.
+
+## Release Context
+
+- Production host: Firebase Hosting
+- Production Firebase project: separate from development
+- Deploy owner: human operator
+- Deploy approval: explicit human approval required
+
+## Checklist
+
+| Area | Steps | Expected result |
+|---|---|---|
+| App load | Open the production URL on desktop Chrome or Safari. | The app loads without a blank screen or console-blocking error. |
+| Google Auth | Sign in with Google, then sign out. | Sign-in and sign-out complete, and the signed-out screen returns. |
+| Nail CRUD | Create, edit, and delete one test nail item. | The item persists after refresh, updates correctly, and deletes after confirmation. |
+| Image upload | Add a jpeg, png, or webp image under 5 MB. | The image uploads, previews, displays in the card, and is removed when the item is deleted. |
+| Search/filter | Search by title and filter by tag/month if test data exists. | Matching items remain visible and clearing filters restores the list. |
+| Export | Download CSV and JSON from the collection. | Files download and contain expected item fields without private app metadata. |
+| Public share create | Create a public share for selected items. | A share URL is generated and can be copied. |
+| Public share view | Open the share URL in an incognito/private window. | The public read-only page loads without requiring sign-in. |
+| Public share revoke | Disable the share and reload the public URL. | The public page no longer exposes the shared collection. |
+| Mobile Safari | Repeat app load, auth, list view, and public share view on Mobile Safari. | Layout remains usable and no content overlaps. |
+| Privacy/Terms | Open Privacy Policy and Terms links once implemented. | Links are visible, routes load, and text matches the approved policy draft. |
+| Error fallback | Temporarily test with a failed network or invalid share URL if practical. | User-facing error states are understandable and do not expose sensitive details. |
+
+## Go / No-Go
+
+- Go: all critical flows pass, or only documented non-blocking issues remain.
+- No-go: auth, CRUD, upload, public share, or rollback readiness fails.


### PR DESCRIPTION
## Summary
- Add a Firebase Hosting production release runbook for the commercial MVP.
- Add a production smoke test checklist covering Auth, CRUD, upload, export, public share, Mobile Safari, and policy links.
- Document human-gated deploy, rollback, and emergency stop procedures.

Fixes #103
Fixes #110
Fixes #111

## Validation
- npm run build
- npm run lint

## Notes
- No deploy command was run.
- No Firebase rules, secrets, or CI deploy automation were changed.