### PR TITLE
Add User Data Management and Deletion Guide UI

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -99,6 +99,11 @@
   text-decoration: underline;
 }
 
+.auth-data-mgmt {
+  color: var(--accent) !important;
+  font-weight: 600;
+}
+
 #nail-section {
   width: 100%;
   max-width: 600px;
@@ -1560,6 +1565,17 @@
   font-size: 0.82rem;
   line-height: 1.6;
   color: var(--text);
+}
+
+.help-mailto {
+  color: var(--accent);
+  text-decoration: none;
+  font-size: 0.88rem;
+  font-weight: 600;
+}
+
+.help-mailto:hover {
+  text-decoration: underline;
 }
 
 /* Legal Pages */

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -186,6 +186,7 @@ function App() {
   const [nailImagePreview, setNailImagePreview] = useState<string | null>(null)
   const [editingId, setEditingId] = useState<string | null>(null)
   const [detailItemId, setDetailItemId] = useState<string | null>(null)
+  const [isDataModalOpen, setIsDataModalOpen] = useState(false)
   const [comparisonItemIds, setComparisonItemIds] = useState<string[]>([])
   const [nailLoading, setNailLoading] = useState(false)
   const [nailError, setNailError] = useState('')
@@ -209,6 +210,7 @@ function App() {
   const uploadInputRef = useRef<HTMLInputElement>(null)
   const cameraInputRef = useRef<HTMLInputElement>(null)
   const detailCloseButtonRef = useRef<HTMLButtonElement>(null)
+  const dataModalCloseButtonRef = useRef<HTMLButtonElement>(null)
   const previewUrlRef = useRef<string | null>(null)
 
   useEffect(() => () => {
@@ -305,6 +307,16 @@ function App() {
     detailCloseButtonRef.current?.focus()
     return () => document.removeEventListener('keydown', handleKeyDown)
   }, [detailItemId])
+
+  useEffect(() => {
+    if (!isDataModalOpen) return
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setIsDataModalOpen(false)
+    }
+    document.addEventListener('keydown', handleKeyDown)
+    dataModalCloseButtonRef.current?.focus()
+    return () => document.removeEventListener('keydown', handleKeyDown)
+  }, [isDataModalOpen])
 
   useEffect(() => {
     if (isPublicSharePage) return
@@ -898,10 +910,68 @@ function App() {
           </div>
         )
       })()}
+      {isDataModalOpen && (
+        <div
+          className="nail-detail-backdrop"
+          role="presentation"
+          onClick={() => setIsDataModalOpen(false)}
+        >
+          <div
+            className="nail-detail-dialog"
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="data-mgmt-title"
+            onClick={e => e.stopPropagation()}
+          >
+            <div className="nail-detail-header">
+              <p className="nail-detail-kicker">データ管理</p>
+              <button
+                ref={dataModalCloseButtonRef}
+                type="button"
+                className="nail-detail-close"
+                onClick={() => setIsDataModalOpen(false)}
+                aria-label="データ管理を閉じる"
+              >
+                閉じる
+              </button>
+            </div>
+            <div className="nail-detail-body">
+              <h2 id="data-mgmt-title" className="nail-detail-title">ヘルプとデータ管理</h2>
+              <div className="nail-detail-section">
+                <h3 className="nail-detail-label">データのエクスポート</h3>
+                <p className="help-text">
+                  「コレクション概要」セクションにある CSV または JSON ボタンから、登録済みのネイル情報をいつでもダウンロードできます。
+                </p>
+              </div>
+              <div className="nail-detail-section">
+                <h3 className="nail-detail-label">データの削除</h3>
+                <p className="help-text">
+                  各ネイルアイテムの「Delete」ボタンから個別にデータを削除できます。
+                </p>
+                <p className="help-text">
+                  アカウントの退会および全データの完全消去をご希望の場合は、プライバシーポリシーに基づき、ご本人確認のため登録メールアドレスより下記サポート窓口までご連絡ください。
+                </p>
+                <div style={{ marginTop: '8px' }}>
+                  <a href="mailto:kikushun0529@gmail.com" className="help-mailto">
+                    kikushun0529@gmail.com
+                  </a>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
       <div id="auth-bar">
         {user === undefined ? null : user ? (
           <div className="auth-user">
             <span>{user.displayName ?? user.email}</span>
+            <button
+              type="button"
+              className="auth-data-mgmt"
+              onClick={() => setIsDataModalOpen(true)}
+            >
+              データ管理
+            </button>
             <button type="button" onClick={() => {
               signOutUser().catch((e: unknown) => console.error('sign-out failed', e))
             }}>Sign out</button>
@@ -1372,23 +1442,6 @@ function App() {
               })}
             </ul>
           )}
-          <div id="help-section" className="help-section">
-            <h3 className="summary-heading">ヘルプとデータ管理</h3>
-            <div className="help-content">
-              <div className="help-item">
-                <h4 className="help-title">データのエクスポート</h4>
-                <p className="help-text">
-                  「コレクション概要」セクションのボタンから、登録済みのネイル情報をCSVまたはJSON形式でダウンロードできます。
-                </p>
-              </div>
-              <div className="help-item">
-                <h4 className="help-title">データの削除</h4>
-                <p className="help-text">
-                  各アイテムの「Delete」ボタンから個別にデータを削除できます。アカウントの退会や、すべてのデータの完全消去をご希望の場合は、お手数ですが kikushun0529@gmail.com までお問い合わせください。
-                </p>
-              </div>
-            </div>
-          </div>
         </div>
       )}
       {renderFooter()}


### PR DESCRIPTION
Added a dedicated 'データ管理' (Data Management) button and modal for authenticated users. This UI provides clear instructions on how to export data using existing CSV/JSON buttons and how to request full account deletion via email (kikushun0529@gmail.com), as outlined in the Privacy Policy. Reused existing modal components for a consistent design and ensured accessibility compliance.

Fixes #155

---
*PR created automatically by Jules for task [7785160277691083241](https://jules.google.com/task/7785160277691083241) started by @ksc0000*