### PR TITLE
Add nail image detail viewer

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -479,6 +479,7 @@
   aspect-ratio: 4 / 3;
   overflow: hidden;
   background: var(--border);
+  cursor: pointer;
 }
 
 .nail-thumb-placeholder {
@@ -505,6 +506,7 @@
   display: flex;
   flex-direction: column;
   gap: 6px;
+  cursor: pointer;
 }
 
 .nail-item-title {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,6 +14,7 @@ import { uploadNailImage, deleteNailImage } from './lib/storage'
 import ErrorBanner from './components/ErrorBanner'
 import PrivacyPolicyPage from './components/PrivacyPolicyPage'
 import TermsOfServicePage from './components/TermsOfServicePage'
+import NailImageDetailViewer from './components/NailImageDetailViewer'
 import './App.css'
 
 const sortByDate = (items: NailItemDoc[]): NailItemDoc[] =>
@@ -208,7 +209,6 @@ function App() {
   )
   const uploadInputRef = useRef<HTMLInputElement>(null)
   const cameraInputRef = useRef<HTMLInputElement>(null)
-  const detailCloseButtonRef = useRef<HTMLButtonElement>(null)
   const previewUrlRef = useRef<string | null>(null)
 
   useEffect(() => () => {
@@ -295,16 +295,6 @@ function App() {
       setComparisonItemIds([])
     }
   }), [isPublicSharePage])
-
-  useEffect(() => {
-    if (!detailItemId) return
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') setDetailItemId(null)
-    }
-    document.addEventListener('keydown', handleKeyDown)
-    detailCloseButtonRef.current?.focus()
-    return () => document.removeEventListener('keydown', handleKeyDown)
-  }, [detailItemId])
 
   useEffect(() => {
     if (isPublicSharePage) return
@@ -817,87 +807,12 @@ function App() {
     <section id="center">
       <h1 id="app-title">Nailous</h1>
       <ErrorBanner message={bannerError} onClose={() => setBannerError('')} />
-      {detailItem && (() => {
-        const createdDate = formatDate(detailItem.createdAt)
-        const updatedDate = (detailItem.updatedAt && detailItem.createdAt &&
-          detailItem.updatedAt.seconds !== detailItem.createdAt.seconds)
-          ? formatDate(detailItem.updatedAt)
-          : null
-        return (
-          <div
-            className="nail-detail-backdrop"
-            role="presentation"
-            onClick={() => setDetailItemId(null)}
-          >
-            <div
-              className="nail-detail-dialog"
-              role="dialog"
-              aria-modal="true"
-              aria-labelledby="nail-detail-title"
-              onClick={e => e.stopPropagation()}
-            >
-              <div className="nail-detail-header">
-                <p className="nail-detail-kicker">ネイル詳細</p>
-                <button
-                  ref={detailCloseButtonRef}
-                  type="button"
-                  className="nail-detail-close"
-                  onClick={() => setDetailItemId(null)}
-                  aria-label="ネイル詳細を閉じる"
-                >
-                  閉じる
-                </button>
-              </div>
-              <div className="nail-detail-image-frame">
-                {detailItem.imageUrl ? (
-                  <img
-                    className="nail-detail-image"
-                    src={detailItem.imageUrl}
-                    alt={detailItem.title + ' のネイル画像'}
-                  />
-                ) : (
-                  <div className="nail-detail-no-image">画像なし</div>
-                )}
-              </div>
-              <div className="nail-detail-body">
-                <h2 id="nail-detail-title" className="nail-detail-title">{detailItem.title}</h2>
-                <div className="nail-detail-section">
-                  <h3 className="nail-detail-label">タグ</h3>
-                  {detailItem.tags.length > 0 ? (
-                    <div className="nail-item-tags">
-                      {detailItem.tags.map(t => (
-                        <span key={t} className="nail-tag">#{t}</span>
-                      ))}
-                    </div>
-                  ) : (
-                    <p className="nail-detail-empty">タグなし</p>
-                  )}
-                </div>
-                {detailItem.memo && (
-                  <div className="nail-detail-section">
-                    <h3 className="nail-detail-label">メモ</h3>
-                    <p className="nail-detail-memo">{detailItem.memo}</p>
-                  </div>
-                )}
-                <dl className="nail-detail-meta">
-                  {createdDate && (
-                    <div>
-                      <dt>作成日</dt>
-                      <dd>{createdDate}</dd>
-                    </div>
-                  )}
-                  {updatedDate && (
-                    <div>
-                      <dt>更新日</dt>
-                      <dd>{updatedDate}</dd>
-                    </div>
-                  )}
-                </dl>
-              </div>
-            </div>
-          </div>
-        )
-      })()}
+      {detailItem && (
+        <NailImageDetailViewer
+          item={detailItem}
+          onClose={() => setDetailItemId(null)}
+        />
+      )}
       <div id="auth-bar">
         {user === undefined ? null : user ? (
           <div className="auth-user">
@@ -1318,7 +1233,10 @@ function App() {
                       isCompareSelected ? 'comparison-selected' : '',
                     ].filter(Boolean).join(' ')}
                   >
-                    <div className="nail-card-thumb">
+                    <div
+                      className="nail-card-thumb"
+                      onClick={() => setDetailItemId(item.id)}
+                    >
                       <div className="nail-thumb-placeholder">No image</div>
                       {item.imageUrl && (
                         <img
@@ -1329,7 +1247,10 @@ function App() {
                         />
                       )}
                     </div>
-                    <div className="nail-card-body">
+                    <div
+                      className="nail-card-body"
+                      onClick={() => setDetailItemId(item.id)}
+                    >
                       <span className="nail-item-title">{item.title}</span>
                       {item.tags.length > 0 && (
                         <div className="nail-item-tags">

--- a/src/components/NailImageDetailViewer.tsx
+++ b/src/components/NailImageDetailViewer.tsx
@@ -1,0 +1,122 @@
+import React, { useEffect, useRef } from 'react';
+import type { NailItemDoc } from '../lib/firestore';
+
+interface NailImageDetailViewerProps {
+  item: NailItemDoc;
+  onClose: () => void;
+}
+
+const formatDate = (ts: { toDate(): Date } | null | undefined): string | null => {
+  if (!ts) return null;
+  try {
+    return ts.toDate().toLocaleDateString('ja-JP', {
+      year: 'numeric',
+      month: 'numeric',
+      day: 'numeric',
+    });
+  } catch {
+    return null;
+  }
+};
+
+const NailImageDetailViewer: React.FC<NailImageDetailViewerProps> = ({ item, onClose }) => {
+  const closeButtonRef = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    document.addEventListener('keydown', handleKeyDown);
+    closeButtonRef.current?.focus();
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [onClose]);
+
+  const createdDate = formatDate(item.createdAt);
+  const updatedDate =
+    item.updatedAt &&
+    item.createdAt &&
+    item.updatedAt.seconds !== item.createdAt.seconds
+      ? formatDate(item.updatedAt)
+      : null;
+
+  return (
+    <div
+      className="nail-detail-backdrop"
+      role="presentation"
+      onClick={onClose}
+    >
+      <div
+        className="nail-detail-dialog"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="nail-detail-title"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="nail-detail-header">
+          <p className="nail-detail-kicker">ネイル詳細</p>
+          <button
+            ref={closeButtonRef}
+            type="button"
+            className="nail-detail-close"
+            onClick={onClose}
+            aria-label="ネイル詳細を閉じる"
+          >
+            閉じる
+          </button>
+        </div>
+        <div className="nail-detail-image-frame">
+          {item.imageUrl ? (
+            <img
+              className="nail-detail-image"
+              src={item.imageUrl}
+              alt={item.title + ' のネイル画像'}
+            />
+          ) : (
+            <div className="nail-detail-no-image">画像なし</div>
+          )}
+        </div>
+        <div className="nail-detail-body">
+          <h2 id="nail-detail-title" className="nail-detail-title">
+            {item.title}
+          </h2>
+          <div className="nail-detail-section">
+            <h3 className="nail-detail-label">タグ</h3>
+            {item.tags.length > 0 ? (
+              <div className="nail-item-tags">
+                {item.tags.map((t) => (
+                  <span key={t} className="nail-tag">
+                    #{t}
+                  </span>
+                ))}
+              </div>
+            ) : (
+              <p className="nail-detail-empty">タグなし</p>
+            )}
+          </div>
+          {item.memo && (
+            <div className="nail-detail-section">
+              <h3 className="nail-detail-label">メモ</h3>
+              <p className="nail-detail-memo">{item.memo}</p>
+            </div>
+          )}
+          <dl className="nail-detail-meta">
+            {createdDate && (
+              <div>
+                <dt>作成日</dt>
+                <dd>{createdDate}</dd>
+              </div>
+            )}
+            {updatedDate && (
+              <div>
+                <dt>更新日</dt>
+                <dd>{updatedDate}</dd>
+              </div>
+            )}
+          </dl>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default NailImageDetailViewer;


### PR DESCRIPTION
Implemented a dedicated nail image detail viewer component, integrated it into the main app, and added click triggers to nail image cards for better UX.

Fixes #156

---
*PR created automatically by Jules for task [17079179482669529365](https://jules.google.com/task/17079179482669529365) started by @ksc0000*