### PR TITLE
feat: add floating nail charm preview

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -679,6 +679,142 @@
   object-fit: contain;
 }
 
+.nail-charm-panel {
+  display: grid;
+  grid-template-columns: minmax(0, 0.8fr) minmax(220px, 1.2fr);
+  gap: 16px;
+  align-items: center;
+  padding: 18px;
+  border-top: 1px solid var(--border);
+  border-bottom: 1px solid var(--border);
+  background:
+    radial-gradient(circle at 20% 20%, rgba(255, 255, 255, 0.12), transparent 26%),
+    linear-gradient(135deg, rgba(255, 255, 255, 0.08), rgba(255, 255, 255, 0.02));
+}
+
+.nail-charm-copy {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.nail-charm-title {
+  margin: 0;
+  color: var(--text-h);
+  font-size: 1.1rem;
+  line-height: 1.35;
+}
+
+.nail-charm-stage {
+  position: relative;
+  min-height: 210px;
+  overflow: hidden;
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  background:
+    radial-gradient(circle at 50% 18%, rgba(255, 255, 255, 0.2), transparent 24%),
+    radial-gradient(circle at 50% 115%, rgba(0, 0, 0, 0.28), transparent 34%),
+    linear-gradient(160deg, #f8f4f5 0%, #d9e0e3 48%, #9aa2a8 100%);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.5);
+}
+
+.nail-charm-orbit {
+  position: absolute;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.35);
+  opacity: 0.7;
+  pointer-events: none;
+}
+
+.nail-charm-orbit--one {
+  width: 170px;
+  height: 56px;
+  left: 50%;
+  top: 45%;
+  transform: translate(-50%, -50%) rotate(-10deg);
+}
+
+.nail-charm-orbit--two {
+  width: 210px;
+  height: 74px;
+  left: 50%;
+  top: 55%;
+  transform: translate(-50%, -50%) rotate(12deg);
+  opacity: 0.4;
+}
+
+.nail-charm-shell {
+  position: absolute;
+  width: 74px;
+  aspect-ratio: 0.48;
+  filter: drop-shadow(0 20px 16px rgba(0, 0, 0, 0.26));
+  animation: nail-charm-float 4.8s ease-in-out infinite;
+}
+
+.nail-charm-shell--left {
+  left: 20%;
+  top: 32%;
+  transform: rotate(-10deg);
+  animation-delay: -1.4s;
+}
+
+.nail-charm-shell--center {
+  left: 50%;
+  top: 23%;
+  width: 86px;
+  transform: translateX(-50%);
+  animation-delay: -0.3s;
+}
+
+.nail-charm-shell--right {
+  right: 18%;
+  top: 36%;
+  transform: rotate(11deg);
+  animation-delay: -2.2s;
+}
+
+.nail-charm-chip {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+  border: 1px solid rgba(255, 255, 255, 0.72);
+  border-radius: 46% 46% 42% 42% / 18% 18% 60% 60%;
+  background: rgba(255, 255, 255, 0.2);
+  box-shadow:
+    inset 0 10px 18px rgba(255, 255, 255, 0.32),
+    inset 0 -18px 22px rgba(0, 0, 0, 0.16);
+}
+
+.nail-charm-image {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  transform: scale(1.8);
+}
+
+.nail-charm-shell--left .nail-charm-image {
+  object-position: 36% 46%;
+}
+
+.nail-charm-shell--center .nail-charm-image {
+  object-position: 50% 48%;
+}
+
+.nail-charm-shell--right .nail-charm-image {
+  object-position: 64% 46%;
+}
+
+.nail-charm-shine {
+  position: absolute;
+  inset: -20% 28% 0 42%;
+  transform: rotate(16deg);
+  background: linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.68), transparent);
+  opacity: 0.6;
+  mix-blend-mode: screen;
+  animation: nail-charm-shine 3.8s ease-in-out infinite;
+}
+
 .nail-detail-no-image {
   min-height: 220px;
   display: flex;
@@ -811,8 +947,54 @@
     min-height: 180px;
   }
 
+  .nail-charm-panel {
+    grid-template-columns: 1fr;
+    padding: 14px;
+  }
+
+  .nail-charm-stage {
+    min-height: 190px;
+  }
+
+  .nail-charm-shell {
+    width: 62px;
+  }
+
+  .nail-charm-shell--center {
+    width: 72px;
+  }
+
   .nail-detail-meta {
     grid-template-columns: 1fr;
+  }
+}
+
+@keyframes nail-charm-float {
+  0%,
+  100% {
+    translate: 0 0;
+  }
+  50% {
+    translate: 0 -10px;
+  }
+}
+
+@keyframes nail-charm-shine {
+  0%,
+  100% {
+    translate: -38px 0;
+    opacity: 0.3;
+  }
+  45% {
+    translate: 34px 0;
+    opacity: 0.72;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .nail-charm-shell,
+  .nail-charm-shine {
+    animation: none;
   }
 }
 

--- a/src/components/NailImageDetailViewer.tsx
+++ b/src/components/NailImageDetailViewer.tsx
@@ -75,6 +75,30 @@ const NailImageDetailViewer: React.FC<NailImageDetailViewerProps> = ({ item, onC
             <div className="nail-detail-no-image">画像なし</div>
           )}
         </div>
+        {item.imageUrl && (
+          <section className="nail-charm-panel" aria-labelledby="nail-charm-title">
+            <div className="nail-charm-copy">
+              <p className="nail-detail-kicker">Nail Charm</p>
+              <h3 id="nail-charm-title" className="nail-charm-title">浮遊ビュー</h3>
+            </div>
+            <div className="nail-charm-stage" aria-hidden="true">
+              <span className="nail-charm-orbit nail-charm-orbit--one" />
+              <span className="nail-charm-orbit nail-charm-orbit--two" />
+              {['left', 'center', 'right'].map((position) => (
+                <div key={position} className={`nail-charm-shell nail-charm-shell--${position}`}>
+                  <div className="nail-charm-chip">
+                    <img
+                      className="nail-charm-image"
+                      src={item.imageUrl}
+                      alt=""
+                    />
+                    <span className="nail-charm-shine" />
+                  </div>
+                </div>
+              ))}
+            </div>
+          </section>
+        )}
         <div className="nail-detail-body">
           <h2 id="nail-detail-title" className="nail-detail-title">
             {item.title}


### PR DESCRIPTION
## Summary

- Add a `Nail Charm` floating preview to the nail detail viewer.
- Reuses the saved nail image as three small floating chip-like charms with shine and gentle motion.
- Adds responsive and reduced-motion styling.

## Product intent

This is the first UI step toward the Nailous Charm System: moving from plain photo storage toward a playful, animated, object-like nail viewing experience.

## Validation

- npm test
- npm run lint
- npm run build
- bash scripts/qa-preflight.sh
- Playwright top-page smoke screenshot

## Related

- Builds on #232