### PR TITLE
feat: validate nail tag input

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
-    "test": "node --experimental-strip-types --test tests/firestoreModel.test.ts && vitest run tests/firestore.test.ts",
+    "test": "node --experimental-strip-types --test tests/firestoreModel.test.ts tests/nailTags.test.ts && vitest run tests/firestore.test.ts",
     "preview": "vite preview"
   },
   "dependencies": {

--- a/src/App.css
+++ b/src/App.css
@@ -377,6 +377,13 @@
   margin: 0;
 }
 
+.nail-input-note {
+  font-size: 0.78rem;
+  color: #777;
+  margin: -8px 0 2px;
+  line-height: 1.5;
+}
+
 .nail-loading {
   text-align: center;
   padding: 40px 0;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,7 @@ import {
 } from './lib/publicShares'
 import type { PublicShareDocWithId, PublicShareItemSnapshot } from './lib/publicShares'
 import { uploadNailImage, deleteNailImage } from './lib/storage'
+import { MAX_NAIL_TAG_LENGTH, MAX_NAIL_TAGS, parseNailTags } from './lib/nailTags'
 import ErrorBanner from './components/ErrorBanner'
 import PrivacyPolicyPage from './components/PrivacyPolicyPage'
 import TermsOfServicePage from './components/TermsOfServicePage'
@@ -421,9 +422,6 @@ function App() {
     setNailImageSource('unknown')
   }
 
-  const parseTags = (s: string): string[] =>
-    s.split(',').map(t => t.trim()).filter(Boolean)
-
   const resetForm = () => {
     setNailTitle('')
     setNailTags('')
@@ -442,13 +440,18 @@ function App() {
       const err = validateImageFile(nailImageFile)
       if (err) { setNailError(err); return }
     }
+    const parsedTags = parseNailTags(nailTags)
+    if (parsedTags.error) {
+      setNailError(parsedTags.error)
+      return
+    }
     const uid = user.uid
     setNailLoading(true)
     setNailError('')
     setBannerError('')
     const baseInput = {
       title: nailTitle.trim(),
-      tags: parseTags(nailTags),
+      tags: parsedTags.tags,
       memo: nailMemo.trim(),
       imageSource: nailImageSource,
     }
@@ -890,9 +893,12 @@ function App() {
               type="text"
               value={nailTags}
               onChange={e => setNailTags(e.target.value)}
-              placeholder="Tags (comma separated)"
+              placeholder="Tags (comma separated, max 12)"
               className="nail-input"
             />
+            <p className="nail-input-note">
+              タグはカンマ区切りで最大{MAX_NAIL_TAGS}個、1つ{MAX_NAIL_TAG_LENGTH}文字まで。
+            </p>
             <textarea
               value={nailMemo}
               onChange={e => setNailMemo(e.target.value)}

--- a/src/lib/nailTags.ts
+++ b/src/lib/nailTags.ts
@@ -1,0 +1,40 @@
+export const MAX_NAIL_TAGS = 12
+export const MAX_NAIL_TAG_LENGTH = 24
+
+export interface NailTagParseResult {
+  tags: string[]
+  error: string
+}
+
+export const parseNailTags = (value: string): NailTagParseResult => {
+  const tags: string[] = []
+  const seen = new Set<string>()
+  const rawTags = value
+    .split(',')
+    .map(tag => tag.trim().replace(/^#+/, '').trim())
+    .filter(Boolean)
+
+  for (const tag of rawTags) {
+    if (tag.length > MAX_NAIL_TAG_LENGTH) {
+      return {
+        tags: [],
+        error: `タグは1つ${MAX_NAIL_TAG_LENGTH}文字以内にしてください。`,
+      }
+    }
+
+    const key = tag.toLocaleLowerCase()
+    if (!seen.has(key)) {
+      seen.add(key)
+      tags.push(tag)
+    }
+  }
+
+  if (tags.length > MAX_NAIL_TAGS) {
+    return {
+      tags: [],
+      error: `タグは最大${MAX_NAIL_TAGS}個までです。`,
+    }
+  }
+
+  return { tags, error: '' }
+}

--- a/tests/nailTags.test.ts
+++ b/tests/nailTags.test.ts
@@ -1,0 +1,25 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+import {
+  MAX_NAIL_TAG_LENGTH,
+  MAX_NAIL_TAGS,
+  parseNailTags,
+} from '../src/lib/nailTags.ts'
+
+test('parseNailTags trims, removes hash prefixes, and drops duplicates', () => {
+  assert.deepEqual(parseNailTags(' pink, #gel, Pink, , art ').tags, ['pink', 'gel', 'art'])
+})
+
+test('parseNailTags rejects too many tags', () => {
+  const value = Array.from({ length: MAX_NAIL_TAGS + 1 }, (_, i) => `tag${i}`).join(',')
+  const result = parseNailTags(value)
+  assert.deepEqual(result.tags, [])
+  assert.match(result.error, /最大/)
+})
+
+test('parseNailTags rejects tags that are too long', () => {
+  const value = 'a'.repeat(MAX_NAIL_TAG_LENGTH + 1)
+  const result = parseNailTags(value)
+  assert.deepEqual(result.tags, [])
+  assert.match(result.error, /文字以内/)
+})


### PR DESCRIPTION
## Summary
- Add shared nail tag parsing and validation
- Limit tags to 12 items and 24 characters each
- Remove duplicate tags case-insensitively and strip leading # symbols
- Add form helper copy and unit tests

## Validation
- git diff --check
- npm test
- npm run lint
- npm run build

## Notes
- Build still emits the known Vite >500 kB chunk warning.
- No Firebase rules, deployment, secrets, or dependencies changed.