### PR TITLE
ci: disable Claude review routing

### DIFF
--- a/.github/workflows/agent-issue-router.yml
+++ b/.github/workflows/agent-issue-router.yml
@@ -74,15 +74,15 @@ jobs:
 
             const routeNotes = {
               "agent-ready": [
-                "Choose one execution label next: `claude-ready`, `codex-ready`, or `jules-ready`.",
+                "Choose one execution label next: `codex-ready` or `jules-ready`.",
               ],
               "claude-ready": [
-                "Recommended executor: Claude Code CLI on a local branch.",
-                "Create a branch, implement the issue, run focused checks, then open a PR.",
+                "Claude routing is currently disabled for this repository.",
+                "Use `codex-ready` or `jules-ready` instead.",
               ],
               "codex-ready": [
                 "Recommended executor: Codex for implementation or a focused patch.",
-                "PR review is handled by Claude via the `request-ai-review` label (Codex is not used for review).",
+                "Review is handled by maintainer judgment and CI; do not request Claude review.",
               ],
               "jules-ready": [
                 "Recommended executor: Google Jules for small, parallelizable tasks.",

--- a/.github/workflows/agent-pr-review-router.yml
+++ b/.github/workflows/agent-pr-review-router.yml
@@ -3,7 +3,6 @@ name: Agent PR Review Router
 on:
   pull_request_target:
     types:
-      - labeled
       - opened
       - ready_for_review
 
@@ -53,18 +52,17 @@ jobs:
               "## Agent PR next steps",
               "",
               isJules
-                ? "This PR appears to be from Jules. When implementation is ready, add the `request-ai-review` label to trigger a Claude review."
-                : "When this PR is ready for AI review, add the `request-ai-review` label to trigger a Claude review.",
+                ? "This PR appears to be from Jules. Wait for CI, then use maintainer review and merge judgment."
+                : "Wait for CI, then use maintainer review and merge judgment.",
               "",
-              "Expected review flow:",
+              "Expected PR flow:",
               "",
               "```text",
               "PR opened",
               "  -> CI runs",
-              "  -> add request-ai-review label",
-              "  -> @claude review",
-              "  -> fix comments",
-              "  -> human merge",
+              "  -> maintainer review",
+              "  -> fix comments if needed",
+              "  -> human or explicitly-approved agent merge",
               "```",
               "",
               marker,
@@ -78,56 +76,5 @@ jobs:
             if (!existing) {
               await github.rest.issues.createComment({
                 owner, repo, issue_number: pr.number, body,
-              });
-            }
-
-  request-ai-review:
-    name: Request Claude review
-    if: >
-      github.event.action == 'labeled' &&
-      github.event.label.name == 'request-ai-review'
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Post Claude review request
-        uses: actions/github-script@v7
-        with:
-          github-token: ${{ secrets.GH_AW_AGENT_TOKEN || github.token }}
-          script: |
-            const owner = context.repo.owner;
-            const repo = context.repo.repo;
-            const pr = context.payload.pull_request;
-            const labels = new Set((pr.labels || []).map((label) => label.name));
-            const marker = "<!-- agent-pr-review-router-review-request -->";
-
-            const { data: comments } = await github.rest.issues.listComments({
-              owner, repo, issue_number: pr.number, per_page: 100,
-            });
-
-            const existing = comments.find((c) => c.body && c.body.includes(marker));
-            if (existing) {
-              core.info("AI review request comment already exists.");
-              return;
-            }
-
-            const body = [
-              "@claude review for correctness, regressions, missing tests, and accidental scope creep",
-              "",
-              "Review scope:",
-              "- Verify the PR satisfies the linked issue acceptance criteria.",
-              "- Prioritize correctness, user-visible regressions, security, data loss, and missing tests.",
-              "- Do not merge this PR.",
-              "",
-              marker,
-            ].join("\n");
-
-            await github.rest.issues.createComment({
-              owner, repo, issue_number: pr.number, body,
-            });
-
-            if (!labels.has("ai-review-requested")) {
-              await github.rest.issues.addLabels({
-                owner, repo, issue_number: pr.number,
-                labels: ["ai-review-requested"],
               });
             }


### PR DESCRIPTION
## Summary
- Remove the request-ai-review PR trigger and Claude review request job
- Update agent PR guidance to use CI plus maintainer judgment instead of Claude review
- Update issue router guidance so Codex/Jules routes do not point to Claude review

## Validation
- git diff --check
- Ruby YAML parse for updated workflow files
- npm test
- npm run lint
- npm run build

## Notes
- This intentionally avoids adding request-ai-review or ai-review-requested labels.
- Build still emits the known Vite >500 kB chunk warning.