### PR TITLE
docs: add 3D asset delivery strategy

### DIFF
--- a/docs/product/3D_ASSET_DELIVERY_STRATEGY.md
+++ b/docs/product/3D_ASSET_DELIVERY_STRATEGY.md
@@ -1,0 +1,109 @@
+# 3D Asset Delivery Strategy
+
+This document records the planned delivery strategy for future 3D nail assets in Phase 8 and Phase 9. It is a design document only. No 3D assets, Firebase rules changes, or runtime dependencies are introduced by this document.
+
+## Goals
+
+- Keep the commercial MVP launch independent from 3D/AR work.
+- Prepare a clear asset format and storage direction before implementation begins.
+- Avoid licensing, file size, and Firebase rules surprises when Phase 8 starts.
+
+## Supported Formats
+
+| Format | Use | Notes |
+|---|---|---|
+| GLB | Primary browser-rendered model format | Preferred because geometry, materials, and textures can be bundled into one file |
+| KTX2 / compressed textures | Future texture optimization | Use only after tooling is approved |
+| USDZ | Future iOS AR Quick Look support | Optional Phase 9 asset, not required for the first 3D preview |
+
+GLB is the default for Phase 8. USDZ should be added only if the product direction includes native iOS AR preview or Safari AR Quick Look.
+
+## Proposed Storage Layout
+
+3D assets should be separate from user-uploaded nail photos.
+
+```text
+assets/3d/
+  models/
+    shapes/
+    decorations/
+    presets/
+  textures/
+    materials/
+  thumbnails/
+  LICENSE_CREDITS.md
+```
+
+This path is proposed for future Firebase Storage or Hosting use. The exact deployment target should be confirmed before any assets are uploaded.
+
+## Size And Optimization Targets
+
+| Asset | Target | Hard Limit Before Review |
+|---|---:|---:|
+| Single nail shape GLB | <= 1 MB | 3 MB |
+| Decoration GLB | <= 500 KB | 1 MB |
+| Texture | <= 1024 px square | 2048 px square |
+| Thumbnail | <= 200 KB | 500 KB |
+
+Optimization requirements before adding assets:
+
+- Remove unused meshes, cameras, lights, and animation tracks.
+- Prefer mobile-friendly polygon counts.
+- Compress textures before shipping.
+- Version static filenames, for example `almond_v1.glb`, so long-lived cache headers can be used later.
+- Record source, license, author, and modification notes in `LICENSE_CREDITS.md`.
+
+## Licensing Rules
+
+Allowed without additional legal review:
+
+- Original assets created for Nailous.
+- CC0 assets.
+- MIT or similarly permissive assets when the license text and attribution requirements are recorded.
+
+Requires human/legal review:
+
+- CC-BY assets that need attribution UI.
+- Marketplace assets with unclear redistribution rights.
+- Any asset with non-commercial, no-derivatives, editorial-only, or AI-training restrictions.
+
+Do not commit or upload third-party 3D assets until license and size checks are complete.
+
+## Firebase And Access Model
+
+The expected product behavior is that base 3D assets are public, static product assets, while user nail photos remain private owner-scoped data unless explicitly shared.
+
+Implementation rules:
+
+- Do not change `firestore.rules` or `storage.rules` without human approval.
+- Do not upload 3D assets to production Firebase without human approval.
+- If assets are stored in Firebase Storage, create a rules design and Rules Playground cases before deploy.
+- If assets are served from Firebase Hosting, document cache headers in `firebase.json` before deploy.
+
+## Firestore References
+
+Future `NailItem` documents may reference 3D presets, but the current commercial MVP schema must remain unchanged.
+
+Potential future fields:
+
+```ts
+interface NailItem3DFields {
+  shape?: string
+  color?: string
+  texture?: string
+  modelUrl?: string
+  materialPreset?: string
+}
+```
+
+These fields require a separate schema design, UI design, and human approval before implementation.
+
+## Phase 8 Entry Criteria
+
+Before implementation starts:
+
+- [ ] Human confirms Phase 8 priority after commercial MVP launch.
+- [ ] 3D rendering dependency is approved if required.
+- [ ] At least one test GLB has documented ownership or license.
+- [ ] Asset size and optimization checks are complete.
+- [ ] Firebase delivery path and security rules impact are reviewed.

--- a/docs/product/PRODUCT_SPEC.md
+++ b/docs/product/PRODUCT_SPEC.md
@@ -223,6 +223,7 @@ interface NailItem {
 | ドキュメント | 内容 |
 |---|---|
 | [ROADMAP.md](./ROADMAP.md) | 開発ロードマップ |
+| [3D_ASSET_DELIVERY_STRATEGY.md](./3D_ASSET_DELIVERY_STRATEGY.md) | 3D アセット配信戦略 |
 | [ACCEPTANCE_CRITERIA.md](./ACCEPTANCE_CRITERIA.md) | タスク完了基準 |
 | [HUMAN_GATES.md](../harness/HUMAN_GATES.md) | 人間確認が必要な条件 |
 | [PRODUCTION_RELEASE_RUNBOOK.md](../operations/PRODUCTION_RELEASE_RUNBOOK.md) | 本番リリース手順 |

--- a/docs/product/ROADMAP.md
+++ b/docs/product/ROADMAP.md
@@ -326,7 +326,7 @@
 - [ ] 3D プレビュー画面の実装（形状・カラー・テクスチャのプリセット選択）
 - [ ] NailItem への将来フィールド追加検討（`shape` / `color` / `texture` / `modelUrl` / `materialPreset`）
 - [ ] Firestore スキーマ拡張設計（マイグレーション戦略）
-- [ ] 3D アセットのライセンス・サイズ・配信戦略の確定
+- [x] 3D アセットのライセンス・サイズ・配信戦略の確定（[3D_ASSET_DELIVERY_STRATEGY.md](./3D_ASSET_DELIVERY_STRATEGY.md)）
 
 ### Human Gates
 
@@ -397,5 +397,6 @@
 | ドキュメント | 内容 |
 |---|---|
 | [PRODUCT_SPEC.md](./PRODUCT_SPEC.md) | プロダクト仕様 |
+| [3D_ASSET_DELIVERY_STRATEGY.md](./3D_ASSET_DELIVERY_STRATEGY.md) | 3D アセット配信戦略 |
 | [ACCEPTANCE_CRITERIA.md](./ACCEPTANCE_CRITERIA.md) | タスク完了基準 |
 | [HUMAN_GATES.md](../harness/HUMAN_GATES.md) | 人間確認が必要な条件 |


### PR DESCRIPTION
## Summary

- Add a Phase 8/9 3D asset delivery strategy for Nailous.
- Define GLB-first format guidance, proposed asset layout, size targets, licensing checks, and Firebase/human-gate constraints.
- Link the strategy from the product spec and roadmap.

## Validation

- npm test
- npm run lint
- npm run build
- bash scripts/qa-preflight.sh

## Related

- Resolves #212
- Supersedes draft PR #213