### PR TITLE
feat: gate AI tag suggestion behind env flag

### DIFF
--- a/docs/operations/PRODUCTION_FIREBASE_PREFLIGHT.md
+++ b/docs/operations/PRODUCTION_FIREBASE_PREFLIGHT.md
@@ -23,6 +23,10 @@ This checklist must be completed and approved by a human operator before any pro
     - `VITE_FIREBASE_STORAGE_BUCKET`
     - `VITE_FIREBASE_MESSAGING_SENDER_ID`
     - `VITE_FIREBASE_APP_ID`
+- [ ] Confirm whether AI tag suggestion is enabled for this release:
+    - `VITE_ENABLE_AI_TAG_SUGGESTION=false` or unset for the default commercial MVP path.
+    - `VITE_ENABLE_AI_TAG_SUGGESTION=true` only after the AI production gate is approved.
+- [ ] If AI tag suggestion is enabled, confirm Firebase AI / Gemini backend, billing, privacy policy coverage, and rollback plan.
 
 ## 4. Auth Providers
 - [ ] Confirm Google Auth is enabled in the production Firebase Console.

--- a/docs/product/PRODUCT_SPEC.md
+++ b/docs/product/PRODUCT_SPEC.md
@@ -163,7 +163,7 @@ interface NailItem {
 **決定事項:**
 - `thumbnailUrl` を `imageUrl` と別フィールドで保持 — モバイルリスト表示でフル解像度は重い。将来 Cloud Storage Resize Extension で自動生成可能。
 - `memo` を追加 — サロン名・価格・シーンのメモニーズに対応。
-- `color` / AI フィールドはスキップ — Gemini API 連携フェーズ（Phase 4 以降）で追加。
+- `color` / AI フィールドはスキップ — AI タグ提案は既存 `tags` にユーザー確認後の文字列として保存する。
 - `tags` は `string[]` のままで構造化しない — スタイル・色・シーンを自由に分類できる柔軟性を優先。
 
 **アクセスルール（Phase 1 Security Rules 移行後）:**
@@ -173,12 +173,12 @@ interface NailItem {
 
 ## AI Features
 
-現在: AI 支援**開発**ツールとして活用（プロダクト機能としての AI は未実装）
+現在: 画像から AI タグ提案を行う UI は実装済み。ただし `VITE_ENABLE_AI_TAG_SUGGESTION=true` の時だけ表示・実行される。
 
-商用 MVP: AI タグ提案、OCR、類似推薦は含めず、post-launch 候補として扱います。
+商用 MVP: AI タグ提案を有効化するかは production gate で判断する。既定では無効にし、OCR と類似推薦は post-launch 候補として扱う。
 
 将来候補:
-- [ ] AI によるネイルタグ自動提案（色・スタイル分析）
+- [x] AI によるネイルタグ自動提案（色・スタイル分析）
 - [ ] 画像からサロン名・価格を自動読み取り（OCR）
 - [ ] 類似ネイル推薦
 

--- a/docs/product/ROADMAP.md
+++ b/docs/product/ROADMAP.md
@@ -177,7 +177,7 @@
 - [x] design: plan camera capture flow
 - [x] feature: add upload/camera source distinction
 - [x] design: plan nail/hand detection pipeline
-- [ ] feature: add AI nail tag suggestion from image
+- [x] feature: add AI nail tag suggestion from image
 - [x] design: plan iOS capture requirements
 - [x] design: decide PWA vs native iOS release path
 
@@ -188,6 +188,7 @@
 - G3: `imageSource` / `manualRegions` / `analysis` 等の Firestore schema 追加
 - G6: カメラ・ユーザー写真・AI 画像解析のプライバシー方針
 - G7: 外部 AI API キーが必要な場合
+- G15: commercial MVP で AI tag suggestion を有効化するかの production gate
 - G8: 画像処理 / ML / camera helper library 追加
 
 ### Done Criteria
@@ -195,7 +196,7 @@
 - [ ] NailItem の画像 detail viewer が既存データで動作する
 - [ ] 画像比較の最小 UX がスマートフォン幅で破綻しない
 - [ ] カメラ/アップロード source の方針が docs にまとまっている
-- [ ] AI tag suggestion / nail detection / iOS capture の判断材料が docs にまとまっている
+- [x] AI tag suggestion / nail detection / iOS capture の判断材料が docs にまとまっている
 - [ ] 既存の NailItem CRUD / upload / share 機能を壊していない
 - [ ] `npm run build` が成功している
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,6 +19,7 @@ import {
   validateNailTitle,
 } from './lib/nailTags'
 import { fileToGenerativePart, urlToGenerativePart, generateNailTagsFromImage } from './lib/aiUtils'
+import { isAiTagSuggestionEnabled } from './lib/featureFlags'
 import ErrorBanner from './components/ErrorBanner'
 import PrivacyPolicyPage from './components/PrivacyPolicyPage'
 import TermsOfServicePage from './components/TermsOfServicePage'
@@ -448,6 +449,10 @@ function App() {
   }
 
   const handleGenerateTagsWithAI = async () => {
+    if (!isAiTagSuggestionEnabled) {
+      setNailError('AIタグ生成は現在無効です。')
+      return
+    }
     try {
       setIsAIGeneratingTags(true)
       setNailError('')
@@ -962,7 +967,7 @@ function App() {
             <p className="nail-input-note">
               タグはカンマ区切りで最大{MAX_NAIL_TAGS}個、1つ{MAX_NAIL_TAG_LENGTH}文字まで。
             </p>
-            {(nailImageFile || editingItem?.imageUrl) && (
+            {isAiTagSuggestionEnabled && (nailImageFile || editingItem?.imageUrl) && (
               <button
                 type="button"
                 className="ai-tag-btn"
@@ -1005,9 +1010,11 @@ function App() {
                 </label>
               </div>
               <p className="nail-file-note">カメラが起動しない場合は、アルバムから画像を選択してください。</p>
-              <p className="nail-file-privacy-note">
-                写真は非公開で保存されます。「AIでタグを生成」ボタンを押した場合のみ、画像が一時的にAIによる解析へ送信されます（AIの学習には使用されません）。
-              </p>
+              {isAiTagSuggestionEnabled && (
+                <p className="nail-file-privacy-note">
+                  写真は非公開で保存されます。「AIでタグを生成」ボタンを押した場合のみ、画像が一時的にAIによる解析へ送信されます（AIの学習には使用されません）。
+                </p>
+              )}
               {nailImageFile && nailImagePreview && (
                 <div className="nail-file-preview-area">
                   <img

--- a/src/lib/aiUtils.ts
+++ b/src/lib/aiUtils.ts
@@ -1,4 +1,4 @@
-import { generativeModel } from './firebase'
+import { app } from './firebase'
 
 export async function fileToGenerativePart(file: File): Promise<{ inlineData: { data: string, mimeType: string } }> {
   const base64EncodedDataPromise = new Promise<string>((resolve) => {
@@ -40,6 +40,14 @@ export async function urlToGenerativePart(url: string): Promise<{ inlineData: { 
 
 export async function generateNailTagsFromImage(imagePart: { inlineData: { data: string, mimeType: string } }): Promise<string> {
   const prompt = "この画像を解析して、ネイルのスタイル、色、デザインに関する特徴を最大5つ、カンマ区切りで出力してください。出力はタグの文字列のみとし、前置きや説明は不要です。例: ピンク, フレンチ, ラメ, 夏, シンプル"
+  const { getAI, getGenerativeModel, GoogleAIBackend } = await import('firebase/ai')
+  const ai = getAI(app, { backend: new GoogleAIBackend() })
+  const generativeModel = getGenerativeModel(ai, {
+    model: 'gemini-2.5-flash-lite',
+    generationConfig: {
+      temperature: 0.7,
+    },
+  })
   
   const result = await generativeModel.generateContent([prompt, imagePart])
   const response = await result.response

--- a/src/lib/featureFlags.ts
+++ b/src/lib/featureFlags.ts
@@ -1,0 +1,1 @@
+export const isAiTagSuggestionEnabled = import.meta.env.VITE_ENABLE_AI_TAG_SUGGESTION === 'true'

--- a/src/lib/firebase.ts
+++ b/src/lib/firebase.ts
@@ -2,7 +2,6 @@ import { initializeApp } from 'firebase/app'
 import { getAuth } from 'firebase/auth'
 import { getFirestore } from 'firebase/firestore'
 import { getStorage } from 'firebase/storage'
-import { getAI, getGenerativeModel, GoogleAIBackend } from 'firebase/ai'
 
 const firebaseConfig = {
   apiKey: import.meta.env.VITE_FIREBASE_API_KEY,
@@ -13,17 +12,8 @@ const firebaseConfig = {
   appId: import.meta.env.VITE_FIREBASE_APP_ID,
 }
 
-const app = initializeApp(firebaseConfig)
+export const app = initializeApp(firebaseConfig)
 
 export const auth = getAuth(app)
 export const db = getFirestore(app)
 export const storage = getStorage(app)
-
-// Initialize AI Logic (Gemini Developer API)
-export const ai = getAI(app, { backend: new GoogleAIBackend() })
-export const generativeModel = getGenerativeModel(ai, {
-  model: 'gemini-2.5-flash-lite',
-  generationConfig: {
-    temperature: 0.7,
-  },
-})


### PR DESCRIPTION
## Summary
- Gate AI tag suggestion behind `VITE_ENABLE_AI_TAG_SUGGESTION=true`
- Stop initializing Firebase AI during normal app startup; load `firebase/ai` only when the gated action runs
- Update product and Firebase preflight docs so commercial MVP defaults to AI disabled until the production gate is approved

## Validation
- `npm test`
- `npm run lint`
- `npm run build`

## Notes
- No deploy command was run.
- No Firebase rules, secrets, `package.json`, or `src/main.tsx` changes.
- `npm run build` still emits the existing Vite chunk-size warning.
