### PR TITLE
docs: add monitoring and error logging decision note

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ export default defineConfig([
 | [docs/operations/IMAGE_UPLOAD_QA.md](docs/operations/IMAGE_UPLOAD_QA.md) | QA checklist for image upload — normal, error, edit, delete, and pre-merge checks |
 | [docs/operations/SECURITY_HEADERS_DECISION.md](docs/operations/SECURITY_HEADERS_DECISION.md) | Security headers decision note for the commercial MVP |
 | [docs/operations/SECURITY_HEADERS_GUIDE.md](docs/operations/SECURITY_HEADERS_GUIDE.md) | Technical guide for security headers and CSP configuration |
+| [docs/operations/MONITORING_ERROR_LOGGING_DECISION.md](docs/operations/MONITORING_ERROR_LOGGING_DECISION.md) | Monitoring and error logging decision note for the commercial MVP |
 
 ### Design References
 

--- a/docs/operations/MONITORING_ERROR_LOGGING_DECISION.md
+++ b/docs/operations/MONITORING_ERROR_LOGGING_DECISION.md
@@ -1,0 +1,50 @@
+# Monitoring and Error Logging Decision - Commercial MVP
+
+## Status
+- [x] Recommended for MVP (Manual Monitoring)
+- [ ] Deferred for Post-MVP (Automated SDKs)
+
+## Overview
+This document records the decision regarding monitoring and error logging for the Nailous commercial MVP. The goal is to balance operational visibility with the need for a lean, dependency-free initial launch.
+
+## Comparison: MVP Deferral vs. Lightweight Monitoring
+
+| Aspect | MVP Deferral (Current) | Automated Monitoring (Post-MVP) |
+|--------|------------------------|----------------------------------|
+| **Setup Cost** | Zero (Built-in) | High (SDK integration, config) |
+| **Maintenance** | Minimal | Ongoing (Updates, alert tuning) |
+| **Granularity** | Coarse (Service-level) | Fine (User-trace level) |
+| **Real-time** | Delayed/Manual | Near-instant alerts |
+
+## Decision
+For the commercial MVP, we will **defer the integration of third-party monitoring SDKs** (e.g., Sentry, LogRocket, Datadog) to avoid increasing bundle size and privacy complexity. Instead, we will rely on **lightweight manual monitoring** via the Firebase Console and built-in service logs.
+
+## Critical Launch Monitoring Targets
+During and immediately after launch, the following areas must be monitored manually:
+
+1. **Authentication Failures**:
+   - Monitor Firebase Auth console for unusual sign-in failure rates.
+   - Verify Google OAuth provider status.
+2. **CRUD & Upload Failures**:
+   - Check Firestore usage metrics and error rates.
+   - Monitor Cloud Storage for upload failures or quota issues.
+3. **Public Sharing Issues**:
+   - Verify `publicShares` collection for unexpected growth or access errors.
+   - Monitor for "404 Not Found" or "403 Forbidden" on share links.
+4. **Deployment & Rollback**:
+   - Monitor Firebase Hosting for successful deploys.
+   - Be ready to trigger a rollback in the Firebase Console if critical UI regressions are reported.
+
+## Default MVP Stance
+- **No additional SDKs**: Maintain zero external monitoring dependencies.
+- **Service Dashboard Review**: Human operators should check Firebase service health dashboards daily during the first week of launch.
+- **User Feedback Loop**: Rely on direct user reports (e.g., via the support email mentioned in the Data Management modal) for client-side JavaScript errors.
+
+## Post-MVP Human Decisions Needed
+Transitioning to automated monitoring will require explicit human approval on:
+- **Vendor Selection**: Choosing between Sentry, Google Cloud Monitoring, or others.
+- **Privacy Impact**: Updating the Privacy Policy to reflect data collection by monitoring services.
+- **Performance Budget**: Assessing the impact of monitoring SDKs on the production bundle size.
+
+---
+Refer to [PRODUCTION_RELEASE_RUNBOOK.md](./PRODUCTION_RELEASE_RUNBOOK.md) for rollback procedures.

--- a/docs/product/ROADMAP.md
+++ b/docs/product/ROADMAP.md
@@ -244,7 +244,7 @@
 
 - [x] セキュリティヘッダーの設定（CSP 等）
 - [x] 入力バリデーションの強化（tags 件数制限 UI 等）
-- [ ] エラーログ / 監視の整備
+- [x] エラーログ / 監視の整備（[MONITORING_ERROR_LOGGING_DECISION.md](../operations/MONITORING_ERROR_LOGGING_DECISION.md)）
 - [ ] 依存関係の脆弱性スキャン
 
 ### Human Gates


### PR DESCRIPTION
Added a decision note documenting the lightweight manual monitoring strategy for the commercial MVP. Updated the roadmap and README to reflect this addition.

Fixes #197

---
*PR created automatically by Jules for task [11774924875371370657](https://jules.google.com/task/11774924875371370657) started by @ksc0000*