### PR TITLE
ux: show auth action errors

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -408,6 +408,26 @@ function App() {
     window.dispatchEvent(new PopStateEvent('popstate'))
   }
 
+  const handleSignIn = async () => {
+    setBannerError('')
+    try {
+      await signInWithGoogle()
+    } catch (e: unknown) {
+      console.error('sign-in failed', e)
+      setBannerError('Google サインインに失敗しました。時間をおいて再度お試しください。')
+    }
+  }
+
+  const handleSignOut = async () => {
+    setBannerError('')
+    try {
+      await signOutUser()
+    } catch (e: unknown) {
+      console.error('sign-out failed', e)
+      setBannerError('サインアウトに失敗しました。時間をおいて再度お試しください。')
+    }
+  }
+
   const handleNailFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0] ?? null
     if (!file) {
@@ -938,15 +958,16 @@ function App() {
             >
               データ管理
             </button>
-            <button type="button" onClick={() => {
-              signOutUser().catch((e: unknown) => console.error('sign-out failed', e))
-            }}>Sign out</button>
+            <button type="button" onClick={handleSignOut}>Sign out</button>
           </div>
         ) : (
           <div className="auth-signin-container">
-            <button type="button" className="auth-signin" onClick={() => {
-              signInWithGoogle().catch((e: unknown) => console.error('sign-in failed', e))
-            }} disabled={!isFirebaseConfigComplete}>
+            <button
+              type="button"
+              className="auth-signin"
+              onClick={handleSignIn}
+              disabled={!isFirebaseConfigComplete}
+            >
               Sign in with Google
             </button>
             {!isFirebaseConfigComplete && (


### PR DESCRIPTION
## Summary
- Show user-facing banner messages when Google sign-in or sign-out fails
- Keep detailed auth errors in the console while avoiding raw provider errors in the UI
- Replace inline auth catch handlers with focused action helpers

## Validation
- `npm test`
- `npm run lint`
- `npm run build`

## Notes
- No Firebase deploy command was run.
- No Firebase rules, secrets, dependencies, workflows, or `src/main.tsx` changes.
- `npm run build` still emits the existing Vite chunk-size warning.
