### PR TITLE
ux: improve share link copy fallback

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -652,35 +652,27 @@ function App() {
     setShareError('')
     setShareStatusMessage('')
 
-    if (!navigator.clipboard?.writeText) {
-      setShareError('Clipboard API is not available in this browser.')
-      return
-    }
-
-    try {
-      await navigator.clipboard.writeText(shareUrl)
-      setShareStatusMessage('Share link copied to clipboard.')
-    } catch (e: unknown) {
-      const message = e instanceof Error ? e.message : 'Failed to copy share link.'
-      setShareError(message)
-    }
+    await copyShareUrl(shareUrl)
   }
 
   const handleCopyManagedShareLink = async (managedShareId: string) => {
     setShareError('')
     setShareStatusMessage('')
 
+    await copyShareUrl(getShareUrl(managedShareId))
+  }
+
+  const copyShareUrl = async (url: string) => {
     if (!navigator.clipboard?.writeText) {
-      setShareError('Clipboard API is not available in this browser.')
+      setShareStatusMessage('コピー機能が使えないため、表示されているURLを選択してコピーしてください。')
       return
     }
 
     try {
-      await navigator.clipboard.writeText(getShareUrl(managedShareId))
+      await navigator.clipboard.writeText(url)
       setShareStatusMessage('リンクをコピーしました。')
-    } catch (e: unknown) {
-      const message = e instanceof Error ? e.message : '共有リンクのコピーに失敗しました。'
-      setShareError(message)
+    } catch {
+      setShareStatusMessage('自動コピーできませんでした。表示されているURLを選択してコピーしてください。')
     }
   }
 


### PR DESCRIPTION
## Summary
- Reuse one share-link copy helper for current and managed share links
- Replace Clipboard API hard failures with a manual-copy fallback message
- Keep the visible share URL as the fallback path for browsers that block clipboard access

## Validation
- `npm test`
- `npm run lint`
- `npm run build`

## Notes
- No Firebase deploy command was run.
- No Firebase rules, secrets, dependencies, workflows, or `src/main.tsx` changes.
- `npm run build` still emits the existing Vite chunk-size warning.
