### PR TITLE
Add imageSource for upload/camera distinction

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -93,6 +93,7 @@ interface ExportedNailItem {
   tags: string
   memo: string
   imageUrl: string
+  imageSource: string
   createdAt: string
   updatedAt: string
 }
@@ -108,11 +109,12 @@ const formatNailItemForExport = (item: NailItemDoc): ExportedNailItem => ({
   tags: item.tags.join(';'),
   memo: item.memo ?? '',
   imageUrl: item.imageUrl ?? '',
+  imageSource: item.imageSource ?? 'unknown',
   createdAt: formatTimestampForExport(item.createdAt),
   updatedAt: formatTimestampForExport(item.updatedAt),
 })
 
-const CSV_HEADERS = ['id', 'title', 'tags', 'memo', 'imageUrl', 'createdAt', 'updatedAt'] as const
+const CSV_HEADERS = ['id', 'title', 'tags', 'memo', 'imageUrl', 'imageSource', 'createdAt', 'updatedAt'] as const
 
 const escapeCsvCell = (value: string): string => {
   if (/[",\n\r]/.test(value)) return `"${value.replace(/"/g, '""')}"`
@@ -198,6 +200,7 @@ function App() {
   const [nailMemo, setNailMemo] = useState('')
   const [nailImageFile, setNailImageFile] = useState<File | null>(null)
   const [nailImagePreview, setNailImagePreview] = useState<string | null>(null)
+  const [nailImageSource, setNailImageSource] = useState<'upload' | 'camera' | 'unknown'>('unknown')
   const [editingId, setEditingId] = useState<string | null>(null)
   const [detailItemId, setDetailItemId] = useState<string | null>(null)
   const [isDataModalOpen, setIsDataModalOpen] = useState(false)
@@ -385,17 +388,31 @@ function App() {
 
   const handleNailFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0] ?? null
-    if (!file) { setNailImageFile(null); clearPreview(); setNailError(''); return }
+    if (!file) {
+      setNailImageFile(null)
+      clearPreview()
+      setNailError('')
+      setNailImageSource('unknown')
+      return
+    }
     const err = validateImageFile(file)
     if (err) {
       setNailError(err)
       setNailImageFile(null)
       clearPreview()
       clearImageInputs()
+      setNailImageSource('unknown')
       return
     }
     setNailError('')
     setNailImageFile(file)
+    if (e.target === cameraInputRef.current) {
+      setNailImageSource('camera')
+    } else if (e.target === uploadInputRef.current) {
+      setNailImageSource('upload')
+    } else {
+      setNailImageSource('unknown')
+    }
     clearPreview()
     const url = URL.createObjectURL(file)
     previewUrlRef.current = url
@@ -407,6 +424,7 @@ function App() {
     clearPreview()
     setNailError('')
     clearImageInputs()
+    setNailImageSource('unknown')
   }
 
   const parseTags = (s: string): string[] =>
@@ -419,6 +437,7 @@ function App() {
     setNailImageFile(null)
     clearPreview()
     clearImageInputs()
+    setNailImageSource('unknown')
     setEditingId(null)
     setNailError('')
   }
@@ -433,7 +452,12 @@ function App() {
     setNailLoading(true)
     setNailError('')
     setBannerError('')
-    const baseInput = { title: nailTitle.trim(), tags: parseTags(nailTags), memo: nailMemo.trim() }
+    const baseInput = {
+      title: nailTitle.trim(),
+      tags: parseTags(nailTags),
+      memo: nailMemo.trim(),
+      imageSource: nailImageSource,
+    }
     try {
       if (editingId) {
         const editingItem = nailItems.find(i => i.id === editingId)
@@ -470,6 +494,7 @@ function App() {
     setNailTitle(item.title)
     setNailTags(item.tags.join(', '))
     setNailMemo(item.memo ?? '')
+    setNailImageSource(item.imageSource ?? 'unknown')
     setNailImageFile(null)
     clearPreview()
     clearImageInputs()

--- a/src/lib/firestoreModel.ts
+++ b/src/lib/firestoreModel.ts
@@ -6,6 +6,7 @@ export interface NailItem {
   thumbnailUrl: string
   tags: string[]
   memo: string
+  imageSource?: 'upload' | 'camera' | 'unknown'
   createdAt: Timestamp | null
   updatedAt: Timestamp | null
 }
@@ -19,6 +20,7 @@ export interface NailItemInput {
   imageUrl: string
   tags: string[]
   memo: string
+  imageSource?: 'upload' | 'camera' | 'unknown'
 }
 
 export const toNailItemDoc = (id: string, data: NailItem): NailItemDoc => ({
@@ -32,6 +34,7 @@ export const buildCreateNailItemData = (input: NailItemInput, timestamp: unknown
   thumbnailUrl: input.imageUrl,
   tags: input.tags,
   memo: input.memo,
+  imageSource: input.imageSource ?? 'unknown',
   createdAt: timestamp,
   updatedAt: timestamp,
 })
@@ -42,5 +45,6 @@ export const buildUpdateNailItemData = (input: NailItemInput, timestamp: unknown
   thumbnailUrl: input.imageUrl,
   tags: input.tags,
   memo: input.memo,
+  imageSource: input.imageSource ?? 'unknown',
   updatedAt: timestamp,
 })

--- a/tests/firestoreModel.test.ts
+++ b/tests/firestoreModel.test.ts
@@ -11,6 +11,7 @@ const input: NailItemInput = {
   imageUrl: 'https://example.com/nail.jpg',
   tags: ['pink', 'gel'],
   memo: 'soft gradient',
+  imageSource: 'camera',
 }
 test('buildCreateNailItemData creates the Firestore write payload', () => {
   const timestamp = Symbol('serverTimestamp')
@@ -20,9 +21,16 @@ test('buildCreateNailItemData creates the Firestore write payload', () => {
     thumbnailUrl: input.imageUrl,
     tags: input.tags,
     memo: input.memo,
+    imageSource: 'camera',
     createdAt: timestamp,
     updatedAt: timestamp,
   })
+})
+test('buildCreateNailItemData defaults imageSource to unknown', () => {
+  const timestamp = Symbol('serverTimestamp')
+  const noSourceInput = { ...input, imageSource: undefined }
+  const result = buildCreateNailItemData(noSourceInput, timestamp)
+  assert.equal(result.imageSource, 'unknown')
 })
 test('buildUpdateNailItemData omits createdAt and refreshes updatedAt', () => {
   const timestamp = Symbol('serverTimestamp')
@@ -32,6 +40,7 @@ test('buildUpdateNailItemData omits createdAt and refreshes updatedAt', () => {
     thumbnailUrl: input.imageUrl,
     tags: input.tags,
     memo: input.memo,
+    imageSource: 'camera',
     updatedAt: timestamp,
   })
 })


### PR DESCRIPTION
This change enables tracking whether a nail image was uploaded from the browser or captured via a camera. It updates the Firestore data model, UI logic for source detection during file selection, and ensures the field is included in data exports (CSV/JSON). Backward compatibility is maintained by defaulting missing fields to 'unknown'.

Fixes #163

---
*PR created automatically by Jules for task [3038837325305616951](https://jules.google.com/task/3038837325305616951) started by @ksc0000*