### PR TITLE
docs: update QA roadmap and iPhone smoke template

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,8 @@ export default defineConfig([
 | [docs/operations/LOCAL_DEVELOPMENT_MANUAL.md](docs/operations/LOCAL_DEVELOPMENT_MANUAL.md) | Step-by-step local development guide including VS Code Tunnel |
 | [docs/operations/COMMERCIAL_LAUNCH_QA_REPORT.md](docs/operations/COMMERCIAL_LAUNCH_QA_REPORT.md) | Reusable QA result template for Issue #113 commercial launch |
 | [docs/operations/PRODUCTION_FIREBASE_PREFLIGHT.md](docs/operations/PRODUCTION_FIREBASE_PREFLIGHT.md) | Production Firebase preflight checklist for project, auth, rules, and rollback readiness |
+| [docs/operations/IPHONE_SAFARI_CAMERA_SMOKE_REPORT.md](docs/operations/IPHONE_SAFARI_CAMERA_SMOKE_REPORT.md) | Focused iPhone Safari camera/upload smoke report template for Issue #113 |
+| [docs/operations/BUNDLE_SIZE_WARNING_ACCEPTANCE.md](docs/operations/BUNDLE_SIZE_WARNING_ACCEPTANCE.md) | Documented acceptance of current production bundle size for commercial MVP |
 | [docs/operations/FIRESTORE_SECURITY_RULES.md](docs/operations/FIRESTORE_SECURITY_RULES.md) | Firestore Security Rules design, phase plan, and deploy checklist |
 | [docs/operations/PUBLIC_SHARING_PRIVACY.md](docs/operations/PUBLIC_SHARING_PRIVACY.md) | Public share links, shared/excluded fields, revoke behavior, and privacy notes |
 | [docs/operations/FIREBASE_SETUP.md](docs/operations/FIREBASE_SETUP.md) | Firebase Auth setup and verification steps |

--- a/docs/operations/IPHONE_SAFARI_CAMERA_SMOKE_REPORT.md
+++ b/docs/operations/IPHONE_SAFARI_CAMERA_SMOKE_REPORT.md
@@ -1,0 +1,42 @@
+# iPhone Safari Camera Smoke Report Template (Issue #113)
+
+> Focused smoke report template for iPhone Safari camera and upload behavior.
+> Use this before completing the full [Commercial Launch QA Report](./COMMERCIAL_LAUNCH_QA_REPORT.md).
+
+## 1. Environment Details
+
+- **iPhone Model:** [e.g., iPhone 15 Pro]
+- **iOS Version:** [e.g., 17.4.1]
+- **Mode:** [Safari / PWA standalone]
+- **Orientation:** [Portrait / Landscape]
+- **Tester:** [Name]
+- **Date:** [YYYY-MM-DD]
+- **URL / Commit:** [Production URL or SHA]
+
+## 2. Smoke Test Checklist
+
+| Test Case | Result | Notes / Evidence |
+|---|---|---|
+| Camera button opens system camera/source picker | [Pass/Fail] | |
+| Capture photo and confirm | [Pass/Fail] | |
+| Picker cancel leaves form stable | [Pass/Fail] | |
+| Album/upload fallback opens photo library/files | [Pass/Fail] | |
+| Select existing photo | [Pass/Fail] | |
+| Image preview renders correctly | [Pass/Fail] | |
+| Remove selected image works | [Pass/Fail] | |
+| Replace image with new capture works | [Pass/Fail] | |
+| Add or update item successfully | [Pass/Fail] | |
+| Image is visible in list card | [Pass/Fail] | |
+| Saved item opens in detail viewer | [Pass/Fail] | |
+| Saved item can be used in comparison view | [Pass/Fail] | |
+| No horizontal overflow or hidden controls | [Pass/Fail] | |
+
+## 3. Failure Notes
+
+- [List UI glitches, layout shifts, permission issues, or functional bugs here]
+
+## 4. Final Verification
+
+- [ ] Confirmed on real iPhone hardware.
+- [ ] Upload fallback remains functional.
+- [ ] Matches [iOS Capture Requirements](../product/IOS_CAPTURE_REQUIREMENTS.md).

--- a/docs/product/IOS_CAPTURE_REQUIREMENTS.md
+++ b/docs/product/IOS_CAPTURE_REQUIREMENTS.md
@@ -93,7 +93,9 @@ Reasons:
 
 ## 6. QA Evidence Required For #113
 
-Before commercial launch QA can call iOS capture ready, record:
+Before commercial launch QA can call iOS capture ready, use the
+[iPhone Safari Camera Smoke Report Template](../operations/IPHONE_SAFARI_CAMERA_SMOKE_REPORT.md)
+and record:
 
 - iPhone model and iOS version
 - Safari version or iOS version proxy
@@ -129,6 +131,6 @@ If these are incomplete, keep #113 open or record a conditional go / no-go.
 
 Recommended next sequence:
 
-1. `qa: run iPhone Safari camera capture smoke test`
+1. `qa: run iPhone Safari camera capture smoke test` using the [smoke report template](../operations/IPHONE_SAFARI_CAMERA_SMOKE_REPORT.md)
 2. `ux: polish camera permission and fallback copy`
 3. `design: decide PWA vs native iOS release path`

--- a/docs/product/ROADMAP.md
+++ b/docs/product/ROADMAP.md
@@ -17,8 +17,8 @@
 | Phase 2 | Data Persistence | ✅ 完了 |
 | Phase 3 | Authentication / User Management | ✅ 完了 |
 | Phase 4 | AI-Assisted Features | 🔲 未着手 |
-| Phase 4.5 | Nail View / Camera Foundation | 🔲 推奨 next |
-| Phase 5 | Review / Export / Sharing | 🟡 進行中 |
+| Phase 4.5 | Nail View / Camera Foundation | 🟡 進行中 |
+| Phase 5 | Review / Export / Sharing | ✅ 完了 |
 | Phase 6 | Security / Operations Hardening | 🟡 進行中 |
 | Phase 7 | Release Preparation | 🟡 進行中 |
 | Phase 8 | 3D Preview / Modeling Foundation | 🔲 未着手 |
@@ -209,9 +209,9 @@
 
 ### Example Issues
 
-- [ ] CSV / JSON エクスポート
-- [ ] コレクション振り返り画面（月別・タグ別）
-- [ ] 共有 URL / 公開コレクション機能
+- [x] CSV / JSON エクスポート
+- [x] コレクション振り返り画面（月別・タグ別）
+- [x] 共有 URL / 公開コレクション機能
 
 ### 完了済みサブセット
 
@@ -242,8 +242,8 @@
 
 ### Example Issues
 
-- [ ] セキュリティヘッダーの設定（CSP 等）
-- [ ] 入力バリデーションの強化（tags 件数制限 UI 等）
+- [x] セキュリティヘッダーの設定（CSP 等）
+- [x] 入力バリデーションの強化（tags 件数制限 UI 等）
 - [ ] エラーログ / 監視の整備
 - [ ] 依存関係の脆弱性スキャン
 
@@ -276,10 +276,10 @@
 
 ### Remaining Issues
 
-- [ ] Privacy Policy / Terms routes and visible links
-- [ ] User data export and deletion guidance
-- [ ] Security headers / CSP
-- [ ] Bundle size warning reduction or documented acceptance
+- [x] Privacy Policy / Terms routes and visible links
+- [x] User data export and deletion guidance
+- [x] Security headers / CSP
+- [x] Bundle size warning reduction or documented acceptance
 - [ ] Full manual QA and go/no-go decision
 
 ### References
@@ -293,7 +293,7 @@
 - [ ] カスタムドメイン設定（broader commercial expansion 前に推奨）
 - [ ] 本番ビルド最適化（code splitting 等）
 - [ ] アクセス解析 / モニタリング設定（MVP では defer）
-- [ ] README の最終整備
+- [x] README の最終整備
 
 ### Human Gates
 


### PR DESCRIPTION
## Summary
- Add an iPhone Safari camera/upload smoke report template for #113
- Link the template from iOS capture requirements and README
- Update roadmap status after merged QA prep and hardening work

## Validation
- git diff --check
- npm test
- npm run lint
- npm run build

## Replaces
- Replaces conflicted Jules PR #187
- Replaces conflicted Jules PR #188

Fixes #183
Fixes #184

## Notes
- Build still emits the known Vite >500 kB chunk warning.
- No Firebase rules, deployment, secrets, or dependencies changed.