### PR TITLE
feat: redesign signed-out Nailous landing

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -23,6 +23,11 @@
   color: var(--text-h);
 }
 
+.is-signed-out #app-title {
+  align-self: flex-start;
+  margin-left: clamp(0px, 2vw, 24px);
+}
+
 #auth-bar {
   min-height: 40px;
   display: flex;
@@ -121,6 +126,389 @@
 .auth-data-mgmt {
   color: var(--accent) !important;
   font-weight: 600;
+}
+
+.landing-shell {
+  width: 100%;
+  max-width: 1040px;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  text-align: left;
+}
+
+.landing-hero {
+  display: grid;
+  grid-template-columns: minmax(0, 0.9fr) minmax(360px, 1.1fr);
+  min-height: 520px;
+  border-block: 1px solid var(--border);
+}
+
+.landing-copy {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 18px;
+  padding: clamp(28px, 5vw, 64px) clamp(18px, 4vw, 44px);
+  border-right: 1px solid var(--border);
+}
+
+.landing-kicker {
+  width: fit-content;
+  margin: 0;
+  padding: 5px 9px;
+  border: 1px solid var(--accent-border);
+  border-radius: 6px;
+  background: var(--accent-bg);
+  color: var(--accent);
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.landing-title {
+  max-width: 520px;
+  margin: 0;
+  color: var(--text-h);
+  font-size: clamp(2.1rem, 3.4vw, 3rem);
+  line-height: 1.02;
+  letter-spacing: 0;
+}
+
+.landing-title span {
+  display: block;
+}
+
+.landing-lead {
+  max-width: 520px;
+  margin: 0;
+  color: var(--text);
+  font-size: 0.98rem;
+  line-height: 1.85;
+}
+
+.landing-actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 12px;
+}
+
+.landing-signin {
+  min-height: 44px;
+  padding-inline: 22px;
+  border-color: transparent;
+  background: var(--text-h);
+  color: var(--bg);
+  font-weight: 700;
+}
+
+.landing-signin:hover {
+  background: color-mix(in srgb, var(--text-h) 88%, var(--accent));
+}
+
+.landing-action-note {
+  color: var(--text);
+  font-size: 0.82rem;
+}
+
+.landing-showcase {
+  position: relative;
+  min-height: 520px;
+  overflow: hidden;
+  background:
+    linear-gradient(135deg, rgba(255, 255, 255, 0.78), rgba(244, 243, 236, 0.35)),
+    radial-gradient(circle at 80% 18%, rgba(78, 196, 167, 0.16), transparent 34%),
+    radial-gradient(circle at 20% 78%, rgba(255, 128, 161, 0.18), transparent 36%);
+}
+
+.landing-showcase::before,
+.landing-showcase::after {
+  content: '';
+  position: absolute;
+  inset-inline: 0;
+  height: 1px;
+  background: var(--border);
+}
+
+.landing-showcase::before {
+  top: 28%;
+}
+
+.landing-showcase::after {
+  bottom: 22%;
+}
+
+.landing-orbit-base {
+  position: absolute;
+  right: clamp(18px, 6vw, 88px);
+  bottom: 12px;
+  width: min(50vw, 330px);
+  max-width: 70%;
+  opacity: 0.9;
+  filter: drop-shadow(0 28px 28px rgba(47, 33, 67, 0.18));
+}
+
+.landing-charm {
+  position: absolute;
+  width: clamp(90px, 14vw, 150px);
+  aspect-ratio: 0.58;
+  border: 1px solid rgba(255, 255, 255, 0.72);
+  border-radius: 50% 50% 46% 46% / 18% 18% 42% 42%;
+  box-shadow:
+    inset 0 -18px 22px rgba(0, 0, 0, 0.16),
+    inset 0 16px 20px rgba(255, 255, 255, 0.42),
+    0 28px 34px rgba(48, 32, 68, 0.2);
+  transform-origin: center;
+  animation: landing-float 5.5s ease-in-out infinite;
+}
+
+.landing-charm::before {
+  content: '';
+  position: absolute;
+  inset: 9% 12% auto;
+  height: 22%;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.42);
+  filter: blur(1px);
+}
+
+.landing-charm-shine {
+  position: absolute;
+  inset: 13% 22% auto auto;
+  width: 18%;
+  height: 58%;
+  border-radius: 999px;
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.72), transparent);
+  transform: rotate(11deg);
+}
+
+.landing-charm-rose {
+  top: 66px;
+  right: clamp(142px, 24vw, 270px);
+  background:
+    linear-gradient(150deg, rgba(255, 255, 255, 0.48), transparent 24%),
+    linear-gradient(165deg, #ffe2ea, #e64e7a 48%, #721f4d);
+  transform: rotate(-13deg);
+}
+
+.landing-charm-pearl {
+  top: 166px;
+  right: clamp(52px, 12vw, 144px);
+  background:
+    linear-gradient(130deg, rgba(255, 255, 255, 0.68), transparent 26%),
+    linear-gradient(170deg, #fff8e6, #c8f0df 52%, #3d9e90);
+  transform: rotate(9deg);
+  animation-delay: -1.2s;
+}
+
+.landing-charm-ink {
+  top: 256px;
+  right: clamp(190px, 31vw, 352px);
+  background:
+    linear-gradient(145deg, rgba(255, 255, 255, 0.35), transparent 28%),
+    linear-gradient(160deg, #d9d7ff, #5e57c9 48%, #171532);
+  transform: rotate(16deg);
+  animation-delay: -2.4s;
+}
+
+.landing-detection-frame {
+  position: absolute;
+  left: clamp(20px, 5vw, 62px);
+  bottom: 54px;
+  width: min(38vw, 230px);
+  min-width: 168px;
+  padding: 14px;
+  border: 1px solid rgba(8, 6, 13, 0.16);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.68);
+  box-shadow: var(--shadow);
+  display: grid;
+  gap: 10px;
+}
+
+.landing-detection-frame span {
+  display: block;
+  height: 9px;
+  border-radius: 999px;
+  background: linear-gradient(90deg, rgba(170, 59, 255, 0.72), rgba(78, 196, 167, 0.72));
+}
+
+.landing-detection-frame span:nth-child(2) {
+  width: 74%;
+  background: rgba(8, 6, 13, 0.16);
+}
+
+.landing-detection-frame span:nth-child(3) {
+  width: 58%;
+  background: rgba(8, 6, 13, 0.12);
+}
+
+.landing-steps {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+.landing-steps article {
+  min-height: 164px;
+  padding: 20px;
+  background: var(--social-bg);
+}
+
+.landing-steps article + article {
+  border-left: 1px solid var(--border);
+}
+
+.landing-step-index {
+  display: block;
+  margin-bottom: 16px;
+  color: var(--accent);
+  font-family: var(--mono);
+  font-size: 0.72rem;
+}
+
+.landing-steps h3 {
+  margin: 0 0 8px;
+  color: var(--text-h);
+  font-size: 1rem;
+  line-height: 1.2;
+}
+
+.landing-steps p {
+  margin: 0;
+  color: var(--text);
+  font-size: 0.82rem;
+  line-height: 1.65;
+}
+
+@keyframes landing-float {
+  0%,
+  100% {
+    translate: 0 0;
+  }
+  50% {
+    translate: 0 -14px;
+  }
+}
+
+@media (prefers-color-scheme: dark) {
+  .landing-signin {
+    background: #f3f4f6;
+    color: #16171d;
+  }
+
+  .landing-showcase {
+    background:
+      linear-gradient(135deg, rgba(31, 32, 40, 0.94), rgba(22, 23, 29, 0.72)),
+      radial-gradient(circle at 80% 18%, rgba(78, 196, 167, 0.17), transparent 34%),
+      radial-gradient(circle at 20% 78%, rgba(255, 128, 161, 0.14), transparent 36%);
+  }
+
+  .landing-detection-frame {
+    background: rgba(31, 32, 40, 0.76);
+    border-color: rgba(243, 244, 246, 0.14);
+  }
+
+  .landing-detection-frame span:nth-child(2),
+  .landing-detection-frame span:nth-child(3) {
+    background: rgba(243, 244, 246, 0.18);
+  }
+}
+
+@media (max-width: 820px) {
+  .is-signed-out #app-title {
+    align-self: center;
+    margin-left: 0;
+  }
+
+  .landing-hero {
+    grid-template-columns: 1fr;
+    min-height: auto;
+  }
+
+  .landing-copy {
+    border-right: none;
+    border-bottom: 1px solid var(--border);
+  }
+
+  .landing-showcase {
+    min-height: 440px;
+  }
+
+  .landing-orbit-base {
+    width: min(72vw, 290px);
+  }
+
+  .landing-charm {
+    width: clamp(78px, 22vw, 118px);
+  }
+
+  .landing-charm-rose {
+    top: 54px;
+    right: 45%;
+  }
+
+  .landing-charm-pearl {
+    top: 134px;
+    right: 13%;
+  }
+
+  .landing-charm-ink {
+    top: 222px;
+    right: 50%;
+  }
+
+  .landing-detection-frame {
+    width: 48vw;
+    min-width: 162px;
+  }
+
+  .landing-steps {
+    grid-template-columns: 1fr;
+  }
+
+  .landing-steps article {
+    min-height: auto;
+  }
+
+  .landing-steps article + article {
+    border-left: none;
+    border-top: 1px solid var(--border);
+  }
+}
+
+@media (max-width: 480px) {
+  .landing-shell {
+    gap: 18px;
+  }
+
+  .landing-title {
+    font-size: 2rem;
+    line-height: 1.08;
+  }
+
+  .landing-actions {
+    align-items: stretch;
+  }
+
+  .landing-signin {
+    width: 100%;
+  }
+
+  .landing-action-note {
+    width: 100%;
+    text-align: center;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .landing-charm {
+    animation: none;
+  }
 }
 
 #nail-section {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -22,6 +22,7 @@ import { fileToGenerativePart, urlToGenerativePart, generateNailTagsFromImage } 
 import { isAiTagSuggestionEnabled } from './lib/featureFlags'
 import { isFirebaseConfigComplete, missingFirebaseEnvKeys } from './lib/firebaseConfigStatus'
 import ErrorBanner from './components/ErrorBanner'
+import heroImage from './assets/hero.png'
 const PrivacyPolicyPage = lazy(() => import('./components/PrivacyPolicyPage'))
 const TermsOfServicePage = lazy(() => import('./components/TermsOfServicePage'))
 const NailImageDetailViewer = lazy(() => import('./components/NailImageDetailViewer'))
@@ -878,7 +879,7 @@ function App() {
   }
 
   return (
-    <section id="center">
+    <section id="center" className={user ? undefined : 'is-signed-out'}>
       <h1 id="app-title">Nailous</h1>
       <ErrorBanner
         message={firebaseConfigErrorMessage || bannerError}
@@ -962,42 +963,92 @@ function App() {
           </div>
         </div>
       )}
-      <div id="auth-bar">
-        {user === undefined ? null : user ? (
-          <div className="auth-user">
-            <span>{user.displayName ?? user.email}</span>
-            <button
-              type="button"
-              className="auth-data-mgmt"
-              onClick={() => setIsDataModalOpen(true)}
-            >
-              データ管理
-            </button>
-            <button type="button" onClick={handleSignOut} disabled={authActionPending}>
-              {authActionPending ? 'Signing out...' : 'Sign out'}
-            </button>
-          </div>
-        ) : (
-          <div className="auth-signin-container">
-            <button
-              type="button"
-              className="auth-signin"
-              onClick={handleSignIn}
-              disabled={!isFirebaseConfigComplete || authActionPending}
-            >
-              {authActionPending ? 'Signing in...' : 'Sign in with Google'}
-            </button>
-            {!isFirebaseConfigComplete && (
-              <p className="auth-config-note">{firebaseConfigErrorMessage}</p>
-            )}
-            <div className="auth-signin-links">
-              <a href="/terms" onClick={(e) => handleLinkClick(e, '/terms')}>利用規約</a>
-              <span>・</span>
-              <a href="/privacy" onClick={(e) => handleLinkClick(e, '/privacy')}>プライバシーポリシー</a>
+      {user !== null && (
+        <div id="auth-bar">
+          {user === undefined ? null : user ? (
+            <div className="auth-user">
+              <span>{user.displayName ?? user.email}</span>
+              <button
+                type="button"
+                className="auth-data-mgmt"
+                onClick={() => setIsDataModalOpen(true)}
+              >
+                データ管理
+              </button>
+              <button type="button" onClick={handleSignOut} disabled={authActionPending}>
+                {authActionPending ? 'Signing out...' : 'Sign out'}
+              </button>
             </div>
-          </div>
-        )}
-      </div>
+          ) : null}
+        </div>
+      )}
+      {user === null && (
+        <div className="landing-shell" aria-label="Nailous preview">
+          <section className="landing-hero">
+            <div className="landing-copy">
+              <p className="landing-kicker">Nail charm studio</p>
+              <h2 className="landing-title">
+                <span>ネイルを、</span>
+                <span>浮かぶ作品に。</span>
+              </h2>
+              <p className="landing-lead">
+                Nailous はネイル写真をただ保存するだけでなく、形・色・質感を読み取り、
+                共有しやすい美しいビューへ育てていくための場所です。
+              </p>
+              <div className="landing-actions">
+                <button
+                  type="button"
+                  className="auth-signin landing-signin"
+                  onClick={handleSignIn}
+                  disabled={!isFirebaseConfigComplete || authActionPending}
+                >
+                  {authActionPending ? 'Signing in...' : 'Sign in with Google'}
+                </button>
+                <span className="landing-action-note">保存・比較・共有をはじめる</span>
+              </div>
+              {!isFirebaseConfigComplete && (
+                <p className="auth-config-note">{firebaseConfigErrorMessage}</p>
+              )}
+            </div>
+
+            <div className="landing-showcase" aria-hidden="true">
+              <img className="landing-orbit-base" src={heroImage} alt="" />
+              <div className="landing-charm landing-charm-rose">
+                <span className="landing-charm-shine" />
+              </div>
+              <div className="landing-charm landing-charm-pearl">
+                <span className="landing-charm-shine" />
+              </div>
+              <div className="landing-charm landing-charm-ink">
+                <span className="landing-charm-shine" />
+              </div>
+              <div className="landing-detection-frame">
+                <span />
+                <span />
+                <span />
+              </div>
+            </div>
+          </section>
+
+          <section className="landing-steps" aria-label="Nailous experience">
+            <article>
+              <span className="landing-step-index">01</span>
+              <h3>View</h3>
+              <p>チップだけが浮くショーウィンドウのように、写真からネイルの主役感を引き出します。</p>
+            </article>
+            <article>
+              <span className="landing-step-index">02</span>
+              <h3>Detect</h3>
+              <p>輪郭・長さ・艶・立体感を扱えるように、まずは手動補正しやすい検出体験から育てます。</p>
+            </article>
+            <article>
+              <span className="landing-step-index">03</span>
+              <h3>Share</h3>
+              <p>お気に入りのビューをコレクションやSNSへ運びやすい形で整えていきます。</p>
+            </article>
+          </section>
+        </div>
+      )}
       {user && (
         <div id="nail-section">
           <div id="nail-form">


### PR DESCRIPTION
## Summary
- Replaces the signed-out top page with a Nailous-first landing experience inspired by docs/design-references/nail-view-prototype/prototype.html
- Adds a floating nail charm showcase, detection preview, and concise View / Detect / Share experience blocks
- Keeps auth, Firestore, Storage, and legal pages unchanged

## Verification
- npm run lint
- npm run build
- npm test
- bash scripts/qa-preflight.sh (passes with existing JS bundle size warning)
- Playwright screenshots checked at 1280x900 and 390x844

Claude review was not requested or triggered.