### PR TITLE
Implement unit tests for Firestore helper functions

### DIFF
--- a/src/__tests__/firestore.test.ts
+++ b/src/__tests__/firestore.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import {
+  getNailItem,
+  addNailItem,
+} from '../lib/firestore'
+import * as firestore from 'firebase/firestore'
+
+// Mock firebase/firestore
+vi.mock('firebase/firestore', () => ({
+  collection: vi.fn(),
+  addDoc: vi.fn(),
+  getDocs: vi.fn(),
+  getDoc: vi.fn(),
+  doc: vi.fn(),
+  updateDoc: vi.fn(),
+  deleteDoc: vi.fn(),
+  serverTimestamp: vi.fn(() => 'mock-timestamp'),
+}))
+
+// Mock ../lib/firebase
+vi.mock('../lib/firebase', () => ({
+  db: { type: 'firestore' },
+}))
+
+describe('firestore helper functions', () => {
+  const userId = 'user-123'
+  const itemId = 'item-456'
+  const input = {
+    title: 'New Nail',
+    imageUrl: 'http://example.com/image.png',
+    tags: ['tag1'],
+    memo: 'memo content',
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('getNailItem', () => {
+    it('returns nail item when it exists', async () => {
+      const mockData = {
+        title: 'Existing Nail',
+        imageUrl: 'url',
+        thumbnailUrl: 'url',
+        tags: [],
+        memo: '',
+        createdAt: null,
+        updatedAt: null,
+      }
+      vi.mocked(firestore.getDoc).mockResolvedValue({
+        exists: () => true,
+        id: itemId,
+        data: () => mockData,
+      } as unknown as never)
+
+      const result = await getNailItem(userId, itemId)
+
+      expect(firestore.doc).toHaveBeenCalledWith(expect.anything(), 'users', userId, 'nailItems', itemId)
+      expect(result).toEqual({
+        id: itemId,
+        ...mockData,
+      })
+    })
+
+    it('returns null when nail item does not exist', async () => {
+      vi.mocked(firestore.getDoc).mockResolvedValue({
+        exists: () => false,
+      } as unknown as never)
+
+      const result = await getNailItem(userId, itemId)
+
+      expect(result).toBeNull()
+    })
+  })
+
+  describe('addNailItem', () => {
+    it('adds a new nail item and returns its ID', async () => {
+      vi.mocked(firestore.addDoc).mockResolvedValue({
+        id: 'new-item-id',
+      } as unknown as never)
+
+      const result = await addNailItem(userId, input)
+
+      expect(firestore.collection).toHaveBeenCalledWith(expect.anything(), 'users', userId, 'nailItems')
+      expect(firestore.addDoc).toHaveBeenCalled()
+      expect(result).toBe('new-item-id')
+    })
+  })
+})

--- a/src/lib/firestore.ts
+++ b/src/lib/firestore.ts
@@ -2,6 +2,7 @@ import {
   collection, addDoc, getDocs,
   doc, updateDoc, deleteDoc,
   serverTimestamp,
+  getDoc,
 } from 'firebase/firestore'
 import { db } from './firebase'
 import {
@@ -38,4 +39,11 @@ export const updateNailItem = async (
 export const deleteNailItem = async (userId: string, itemId: string): Promise<void> => {
   const ref = doc(db, 'users', userId, 'nailItems', itemId)
   await deleteDoc(ref)
+}
+
+export const getNailItem = async (userId: string, itemId: string): Promise<NailItemDoc | null> => {
+  const ref = doc(db, 'users', userId, 'nailItems', itemId)
+  const snap = await getDoc(ref)
+  if (!snap.exists()) return null
+  return toNailItemDoc(snap.id, snap.data() as NailItem)
 }


### PR DESCRIPTION
This PR addresses Phase 2.1 of the roadmap by improving test coverage for Firestore helper functions. It adds a new `getNailItem` function to the `src/lib/firestore.ts` module and introduces comprehensive unit tests in a new `src/__tests__/` directory. All Firebase dependencies are properly mocked using Vitest to ensure tests are stable and performant.

Fixes #166

---
*PR created automatically by Jules for task [11160603246785285122](https://jules.google.com/task/11160603246785285122) started by @ksc0000*