### PR TITLE
chore: align Nailous branding and URL guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,18 @@
-# React + TypeScript + Vite
+# Nailous
 
-This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
+Nailous is a Firebase-backed personal nail archive for saving nail photos, tags, and notes, then reviewing or sharing selected collections.
+
+Commercial MVP release direction:
+
+- App name: `Nailous`
+- Production host: Firebase Hosting
+- Recommended production Firebase project ID: `nailous-prod`
+- Initial Firebase Hosting URL: `https://nailous-prod.web.app`
+- Custom domain: decide and configure after the domain is acquired and DNS ownership can be verified
+
+## Development
+
+This app uses React, TypeScript, Vite, and Firebase.
 
 Currently, two official plugins are available:
 

--- a/docs/operations/PRODUCTION_FIREBASE_PREFLIGHT.md
+++ b/docs/operations/PRODUCTION_FIREBASE_PREFLIGHT.md
@@ -6,6 +6,7 @@ This checklist must be completed and approved by a human operator before any pro
 
 ## 1. Project Setup
 - [ ] Confirm the current Firebase project is the **Production** project (e.g., `nailous-prod`).
+- [ ] Confirm the production Firebase project name and Hosting site use the `nailous` brand.
 - [ ] Verify that no development or staging data exists in the production Firestore/Storage.
 - [ ] Ensure the billing account is active and limits are set if necessary.
 
@@ -30,7 +31,7 @@ This checklist must be completed and approved by a human operator before any pro
 
 ## 4. Auth Providers
 - [ ] Confirm Google Auth is enabled in the production Firebase Console.
-- [ ] Verify that the production URL (and custom domain) is added to the "Authorized domains" list in Firebase Auth settings.
+- [ ] Verify that `nailous-prod.web.app`, `nailous-prod.firebaseapp.com`, and the custom domain if used are added to the "Authorized domains" list in Firebase Auth settings.
 
 ## 5. Firestore & Storage Rules
 - [ ] Review `firestore.rules` for production readiness (no open access, user-specific locks).
@@ -41,6 +42,7 @@ This checklist must be completed and approved by a human operator before any pro
     ```
 
 ## 6. Custom Domain (Optional)
+- [ ] Decide the launch domain. Recommended order: `nailous.app`, `nailous.jp`, then a practical fallback such as `nailous-nail.app` if the shorter domains are unavailable.
 - [ ] If using a custom domain, confirm DNS records are propagated.
 - [ ] Verify SSL certificate status in the Firebase Hosting console.
 

--- a/docs/operations/PRODUCTION_RELEASE_RUNBOOK.md
+++ b/docs/operations/PRODUCTION_RELEASE_RUNBOOK.md
@@ -5,8 +5,12 @@ Do not run production deploy commands without explicit human approval.
 
 ## Approved Release Direction
 
+- App name: Nailous
 - Hosting: Firebase Hosting
 - Firebase projects: separate development and production projects
+- Recommended production project id: `nailous-prod`
+- Initial production URL: `https://nailous-prod.web.app`
+- Preferred custom domain: a short `nailous` domain after human purchase and DNS verification
 - Deploy owner: human operator
 - CI deploy automation: deferred for MVP
 - MVP scope: personal nail archive with Auth, CRUD, image upload, export, public sharing, and policy links
@@ -36,6 +40,7 @@ npm run lint
 The following Firebase Hosting URLs are expected for the commercial MVP:
 
 - **Production URL:** `https://<project-id>.web.app` (or custom domain if configured). This is the primary entry point for users after a human-approved deploy.
+- **Recommended Nailous production URL:** `https://nailous-prod.web.app` until a custom domain is connected.
 - **Preview Channel URL:** `https://<project-id>--<channel-id>-<hash>.web.app`. These are optional URLs generated for feature testing and must not be shared as the production link.
 
 ## Deploy Procedure

--- a/docs/operations/PRODUCTION_SMOKE_TEST_CHECKLIST.md
+++ b/docs/operations/PRODUCTION_SMOKE_TEST_CHECKLIST.md
@@ -6,7 +6,9 @@ For formal commercial launch QA recording, use the [Commercial Launch QA Report 
 
 ## Release Context
 
+- App name: Nailous
 - Production host: Firebase Hosting
+- Recommended production URL: `https://nailous-prod.web.app`
 - Production Firebase project: separate from development
 - Deploy owner: human operator
 - Deploy approval: explicit human approval required

--- a/docs/product/PRODUCT_SPEC.md
+++ b/docs/product/PRODUCT_SPEC.md
@@ -195,6 +195,10 @@ interface NailItem {
 | バックエンド | Firebase（Auth / Firestore / Storage） | 確定 |
 | デプロイ先 | Firebase Hosting | 確定 |
 | Firebase project 方針 | development / production を分離 | 確定 |
+| アプリ名 | Nailous | 確定 |
+| 推奨 production Firebase project ID | `nailous-prod` | 暫定確定 |
+| 初期 production URL | `https://nailous-prod.web.app` | production project 作成後に確定 |
+| カスタムドメイン | `nailous` 関連ドメインを取得後、Firebase Hosting に接続 | human gate |
 | 本番 deploy | human 承認後のみ実行 | 確定 |
 | 対応ブラウザ | モダンブラウザ（Chrome / Safari / Firefox 最新版） | 暫定 |
 | 画像ファイル制限 | jpeg / png / webp、5MB 以下 | 確定 |

--- a/index.html
+++ b/index.html
@@ -4,7 +4,11 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>agent-sandbox</title>
+    <meta
+      name="description"
+      content="Nailous is a personal nail archive for saving, reviewing, and sharing nail photos, tags, and notes."
+    />
+    <title>Nailous</title>
   </head>
   <body>
     <div id="root"></div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "agent-sandbox",
+  "name": "nailous",
   "version": "0.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "agent-sandbox",
+      "name": "nailous",
       "version": "0.0.0",
       "dependencies": {
         "firebase": "^12.12.1",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "agent-sandbox",
+  "name": "nailous",
   "private": true,
   "version": "0.0.0",
   "type": "module",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -254,7 +254,7 @@ function App() {
     let createdMeta: HTMLMetaElement | null = null
 
     if (isPublicSharePage) {
-      document.title = 'Shared nail collection'
+      document.title = 'Shared collection | Nailous'
     } else if (isPrivacyPage) {
       document.title = 'プライバシーポリシー | Nailous'
     } else if (isTermsPage) {
@@ -761,7 +761,7 @@ function App() {
     if (publicShareDisplayState === 'not-found') {
       return (
         <div className="public-share-empty">
-          <h2 className="public-share-heading">Shared nail collection</h2>
+          <h2 className="public-share-heading">Shared Nailous collection</h2>
           <p className="public-share-note">This shared collection could not be found.</p>
           <a className="public-share-link" href="/">Back to home</a>
         </div>
@@ -770,7 +770,7 @@ function App() {
     if (publicShareDisplayState === 'disabled') {
       return (
         <div className="public-share-empty">
-          <h2 className="public-share-heading">Shared nail collection</h2>
+          <h2 className="public-share-heading">Shared Nailous collection</h2>
           <p className="public-share-note">This shared collection is no longer available.</p>
           <a className="public-share-link" href="/">Back to home</a>
         </div>
@@ -779,7 +779,7 @@ function App() {
     if (publicShareDisplayState === 'error') {
       return (
         <div className="public-share-empty">
-          <h2 className="public-share-heading">Shared nail collection</h2>
+          <h2 className="public-share-heading">Shared Nailous collection</h2>
           <p className="public-share-note">
             {firebaseConfigErrorMessage || 'We could not load this shared collection right now.'}
           </p>
@@ -792,7 +792,7 @@ function App() {
     return (
       <div id="public-share-page">
         <div className="public-share-header">
-          <p className="public-share-kicker">Shared nail collection</p>
+          <p className="public-share-kicker">Shared Nailous collection</p>
           <h2 className="public-share-heading">{publicShare.title}</h2>
           <p className="public-share-note">
             {publicShare.items.length} items shared. This page is read-only and does not include memo or image data.
@@ -1183,7 +1183,7 @@ function App() {
                     type="button"
                     className="btn-export"
                     onClick={() => downloadTextFile(
-                      `nail-report-export-${getExportDateStamp()}.csv`,
+                      `nailous-export-${getExportDateStamp()}.csv`,
                       toCsv(nailItems),
                       'text/csv;charset=utf-8;'
                     )}
@@ -1193,7 +1193,7 @@ function App() {
                     type="button"
                     className="btn-export"
                     onClick={() => downloadTextFile(
-                      `nail-report-export-${getExportDateStamp()}.json`,
+                      `nailous-export-${getExportDateStamp()}.json`,
                       toJson(nailItems),
                       'application/json'
                     )}


### PR DESCRIPTION
## Summary

- Align app metadata and package name with the Nailous product name.
- Update public-share copy and export filenames to use Nailous.
- Record the recommended `nailous-prod` Firebase project and initial Hosting URL guidance in release docs.

## Validation

- npm test
- npm run lint
- npm run build
- bash scripts/qa-preflight.sh

## Related

- Opens/links follow-up human gate: #226