### PR TITLE
Enhance input validation for tags and title

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,7 +11,13 @@ import {
 } from './lib/publicShares'
 import type { PublicShareDocWithId, PublicShareItemSnapshot } from './lib/publicShares'
 import { uploadNailImage, deleteNailImage } from './lib/storage'
-import { MAX_NAIL_TAG_LENGTH, MAX_NAIL_TAGS, parseNailTags } from './lib/nailTags'
+import {
+  MAX_NAIL_TAG_LENGTH,
+  MAX_NAIL_TAGS,
+  MAX_NAIL_TITLE_LENGTH,
+  parseNailTags,
+  validateNailTitle,
+} from './lib/nailTags'
 import ErrorBanner from './components/ErrorBanner'
 import PrivacyPolicyPage from './components/PrivacyPolicyPage'
 import TermsOfServicePage from './components/TermsOfServicePage'
@@ -441,6 +447,11 @@ function App() {
 
   const handleSubmitNailItem = async () => {
     if (!user || nailTitle.trim() === '') return
+    const titleErr = validateNailTitle(nailTitle.trim())
+    if (titleErr) {
+      setNailError(titleErr)
+      return
+    }
     if (nailImageFile) {
       const err = validateImageFile(nailImageFile)
       if (err) { setNailError(err); return }
@@ -907,12 +918,13 @@ function App() {
               onChange={e => setNailTitle(e.target.value)}
               placeholder="Title *"
               className="nail-input"
+              maxLength={MAX_NAIL_TITLE_LENGTH}
             />
             <input
               type="text"
               value={nailTags}
               onChange={e => setNailTags(e.target.value)}
-              placeholder="Tags (comma separated, max 12)"
+              placeholder="Tags (comma separated, max 10)"
               className="nail-input"
             />
             <p className="nail-input-note">

--- a/src/lib/nailTags.ts
+++ b/src/lib/nailTags.ts
@@ -1,9 +1,17 @@
-export const MAX_NAIL_TAGS = 12
-export const MAX_NAIL_TAG_LENGTH = 24
+export const MAX_NAIL_TAGS = 10
+export const MAX_NAIL_TAG_LENGTH = 20
+export const MAX_NAIL_TITLE_LENGTH = 50
 
 export interface NailTagParseResult {
   tags: string[]
   error: string
+}
+
+export const validateNailTitle = (title: string): string => {
+  if (title.length > MAX_NAIL_TITLE_LENGTH) {
+    return `タイトルは${MAX_NAIL_TITLE_LENGTH}文字以内にしてください。`
+  }
+  return ''
 }
 
 export const parseNailTags = (value: string): NailTagParseResult => {

--- a/tests/nailTags.test.ts
+++ b/tests/nailTags.test.ts
@@ -3,7 +3,9 @@ import { test } from 'node:test'
 import {
   MAX_NAIL_TAG_LENGTH,
   MAX_NAIL_TAGS,
+  MAX_NAIL_TITLE_LENGTH,
   parseNailTags,
+  validateNailTitle,
 } from '../src/lib/nailTags.ts'
 
 test('parseNailTags trims, removes hash prefixes, and drops duplicates', () => {
@@ -22,4 +24,14 @@ test('parseNailTags rejects tags that are too long', () => {
   const result = parseNailTags(value)
   assert.deepEqual(result.tags, [])
   assert.match(result.error, /文字以内/)
+})
+
+test('validateNailTitle accepts valid title', () => {
+  assert.equal(validateNailTitle('Valid Title'), '')
+})
+
+test('validateNailTitle rejects too long title', () => {
+  const value = 'a'.repeat(MAX_NAIL_TITLE_LENGTH + 1)
+  const result = validateNailTitle(value)
+  assert.match(result, /文字以内/)
 })


### PR DESCRIPTION
Enhanced client-side validation for nail items. 
- Title is now limited to 50 characters, enforced via `maxLength` and a validation check on submission.
- Tags are limited to 10, and each tag is limited to 20 characters.
- Error messages are displayed to the user if validation fails.
- Unit tests in `tests/nailTags.test.ts` have been updated and expanded to cover these rules.

Fixes #189

---
*PR created automatically by Jules for task [14415954589979703191](https://jules.google.com/task/14415954589979703191) started by @ksc0000*