### PR TITLE
docs: add security headers decision note

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,8 @@ export default defineConfig([
 | [docs/operations/FIREBASE_SETUP.md](docs/operations/FIREBASE_SETUP.md) | Firebase Auth setup and verification steps |
 | [docs/operations/FIREBASE_STORAGE_RULES.md](docs/operations/FIREBASE_STORAGE_RULES.md) | Storage Security Rules design, allowed types/sizes, and deploy checklist |
 | [docs/operations/IMAGE_UPLOAD_QA.md](docs/operations/IMAGE_UPLOAD_QA.md) | QA checklist for image upload — normal, error, edit, delete, and pre-merge checks |
+| [docs/operations/SECURITY_HEADERS_DECISION.md](docs/operations/SECURITY_HEADERS_DECISION.md) | Security headers decision note for the commercial MVP |
+| [docs/operations/SECURITY_HEADERS_GUIDE.md](docs/operations/SECURITY_HEADERS_GUIDE.md) | Technical guide for security headers and CSP configuration |
 
 ### Design References
 

--- a/docs/operations/SECURITY_HEADERS_DECISION.md
+++ b/docs/operations/SECURITY_HEADERS_DECISION.md
@@ -1,0 +1,46 @@
+# Security Headers Decision - Commercial MVP
+
+## Status
+- [x] Recommended for MVP
+- [ ] Deferred for Post-MVP Hardening
+
+## Overview
+This document records the decision regarding security headers for the Nailous commercial MVP. The goal is to provide a robust security posture that protects user data and prevents common web attacks while ensuring seamless operation of Firebase services.
+
+## Recommended MVP Headers (Standard Baseline)
+These headers are currently configured in `firebase.json` to provide a strong security baseline without breaking core Firebase functionality.
+
+| Header | MVP Setting | Rationale |
+|--------|-------------|-----------|
+| `Content-Security-Policy` | Strict Baseline | Blocks XSS and unauthorized data exfiltration. Tailored for Firebase Auth, Firestore, and Storage. |
+| `X-Content-Type-Options` | `nosniff` | Prevents the browser from MIME-sniffing a response away from the declared content-type. |
+| `X-Frame-Options` | `DENY` | Prevents clickjacking by disallowing the site from being embedded in an iframe. |
+| `Referrer-Policy` | `strict-origin-when-cross-origin` | Protects user privacy while allowing necessary cross-origin requests for Auth and APIs. |
+| `Strict-Transport-Security` | `max-age=31536000; includeSubDomains` | Forces HTTPS. `preload` is intentionally deferred for the MVP to avoid accidental domain lock-in. |
+| `Permissions-Policy` | `camera=(self), ...` | Restricts use of browser features. `camera` is allowed for the core "Take Photo" functionality. |
+
+## Framing Policy
+To provide defense-in-depth against clickjacking:
+- **X-Frame-Options**: Set to `DENY` for compatibility with older browsers.
+- **CSP `frame-ancestors`**: Set to `'none'` for modern browsers.
+
+This combination ensures the application cannot be embedded by any other site.
+
+## Deferred Hardening
+The following security enhancements are identified but deferred to minimize deployment risk during the initial launch phase:
+- **CSP Violation Reporting**: Adding `report-uri` or `report-to` for real-time monitoring of policy violations.
+- **HSTS Preloading**: Submitting the domain to the global HSTS preload list (requires high confidence in long-term HTTPS stability).
+- **Nonce-based CSP for Styles**: Moving away from `'unsafe-inline'` for CSS (requires non-trivial build-time integration with Vite/React).
+
+## Human Approval Requirement
+**IMPORTANT**: Any modifications to the security header configuration in `firebase.json` must receive explicit human approval before being merged or deployed.
+
+Security headers directly impact production behavior and can:
+1. Block critical Firebase Authentication flows.
+2. Prevent image uploads or downloads from Cloud Storage.
+3. Render the application unusable in specific browser versions.
+
+Changes must be verified through the [Manual Smoke Test Instructions](./SECURITY_HEADERS_GUIDE.md#manual-smoke-test-instructions).
+
+---
+Refer to [SECURITY_HEADERS_GUIDE.md](./SECURITY_HEADERS_GUIDE.md) for the technical implementation details of these decisions.

--- a/docs/operations/SECURITY_HEADERS_GUIDE.md
+++ b/docs/operations/SECURITY_HEADERS_GUIDE.md
@@ -1,6 +1,9 @@
 # Security Headers & CSP Guide
 
-This document explains the security headers and Content Security Policy (CSP) configured for Firebase Hosting in `firebase.json`.
+> [!NOTE]
+> For the strategic rationale and decision-making regarding these headers for the commercial MVP, see the [Security Headers Decision Note](./SECURITY_HEADERS_DECISION.md).
+
+This document explains the technical details of the security headers and Content Security Policy (CSP) configured for Firebase Hosting in `firebase.json`.
 
 ## Content Security Policy (CSP)
 


### PR DESCRIPTION
This PR adds a comprehensive security headers decision record for the commercial MVP. 

Key changes:
- **Decision Record**: Created `docs/operations/SECURITY_HEADERS_DECISION.md` which outlines the recommended headers for the initial launch (CSP, HSTS, X-Frame-Options, etc.) and identifies items deferred for post-MVP hardening.
- **Improved Discoverability**: Added the new document and the existing technical guide to the `README.md` operations table.
- **Cross-linking**: Added a contextual note to `docs/operations/SECURITY_HEADERS_GUIDE.md` linking to the rationale behind the technical settings.
- **Safety**: Reinforces the policy that any changes to production security headers (`firebase.json`) require human approval.

All changes are documentation-only and do not affect the application source code or production configuration. Linting and build steps have been verified.

Fixes #180

---
*PR created automatically by Jules for task [3438944147175138600](https://jules.google.com/task/3438944147175138600) started by @ksc0000*