### PR TITLE
Improve accessibility for icon-only buttons

### DIFF
--- a/src/components/ErrorBanner.tsx
+++ b/src/components/ErrorBanner.tsx
@@ -17,7 +17,7 @@ const ErrorBanner: React.FC<ErrorBannerProps> = ({ message, onClose }) => {
         onClick={onClose}
         aria-label="エラーメッセージを閉じる"
       >
-        &times;
+        <span aria-hidden="true">&times;</span>
       </button>
     </div>
   );


### PR DESCRIPTION
Identified and audited all buttons in the application for accessibility compliance. The analysis revealed that most buttons use descriptive text labels. The single icon-only button found (the close button in `ErrorBanner.tsx`) already possessed a descriptive Japanese `aria-label`. I refined this implementation by wrapping the symbol in `aria-hidden="true"` to optimize the screen reader experience. Verified the changes with build and lint checks.

Fixes #149

---
*PR created automatically by Jules for task [8512935573441097257](https://jules.google.com/task/8512935573441097257) started by @ksc0000*