### PR TITLE
docs: finalize Nailous initial production URL decision

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ Commercial MVP release direction:
 
 - App name: `Nailous`
 - Production host: Firebase Hosting
-- Recommended production Firebase project ID: `nailous-prod`
-- Initial Firebase Hosting URL: `https://nailous-prod.web.app`
-- Custom domain: decide and configure after the domain is acquired and DNS ownership can be verified
+- Production Firebase project ID: `nailous-prod`
+- Launch Firebase Hosting URL: `https://nailous-prod.web.app`
+- Custom domain: deferred until after the commercial MVP launch, unless a human operator acquires and verifies a `nailous` domain before go/no-go
 
 ## Development
 

--- a/docs/operations/COMMERCIAL_LAUNCH_QA_REPORT.md
+++ b/docs/operations/COMMERCIAL_LAUNCH_QA_REPORT.md
@@ -4,7 +4,9 @@ This report template is for recording the QA results for the commercial launch o
 Copy this template into a new PR or issue comment when performing QA.
 
 ## QA Environment
-- **URL:** [e.g., https://nailous-production.web.app]
+- **Planned production URL:** https://nailous-prod.web.app
+- **Custom domain:** Deferred for the commercial MVP initial release unless a human operator acquires and verifies a Nailous domain before go/no-go.
+- **Tested URL:** [Actual production or approved preview URL]
 - **Tester:** [Name]
 - **Date:** [YYYY-MM-DD]
 - **Build/Commit:** [SHA or version]

--- a/docs/operations/PRODUCTION_FIREBASE_PREFLIGHT.md
+++ b/docs/operations/PRODUCTION_FIREBASE_PREFLIGHT.md
@@ -5,7 +5,7 @@ This checklist must be completed and approved by a human operator before any pro
 **DO NOT PROCEED with production deploy without explicit human approval.**
 
 ## 1. Project Setup
-- [ ] Confirm the current Firebase project is the **Production** project (e.g., `nailous-prod`).
+- [ ] Confirm the current Firebase project is the **Production** project: `nailous-prod`.
 - [ ] Confirm the production Firebase project name and Hosting site use the `nailous` brand.
 - [ ] Verify that no development or staging data exists in the production Firestore/Storage.
 - [ ] Ensure the billing account is active and limits are set if necessary.
@@ -42,9 +42,10 @@ This checklist must be completed and approved by a human operator before any pro
     ```
 
 ## 6. Custom Domain (Optional)
-- [ ] Decide the launch domain. Recommended order: `nailous.app`, `nailous.jp`, then a practical fallback such as `nailous-nail.app` if the shorter domains are unavailable.
+- [ ] Commercial MVP initial release uses `https://nailous-prod.web.app` unless a custom domain is human-approved before go/no-go.
+- [ ] If using a custom domain later, recommended order is `nailous.app`, `nailous.jp`, then a practical fallback such as `nailous-nail.app` if the shorter domains are unavailable.
 - [ ] If using a custom domain, confirm DNS records are propagated.
-- [ ] Verify SSL certificate status in the Firebase Hosting console.
+- [ ] If using a custom domain, verify SSL certificate status in the Firebase Hosting console.
 
 ## 7. Rollback Readiness
 - [ ] Identify the "last known good" version in the Hosting history.

--- a/docs/operations/PRODUCTION_RELEASE_RUNBOOK.md
+++ b/docs/operations/PRODUCTION_RELEASE_RUNBOOK.md
@@ -8,9 +8,9 @@ Do not run production deploy commands without explicit human approval.
 - App name: Nailous
 - Hosting: Firebase Hosting
 - Firebase projects: separate development and production projects
-- Recommended production project id: `nailous-prod`
+- Production project id: `nailous-prod`
 - Initial production URL: `https://nailous-prod.web.app`
-- Preferred custom domain: a short `nailous` domain after human purchase and DNS verification
+- Custom domain: deferred until after the commercial MVP launch unless a human operator completes purchase and DNS verification before go/no-go
 - Deploy owner: human operator
 - CI deploy automation: deferred for MVP
 - MVP scope: personal nail archive with Auth, CRUD, image upload, export, public sharing, and policy links
@@ -40,7 +40,7 @@ npm run lint
 The following Firebase Hosting URLs are expected for the commercial MVP:
 
 - **Production URL:** `https://<project-id>.web.app` (or custom domain if configured). This is the primary entry point for users after a human-approved deploy.
-- **Recommended Nailous production URL:** `https://nailous-prod.web.app` until a custom domain is connected.
+- **Nailous initial production URL:** `https://nailous-prod.web.app` until a custom domain is connected after launch.
 - **Preview Channel URL:** `https://<project-id>--<channel-id>-<hash>.web.app`. These are optional URLs generated for feature testing and must not be shared as the production link.
 
 ## Deploy Procedure

--- a/docs/operations/PRODUCTION_SMOKE_TEST_CHECKLIST.md
+++ b/docs/operations/PRODUCTION_SMOKE_TEST_CHECKLIST.md
@@ -8,7 +8,8 @@ For formal commercial launch QA recording, use the [Commercial Launch QA Report 
 
 - App name: Nailous
 - Production host: Firebase Hosting
-- Recommended production URL: `https://nailous-prod.web.app`
+- Initial production URL: `https://nailous-prod.web.app`
+- Custom domain: deferred for the commercial MVP initial release unless separately human-approved
 - Production Firebase project: separate from development
 - Deploy owner: human operator
 - Deploy approval: explicit human approval required

--- a/docs/product/PRODUCT_SPEC.md
+++ b/docs/product/PRODUCT_SPEC.md
@@ -196,9 +196,9 @@ interface NailItem {
 | デプロイ先 | Firebase Hosting | 確定 |
 | Firebase project 方針 | development / production を分離 | 確定 |
 | アプリ名 | Nailous | 確定 |
-| 推奨 production Firebase project ID | `nailous-prod` | 暫定確定 |
-| 初期 production URL | `https://nailous-prod.web.app` | production project 作成後に確定 |
-| カスタムドメイン | `nailous` 関連ドメインを取得後、Firebase Hosting に接続 | human gate |
+| production Firebase project ID | `nailous-prod` | 確定 |
+| 初期 production URL | `https://nailous-prod.web.app` | production project 作成後に使用 |
+| カスタムドメイン | 商用 MVP 初回リリースでは defer。`nailous` 関連ドメイン取得後に Firebase Hosting へ接続 | post-launch / human gate |
 | 本番 deploy | human 承認後のみ実行 | 確定 |
 | 対応ブラウザ | モダンブラウザ（Chrome / Safari / Firefox 最新版） | 暫定 |
 | 画像ファイル制限 | jpeg / png / webp、5MB 以下 | 確定 |

--- a/docs/product/ROADMAP.md
+++ b/docs/product/ROADMAP.md
@@ -272,6 +272,8 @@
 - [x] プロダクト定義・対象ユーザー・問題設定決定
 - [x] 本番デプロイ先を Firebase Hosting に決定
 - [x] development / production Firebase project 分離方針決定
+- [x] 初期 production URL 方針決定（`https://nailous-prod.web.app`）
+- [x] カスタムドメインは商用 MVP 初回リリースでは defer
 - [x] 本番 release runbook 作成
 - [x] 本番 smoke test checklist 作成
 
@@ -291,11 +293,11 @@
 ### Example Issues
 
 - [x] デプロイ先の決定（Firebase Hosting）
-- [ ] カスタムドメイン設定（broader commercial expansion 前に推奨）
+- [x] カスタムドメイン設定方針決定（商用 MVP 初回リリースでは defer）
 - [ ] 本番ビルド最適化（code splitting 等）
 - [ ] アクセス解析 / モニタリング設定（MVP では defer）
 - [x] README の最終整備
-- [ ] Record final production/preview URLs in `COMMERCIAL_LAUNCH_QA_REPORT.md` and this roadmap.
+- [x] Record final initial production URL direction in `COMMERCIAL_LAUNCH_QA_REPORT.md` and this roadmap.
 
 ### Human Gates
 


### PR DESCRIPTION
## Summary

- Finalize the commercial MVP initial production URL as `https://nailous-prod.web.app`.
- Record `nailous-prod` as the production Firebase project ID in release docs.
- Defer custom domain setup for the initial MVP launch unless separately human-approved before go/no-go.
- Update the commercial QA report template and roadmap to reflect the decision.

## Validation

- npm test
- npm run lint
- npm run build
- bash scripts/qa-preflight.sh

## Related

- Resolves #226