### PR TITLE
chore: AIレビューをClaudeのみにしCodexをレビューから除外

### DIFF
--- a/.github/workflows/agent-issue-router.yml
+++ b/.github/workflows/agent-issue-router.yml
@@ -81,7 +81,8 @@ jobs:
                 "Create a branch, implement the issue, run focused checks, then open a PR.",
               ],
               "codex-ready": [
-                "Recommended executor: Codex for implementation review or a focused patch.",
+                "Recommended executor: Codex for implementation or a focused patch.",
+                "PR review is handled by Claude via the `request-ai-review` label (Codex is not used for review).",
               ],
               "jules-ready": [
                 "Recommended executor: Google Jules for small, parallelizable tasks.",

--- a/.github/workflows/agent-pr-review-router.yml
+++ b/.github/workflows/agent-pr-review-router.yml
@@ -53,8 +53,8 @@ jobs:
               "## Agent PR next steps",
               "",
               isJules
-                ? "This PR appears to be from Jules. When implementation is ready, add the `request-ai-review` label to trigger Codex review (Claude will follow automatically)."
-                : "When this PR is ready for AI review, add the `request-ai-review` label to trigger Codex review (Claude follows automatically).",
+                ? "This PR appears to be from Jules. When implementation is ready, add the `request-ai-review` label to trigger a Claude review."
+                : "When this PR is ready for AI review, add the `request-ai-review` label to trigger a Claude review.",
               "",
               "Expected review flow:",
               "",
@@ -62,8 +62,7 @@ jobs:
               "PR opened",
               "  -> CI runs",
               "  -> add request-ai-review label",
-              "  -> @codex review",
-              "  -> @claude review (auto-triggered after Codex)",
+              "  -> @claude review",
               "  -> fix comments",
               "  -> human merge",
               "```",
@@ -83,14 +82,14 @@ jobs:
             }
 
   request-ai-review:
-    name: Request Codex review (Claude follows automatically)
+    name: Request Claude review
     if: >
       github.event.action == 'labeled' &&
       github.event.label.name == 'request-ai-review'
     runs-on: ubuntu-latest
 
     steps:
-      - name: Post Codex review request
+      - name: Post Claude review request
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GH_AW_AGENT_TOKEN || github.token }}
@@ -112,14 +111,12 @@ jobs:
             }
 
             const body = [
-              "@codex review for correctness, regressions, missing tests, and accidental scope creep",
+              "@claude review for correctness, regressions, missing tests, and accidental scope creep",
               "",
               "Review scope:",
               "- Verify the PR satisfies the linked issue acceptance criteria.",
               "- Prioritize correctness, user-visible regressions, security, data loss, and missing tests.",
               "- Do not merge this PR.",
-              "",
-              "Note: @claude review will be triggered automatically after Codex responds.",
               "",
               marker,
             ].join("\n");


### PR DESCRIPTION
## 概要
AI自動開発フローは継続したまま、**PRレビューから Codex を外し Claude に一本化**する。

## 変更
- `agent-pr-review-router.yml`: `request-ai-review` のレビュー依頼を `@codex review` → `@claude review`。ジョブ/ステップ名・案内文・フロー図のCodex言及を整理
- `agent-issue-router.yml`: `codex-ready` ルートを実装担当のみとし、レビューはClaude経由と明記

## 補足
`@codex review` メンションで Codex が起動する前提の修正です。Codex を GitHub App として全PR自動レビューに入れている場合は別途 App 側設定の解除が必要です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)