### PR TITLE
docs: add dependency vulnerability scan note

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ export default defineConfig([
 | [docs/operations/IMAGE_UPLOAD_QA.md](docs/operations/IMAGE_UPLOAD_QA.md) | QA checklist for image upload — normal, error, edit, delete, and pre-merge checks |
 | [docs/operations/SECURITY_HEADERS_DECISION.md](docs/operations/SECURITY_HEADERS_DECISION.md) | Security headers decision note for the commercial MVP |
 | [docs/operations/SECURITY_HEADERS_GUIDE.md](docs/operations/SECURITY_HEADERS_GUIDE.md) | Technical guide for security headers and CSP configuration |
+| [docs/operations/DEPENDENCY_VULNERABILITY_SCAN.md](docs/operations/DEPENDENCY_VULNERABILITY_SCAN.md) | Dependency vulnerability scan process for commercial MVP release |
 
 ### Design References
 

--- a/docs/operations/DEPENDENCY_VULNERABILITY_SCAN.md
+++ b/docs/operations/DEPENDENCY_VULNERABILITY_SCAN.md
@@ -1,0 +1,42 @@
+# Dependency Vulnerability Scan
+
+This document describes the process for performing dependency vulnerability scans as part of the commercial MVP release preparation for Nailous.
+
+## Overview
+
+Regularly scanning dependencies for known vulnerabilities is critical for maintaining the security of the application. For the commercial MVP, we use `npm audit` to identify and document vulnerabilities.
+
+## Running the Scan
+
+To perform a vulnerability scan, run the following command in the project root:
+
+```bash
+npm audit
+```
+
+**Note:** Do not run `npm audit fix` or upgrade dependencies without explicit human approval. This document is for scanning and recording findings only.
+
+## Recording Findings
+
+All identified vulnerabilities must be recorded in the table below before release.
+
+### Vulnerability Log Template
+
+| Date | Dependency | Severity | Vulnerability / Advisory URL | Accepted Risk? | Follow-up Issue / Action |
+|------|------------|----------|-----------------------------|----------------|--------------------------|
+| YYYY-MM-DD | | | | Yes/No | |
+
+### Assessment Criteria
+
+- **Severity:** As reported by `npm audit` (Low, Moderate, High, Critical).
+- **Accepted Risk:** Can this vulnerability be deferred? (e.g., it only affects the build tool and not the production bundle).
+- **Follow-up Action:** Plan for mitigation (e.g., "Upgrade in Phase 7", "Wait for upstream fix").
+
+## Release Gate
+
+For the commercial MVP release, all "High" and "Critical" vulnerabilities must either be resolved or have a documented "Accepted Risk" justification approved by a human operator.
+
+## References
+
+- [PRODUCTION_RELEASE_RUNBOOK.md](./PRODUCTION_RELEASE_RUNBOOK.md)
+- [SECURITY_HEADERS_DECISION.md](./SECURITY_HEADERS_DECISION.md)

--- a/docs/product/ROADMAP.md
+++ b/docs/product/ROADMAP.md
@@ -245,7 +245,7 @@
 - [x] セキュリティヘッダーの設定（CSP 等）
 - [x] 入力バリデーションの強化（tags 件数制限 UI 等）
 - [ ] エラーログ / 監視の整備
-- [ ] 依存関係の脆弱性スキャン
+- [ ] 依存関係の脆弱性スキャン ([docs/operations/DEPENDENCY_VULNERABILITY_SCAN.md](../operations/DEPENDENCY_VULNERABILITY_SCAN.md))
 
 ### Human Gates
 


### PR DESCRIPTION
Added a documentation note for dependency vulnerability scans using npm audit, including a process for recording findings and assessment criteria for the commercial MVP release.

Fixes #198

---
*PR created automatically by Jules for task [17539745372158531539](https://jules.google.com/task/17539745372158531539) started by @ksc0000*