### PR TITLE
docs: add iPhone Safari camera smoke report template

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ export default defineConfig([
 |----------|-------------|
 | [docs/operations/LOCAL_DEVELOPMENT_MANUAL.md](docs/operations/LOCAL_DEVELOPMENT_MANUAL.md) | Step-by-step local development guide including VS Code Tunnel |
 | [docs/operations/COMMERCIAL_LAUNCH_QA_REPORT.md](docs/operations/COMMERCIAL_LAUNCH_QA_REPORT.md) | Reusable QA result template for Issue #113 commercial launch |
+| [docs/operations/IPHONE_SAFARI_CAMERA_SMOKE_REPORT.md](docs/operations/IPHONE_SAFARI_CAMERA_SMOKE_REPORT.md) | Focused iPhone Safari camera/upload smoke report template for #113 |
 | [docs/operations/FIRESTORE_SECURITY_RULES.md](docs/operations/FIRESTORE_SECURITY_RULES.md) | Firestore Security Rules design, phase plan, and deploy checklist |
 | [docs/operations/PUBLIC_SHARING_PRIVACY.md](docs/operations/PUBLIC_SHARING_PRIVACY.md) | Public share links, shared/excluded fields, revoke behavior, and privacy notes |
 | [docs/operations/FIREBASE_SETUP.md](docs/operations/FIREBASE_SETUP.md) | Firebase Auth setup and verification steps |

--- a/docs/operations/IPHONE_SAFARI_CAMERA_SMOKE_REPORT.md
+++ b/docs/operations/IPHONE_SAFARI_CAMERA_SMOKE_REPORT.md
@@ -1,0 +1,44 @@
+# iPhone Safari Camera Smoke Report Template (Issue #113)
+
+> This is a focused smoke report template for iPhone Safari camera and upload behavior.
+> Use this before completing the full [Commercial Launch QA Report](./COMMERCIAL_LAUNCH_QA_REPORT.md).
+
+## 1. Environment Details
+- **iPhone Model:** [e.g., iPhone 15 Pro]
+- **iOS Version:** [e.g., 17.4.1]
+- **Mode:** [Safari / PWA (Standalone)]
+- **Orientation:** [Portrait / Landscape]
+- **Tester:** [Name]
+- **Date:** [YYYY-MM-DD]
+- **URL/Commit:** [e.g., Production URL or SHA]
+
+## 2. Smoke Test Checklist
+
+| Test Case | Result | Notes / Evidence |
+|---|---|---|
+| **Camera Picker** | | |
+| 「写真を撮る」 opens system camera | [Pass/Fail] | |
+| Capture photo and confirm | [Pass/Fail] | |
+| Picker cancel (no crash) | [Pass/Fail] | |
+| **Upload Fallback** | | |
+| 「画像を選択」 opens photo library/files | [Pass/Fail] | |
+| Select existing photo | [Pass/Fail] | |
+| **Preview & Edit** | | |
+| Image preview renders correctly | [Pass/Fail] | |
+| 「削除」(Remove) works | [Pass/Fail] | |
+| 「変更」(Replace) with new capture works | [Pass/Fail] | |
+| **Save & Persistence** | | |
+| Add/Update item successfully | [Pass/Fail] | |
+| Image is visible in list card | [Pass/Fail] | |
+| **Post-Save Verification** | | |
+| Opens correctly in Detail Viewer | [Pass/Fail] | |
+| Visible in Comparison View | [Pass/Fail] | |
+| Date/Time formatting (Japanese) | [Pass/Fail] | |
+
+## 3. Failure Notes & Observations
+- [List any UI glitches, layout shifts, or functional bugs here]
+
+## 4. Final Verification
+- [ ] Confirmed on real iPhone hardware.
+- [ ] Upload fallback remains functional.
+- [ ] Matches requirements in [IOS_CAPTURE_REQUIREMENTS.md](../product/IOS_CAPTURE_REQUIREMENTS.md).

--- a/docs/product/IOS_CAPTURE_REQUIREMENTS.md
+++ b/docs/product/IOS_CAPTURE_REQUIREMENTS.md
@@ -93,7 +93,7 @@ Reasons:
 
 ## 6. QA Evidence Required For #113
 
-Before commercial launch QA can call iOS capture ready, record:
+Before commercial launch QA can call iOS capture ready, use the [iPhone Safari Camera Smoke Report Template](../operations/IPHONE_SAFARI_CAMERA_SMOKE_REPORT.md) and record:
 
 - iPhone model and iOS version
 - Safari version or iOS version proxy
@@ -129,6 +129,6 @@ If these are incomplete, keep #113 open or record a conditional go / no-go.
 
 Recommended next sequence:
 
-1. `qa: run iPhone Safari camera capture smoke test`
+1. `qa: run iPhone Safari camera capture smoke test` (using the [smoke report template](../operations/IPHONE_SAFARI_CAMERA_SMOKE_REPORT.md))
 2. `ux: polish camera permission and fallback copy`
 3. `design: decide PWA vs native iOS release path`


### PR DESCRIPTION
Added a focused iPhone Safari camera/upload smoke report template for commercial launch QA #113. Included cross-links in README and iOS capture requirements.

Fixes #183

---
*PR created automatically by Jules for task [7411948097895740098](https://jules.google.com/task/7411948097895740098) started by @ksc0000*