### PR TITLE
ux: add user data export and deletion guidance

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -829,6 +829,9 @@ function App() {
             </div>
             <div className="nail-detail-body">
               <h2 id="data-mgmt-title" className="nail-detail-title">ヘルプとデータ管理</h2>
+              <p className="help-text">
+                登録されたデータはお客様自身のものであり、いつでもエクスポートや削除を行うことができます。
+              </p>
               <div className="nail-detail-section">
                 <h3 className="nail-detail-label">データのエクスポート</h3>
                 <p className="help-text">


### PR DESCRIPTION
This PR adds explicit guidance for user data export and deletion in the Data Management Modal, as part of the Phase 7 Release Preparation.

Key changes:
- Inserted a lead paragraph in the `isDataModalOpen` modal in `src/App.tsx` stating that users own their data and can export or delete it at any time.
- Verified that existing sections for "Data Export" and "Data Deletion" provide the necessary details (CSV/JSON export and individual item deletion) to meet the acceptance criteria.

Verification:
- Frontend verification performed via a Playwright script and screenshot.
- Full validation suite (`lint`, `build`, `test`) passed successfully.

Fixes #190

---
*PR created automatically by Jules for task [14407130935506101183](https://jules.google.com/task/14407130935506101183) started by @ksc0000*