### PR TITLE
feat: surface missing Firebase config

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -71,6 +71,11 @@
   background: rgba(255, 255, 255, 0.08);
 }
 
+.auth-signin:disabled {
+  cursor: not-allowed;
+  opacity: 0.55;
+}
+
 .auth-signin:focus-visible {
   outline: 2px solid var(--accent);
   outline-offset: 2px;
@@ -97,6 +102,15 @@
 
 .auth-signin-links a:hover {
   text-decoration: underline;
+}
+
+.auth-config-note {
+  max-width: min(520px, calc(100vw - 40px));
+  margin: 0;
+  color: var(--text-muted);
+  font-size: 0.8rem;
+  line-height: 1.45;
+  text-align: center;
 }
 
 .auth-data-mgmt {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,6 +20,7 @@ import {
 } from './lib/nailTags'
 import { fileToGenerativePart, urlToGenerativePart, generateNailTagsFromImage } from './lib/aiUtils'
 import { isAiTagSuggestionEnabled } from './lib/featureFlags'
+import { isFirebaseConfigComplete, missingFirebaseEnvKeys } from './lib/firebaseConfigStatus'
 import ErrorBanner from './components/ErrorBanner'
 import PrivacyPolicyPage from './components/PrivacyPolicyPage'
 import TermsOfServicePage from './components/TermsOfServicePage'
@@ -176,6 +177,10 @@ const toggleComparisonId = (prevIds: string[], itemId: string): string[] => {
 
 type PublicShareViewState = 'idle' | 'loading' | 'ready' | 'not-found' | 'disabled' | 'error'
 
+const firebaseConfigErrorMessage = missingFirebaseEnvKeys.length > 0
+  ? `Firebase 設定が不足しています: ${missingFirebaseEnvKeys.join(', ')}`
+  : ''
+
 const getPublicShareIdFromPath = (pathname: string): string | null => {
   const m = pathname.match(/^\/share\/([^/]+)\/?$/)
   return m?.[1] ? decodeURIComponent(m[1]) : null
@@ -196,7 +201,9 @@ function App() {
   const isPublicSharePage = sharePathId !== null
   const isPrivacyPage = pathname === '/privacy'
   const isTermsPage = pathname === '/terms'
-  const [user, setUser] = useState<User | null | undefined>(undefined)
+  const [user, setUser] = useState<User | null | undefined>(
+    isFirebaseConfigComplete ? undefined : null
+  )
   const [nailItems, setNailItems] = useState<NailItemDoc[]>([])
   const [nailTitle, setNailTitle] = useState('')
   const [nailTags, setNailTags] = useState('')
@@ -228,6 +235,8 @@ function App() {
   const [publicShareState, setPublicShareState] = useState<PublicShareViewState>(
     isPublicSharePage ? 'loading' : 'idle'
   )
+  const publicShareDisplayState: PublicShareViewState =
+    !isFirebaseConfigComplete && isPublicSharePage ? 'error' : publicShareState
   const uploadInputRef = useRef<HTMLInputElement>(null)
   const cameraInputRef = useRef<HTMLInputElement>(null)
   const dataModalCloseButtonRef = useRef<HTMLButtonElement>(null)
@@ -278,6 +287,7 @@ function App() {
 
   useEffect(() => {
     if (!isPublicSharePage || !sharePathId) return
+    if (!isFirebaseConfigComplete) return
 
     let didCancel = false
 
@@ -305,18 +315,21 @@ function App() {
     return () => { didCancel = true }
   }, [isPublicSharePage, sharePathId])
 
-  useEffect(() => onAuthStateChanged(auth, nextUser => {
-    if (isPublicSharePage) return
-    setUser(nextUser)
-    if (!nextUser) {
-      setNailItems([])
-      setNailItemsUserId(null)
-      setPublicShares([])
-      setPublicSharesUserId(null)
-      setDetailItemId(null)
-      setComparisonItemIds([])
-    }
-  }), [isPublicSharePage])
+  useEffect(() => {
+    if (!isFirebaseConfigComplete) return
+    return onAuthStateChanged(auth, nextUser => {
+      if (isPublicSharePage) return
+      setUser(nextUser)
+      if (!nextUser) {
+        setNailItems([])
+        setNailItemsUserId(null)
+        setPublicShares([])
+        setPublicSharesUserId(null)
+        setDetailItemId(null)
+        setComparisonItemIds([])
+      }
+    })
+  }, [isPublicSharePage])
 
   useEffect(() => {
     if (!isDataModalOpen) return
@@ -721,10 +734,10 @@ function App() {
   }
 
   const renderPublicShareState = () => {
-    if (publicShareState === 'loading') {
+    if (publicShareDisplayState === 'loading') {
       return <p className="public-share-note">Loading shared collection...</p>
     }
-    if (publicShareState === 'not-found') {
+    if (publicShareDisplayState === 'not-found') {
       return (
         <div className="public-share-empty">
           <h2 className="public-share-heading">Shared nail collection</h2>
@@ -733,7 +746,7 @@ function App() {
         </div>
       )
     }
-    if (publicShareState === 'disabled') {
+    if (publicShareDisplayState === 'disabled') {
       return (
         <div className="public-share-empty">
           <h2 className="public-share-heading">Shared nail collection</h2>
@@ -742,11 +755,13 @@ function App() {
         </div>
       )
     }
-    if (publicShareState === 'error') {
+    if (publicShareDisplayState === 'error') {
       return (
         <div className="public-share-empty">
           <h2 className="public-share-heading">Shared nail collection</h2>
-          <p className="public-share-note">We could not load this shared collection right now.</p>
+          <p className="public-share-note">
+            {firebaseConfigErrorMessage || 'We could not load this shared collection right now.'}
+          </p>
           <a className="public-share-link" href="/">Back to home</a>
         </div>
       )
@@ -840,7 +855,12 @@ function App() {
   return (
     <section id="center">
       <h1 id="app-title">Nailous</h1>
-      <ErrorBanner message={bannerError} onClose={() => setBannerError('')} />
+      <ErrorBanner
+        message={firebaseConfigErrorMessage || bannerError}
+        onClose={() => {
+          if (!firebaseConfigErrorMessage) setBannerError('')
+        }}
+      />
       {detailItem && (
         <NailImageDetailViewer
           item={detailItem}
@@ -934,9 +954,12 @@ function App() {
           <div className="auth-signin-container">
             <button type="button" className="auth-signin" onClick={() => {
               signInWithGoogle().catch((e: unknown) => console.error('sign-in failed', e))
-            }}>
+            }} disabled={!isFirebaseConfigComplete}>
               Sign in with Google
             </button>
+            {!isFirebaseConfigComplete && (
+              <p className="auth-config-note">{firebaseConfigErrorMessage}</p>
+            )}
             <div className="auth-signin-links">
               <a href="/terms" onClick={(e) => handleLinkClick(e, '/terms')}>利用規約</a>
               <span>・</span>

--- a/src/lib/firebaseConfigStatus.ts
+++ b/src/lib/firebaseConfigStatus.ts
@@ -1,0 +1,18 @@
+export const REQUIRED_FIREBASE_ENV_KEYS = [
+  'VITE_FIREBASE_API_KEY',
+  'VITE_FIREBASE_AUTH_DOMAIN',
+  'VITE_FIREBASE_PROJECT_ID',
+  'VITE_FIREBASE_STORAGE_BUCKET',
+  'VITE_FIREBASE_MESSAGING_SENDER_ID',
+  'VITE_FIREBASE_APP_ID',
+] as const
+
+export type FirebaseEnvKey = typeof REQUIRED_FIREBASE_ENV_KEYS[number]
+
+type FirebaseEnv = Partial<Record<FirebaseEnvKey, string | undefined>>
+
+export const getMissingFirebaseEnvKeys = (env: FirebaseEnv = {}): FirebaseEnvKey[] =>
+  REQUIRED_FIREBASE_ENV_KEYS.filter(key => !env[key]?.trim())
+
+export const missingFirebaseEnvKeys = getMissingFirebaseEnvKeys(import.meta.env)
+export const isFirebaseConfigComplete = missingFirebaseEnvKeys.length === 0

--- a/tests/nailTags.test.ts
+++ b/tests/nailTags.test.ts
@@ -7,6 +7,10 @@ import {
   parseNailTags,
   validateNailTitle,
 } from '../src/lib/nailTags.ts'
+import {
+  getMissingFirebaseEnvKeys,
+  REQUIRED_FIREBASE_ENV_KEYS,
+} from '../src/lib/firebaseConfigStatus.ts'
 
 test('parseNailTags trims, removes hash prefixes, and drops duplicates', () => {
   assert.deepEqual(parseNailTags(' pink, #gel, Pink, , art ').tags, ['pink', 'gel', 'art'])
@@ -34,4 +38,15 @@ test('validateNailTitle rejects too long title', () => {
   const value = 'a'.repeat(MAX_NAIL_TITLE_LENGTH + 1)
   const result = validateNailTitle(value)
   assert.match(result, /文字以内/)
+})
+
+test('getMissingFirebaseEnvKeys reports blank and missing config values', () => {
+  const env = Object.fromEntries(REQUIRED_FIREBASE_ENV_KEYS.map(key => [key, 'configured']))
+  env.VITE_FIREBASE_API_KEY = ''
+  delete env.VITE_FIREBASE_APP_ID
+
+  assert.deepEqual(getMissingFirebaseEnvKeys(env), [
+    'VITE_FIREBASE_API_KEY',
+    'VITE_FIREBASE_APP_ID',
+  ])
 })


### PR DESCRIPTION
## Summary
- Add a shared Firebase env readiness helper for required Vite config keys
- Disable Google sign-in and show a clear configuration message when required Firebase env values are missing
- Show a clear public-share error instead of leaving deploy/config failures ambiguous
- Add coverage for missing/blank Firebase env detection

## Validation
- `npm test`
- `npm run lint`
- `npm run build`

## Notes
- No Firebase deploy command was run.
- No Firebase rules, secrets, `package.json`, workflows, or `src/main.tsx` changes.
- `npm run build` still emits the existing Vite chunk-size warning.
