### PR TITLE
docs: add code splitting strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ export default defineConfig([
 | [docs/operations/PRODUCTION_FIREBASE_PREFLIGHT.md](docs/operations/PRODUCTION_FIREBASE_PREFLIGHT.md) | Production Firebase preflight checklist for project, auth, rules, and rollback readiness |
 | [docs/operations/IPHONE_SAFARI_CAMERA_SMOKE_REPORT.md](docs/operations/IPHONE_SAFARI_CAMERA_SMOKE_REPORT.md) | Focused iPhone Safari camera/upload smoke report template for Issue #113 |
 | [docs/operations/BUNDLE_SIZE_WARNING_ACCEPTANCE.md](docs/operations/BUNDLE_SIZE_WARNING_ACCEPTANCE.md) | Documented acceptance of current production bundle size for commercial MVP |
+| [docs/operations/CODE_SPLITTING_STRATEGY.md](docs/operations/CODE_SPLITTING_STRATEGY.md) | Current lazy-loading state and future bundle optimization strategy |
 | [docs/operations/FIRESTORE_SECURITY_RULES.md](docs/operations/FIRESTORE_SECURITY_RULES.md) | Firestore Security Rules design, phase plan, and deploy checklist |
 | [docs/operations/PUBLIC_SHARING_PRIVACY.md](docs/operations/PUBLIC_SHARING_PRIVACY.md) | Public share links, shared/excluded fields, revoke behavior, and privacy notes |
 | [docs/operations/FIREBASE_SETUP.md](docs/operations/FIREBASE_SETUP.md) | Firebase Auth setup and verification steps |

--- a/docs/operations/CODE_SPLITTING_STRATEGY.md
+++ b/docs/operations/CODE_SPLITTING_STRATEGY.md
@@ -1,0 +1,59 @@
+# Code Splitting Strategy
+
+This document records the current bundle-splitting state and the next optimization path for Nailous.
+
+## Current State
+
+The commercial MVP still emits Vite's 500 KB chunk-size warning:
+
+```text
+dist/assets/index-*.js 594 kB+
+```
+
+This warning is accepted for the initial MVP in [BUNDLE_SIZE_WARNING_ACCEPTANCE.md](./BUNDLE_SIZE_WARNING_ACCEPTANCE.md), but the app already uses targeted lazy loading to reduce the initial bundle.
+
+Already split with `React.lazy` and `Suspense`:
+
+- `PrivacyPolicyPage`
+- `TermsOfServicePage`
+- `NailImageDetailViewer`
+- `NailComparisonPanel`
+
+The main remaining contributor is the core authenticated app surface in `App.tsx`, plus Firebase SDK code required for Auth, Firestore, Storage, and public share workflows.
+
+## MVP Policy
+
+- The current warning does not block the commercial MVP.
+- Do not add new dependencies only to chase the warning.
+- Do not change Firebase behavior or security rules as part of bundle optimization.
+- Continue to validate with `npm run build` and `scripts/qa-preflight.sh`.
+
+## Next Optimization Candidates
+
+| Priority | Candidate | Expected Benefit | Risk |
+|---|---|---|---|
+| P1 | Extract public share page into a lazy page component | Keeps signed-out public-share flow smaller and clearer | Low |
+| P1 | Extract authenticated collection page into a dedicated component | Makes future lazy boundaries easier | Medium, because it touches core CRUD UI |
+| P2 | Split data management modal into a lazy component | Small initial bundle reduction | Low |
+| P2 | Dynamically import AI tag generation utilities only when feature flag is enabled | Prevents AI code from affecting default MVP path | Medium, because feature flag behavior must stay exact |
+| P3 | Manual vendor chunking for Firebase modules | May improve cache behavior | Medium/high, because output behavior can shift across Vite/Rolldown versions |
+| P3 | Future 3D/AR preview lazy boundary | Essential before Phase 8/9 ships | Low if added before 3D code enters main bundle |
+
+## Recommended Sequence
+
+1. Keep the MVP warning accepted until full manual QA and launch.
+2. After launch, extract the public share page and authenticated collection page from `App.tsx`.
+3. Re-run `npm run build` and compare generated chunk sizes.
+4. Only consider manual vendor chunking if app-owned component extraction does not reduce the initial payload enough.
+5. Require any future 3D, AR, OCR, or AI-heavy feature to enter through a lazy boundary from the first PR.
+
+## Verification Checklist
+
+Before merging future code-splitting work:
+
+- [ ] `npm run build` passes.
+- [ ] `npm run lint` passes.
+- [ ] `npm test` passes if shared logic moved.
+- [ ] `scripts/qa-preflight.sh` passes or only reports the accepted bundle warning.
+- [ ] `/`, `/privacy`, `/terms`, and `/share/{shareId}` still route correctly.
+- [ ] Google Auth, NailItem CRUD, image upload, public share create/view/revoke, CSV/JSON export still work.

--- a/docs/product/ROADMAP.md
+++ b/docs/product/ROADMAP.md
@@ -294,7 +294,7 @@
 
 - [x] デプロイ先の決定（Firebase Hosting）
 - [x] カスタムドメイン設定方針決定（商用 MVP 初回リリースでは defer）
-- [ ] 本番ビルド最適化（code splitting 等）
+- [x] 本番ビルド最適化方針の記録（[CODE_SPLITTING_STRATEGY.md](../operations/CODE_SPLITTING_STRATEGY.md)）
 - [ ] アクセス解析 / モニタリング設定（MVP では defer）
 - [x] README の最終整備
 - [x] Record final initial production URL direction in `COMMERCIAL_LAUNCH_QA_REPORT.md` and this roadmap.


### PR DESCRIPTION
## Summary

- Add a code splitting strategy document reflecting the current lazy-loaded components.
- Keep the current bundle-size warning accepted for MVP while recording next optimization candidates.
- Link the strategy from README and the product roadmap.

## Validation

- npm test
- npm run lint
- npm run build
- bash scripts/qa-preflight.sh

## Related

- Resolves #216
- Supersedes draft PR #219