### PR TITLE
Update release roadmap and documentation index

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ export default defineConfig([
 |----------|-------------|
 | [docs/operations/LOCAL_DEVELOPMENT_MANUAL.md](docs/operations/LOCAL_DEVELOPMENT_MANUAL.md) | Step-by-step local development guide including VS Code Tunnel |
 | [docs/operations/COMMERCIAL_LAUNCH_QA_REPORT.md](docs/operations/COMMERCIAL_LAUNCH_QA_REPORT.md) | Reusable QA result template for Issue #113 commercial launch |
+| [docs/operations/BUNDLE_SIZE_WARNING_ACCEPTANCE.md](docs/operations/BUNDLE_SIZE_WARNING_ACCEPTANCE.md) | Documented acceptance of current production bundle size for commercial MVP |
 | [docs/operations/FIRESTORE_SECURITY_RULES.md](docs/operations/FIRESTORE_SECURITY_RULES.md) | Firestore Security Rules design, phase plan, and deploy checklist |
 | [docs/operations/PUBLIC_SHARING_PRIVACY.md](docs/operations/PUBLIC_SHARING_PRIVACY.md) | Public share links, shared/excluded fields, revoke behavior, and privacy notes |
 | [docs/operations/FIREBASE_SETUP.md](docs/operations/FIREBASE_SETUP.md) | Firebase Auth setup and verification steps |

--- a/docs/product/ROADMAP.md
+++ b/docs/product/ROADMAP.md
@@ -17,8 +17,8 @@
 | Phase 2 | Data Persistence | ✅ 完了 |
 | Phase 3 | Authentication / User Management | ✅ 完了 |
 | Phase 4 | AI-Assisted Features | 🔲 未着手 |
-| Phase 4.5 | Nail View / Camera Foundation | 🔲 推奨 next |
-| Phase 5 | Review / Export / Sharing | 🟡 進行中 |
+| Phase 4.5 | Nail View / Camera Foundation | 🟡 進行中 |
+| Phase 5 | Review / Export / Sharing | ✅ 完了 |
 | Phase 6 | Security / Operations Hardening | 🟡 進行中 |
 | Phase 7 | Release Preparation | 🟡 進行中 |
 | Phase 8 | 3D Preview / Modeling Foundation | 🔲 未着手 |
@@ -209,9 +209,9 @@
 
 ### Example Issues
 
-- [ ] CSV / JSON エクスポート
-- [ ] コレクション振り返り画面（月別・タグ別）
-- [ ] 共有 URL / 公開コレクション機能
+- [x] CSV / JSON エクスポート
+- [x] コレクション振り返り画面（月別・タグ別）
+- [x] 共有 URL / 公開コレクション機能
 
 ### 完了済みサブセット
 
@@ -242,7 +242,7 @@
 
 ### Example Issues
 
-- [ ] セキュリティヘッダーの設定（CSP 等）
+- [x] セキュリティヘッダーの設定（CSP 等）
 - [ ] 入力バリデーションの強化（tags 件数制限 UI 等）
 - [ ] エラーログ / 監視の整備
 - [ ] 依存関係の脆弱性スキャン
@@ -276,10 +276,10 @@
 
 ### Remaining Issues
 
-- [ ] Privacy Policy / Terms routes and visible links
-- [ ] User data export and deletion guidance
-- [ ] Security headers / CSP
-- [ ] Bundle size warning reduction or documented acceptance
+- [x] Privacy Policy / Terms routes and visible links
+- [x] User data export and deletion guidance
+- [x] Security headers / CSP
+- [x] Bundle size warning reduction or documented acceptance
 - [ ] Full manual QA and go/no-go decision
 
 ### References
@@ -293,7 +293,7 @@
 - [ ] カスタムドメイン設定（broader commercial expansion 前に推奨）
 - [ ] 本番ビルド最適化（code splitting 等）
 - [ ] アクセス解析 / モニタリング設定（MVP では defer）
-- [ ] README の最終整備
+- [x] README の最終整備
 
 ### Human Gates
 


### PR DESCRIPTION
Updated the release roadmap and documentation index to reflect the recently merged commercial launch preparation work. Phase 5 is now marked as complete, and various subtasks in Phases 4.5, 6, and 7 have been updated to show they are finished. Additionally, the bundle size acceptance document is now linked in the README.

Fixes #184

---
*PR created automatically by Jules for task [9009830348526305288](https://jules.google.com/task/9009830348526305288) started by @ksc0000*