### PR TITLE
feat: make home feel like a nail jewelry box

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -128,367 +128,541 @@
   font-weight: 600;
 }
 
+#root:has(.is-signed-out) {
+  width: 100%;
+  border-inline: none;
+  background: #050308;
+}
+
+#center.is-signed-out {
+  min-height: 100svh;
+  padding: 0;
+  gap: 0;
+  overflow: hidden;
+  background:
+    radial-gradient(circle at 50% 42%, rgba(64, 36, 80, 0.42), transparent 34%),
+    radial-gradient(circle at 12% 78%, rgba(236, 64, 122, 0.14), transparent 30%),
+    #050308;
+  color: rgba(255, 255, 255, 0.78);
+}
+
+.is-signed-out #app-title {
+  position: fixed;
+  top: 18px;
+  left: 50%;
+  z-index: 8;
+  margin: 0;
+  translate: -50% 0;
+  color: rgba(255, 255, 255, 0.96);
+  font-size: 1.05rem;
+  font-weight: 300;
+  letter-spacing: 0.38em;
+  text-transform: uppercase;
+  text-shadow: 0 0 24px rgba(236, 64, 122, 0.28);
+}
+
+.is-signed-out .app-footer {
+  display: none;
+}
+
 .landing-shell {
   width: 100%;
-  max-width: 1040px;
+  min-height: 100svh;
+  position: relative;
+  isolation: isolate;
+  text-align: center;
+  overflow: hidden;
+}
+
+.landing-shell::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  z-index: -2;
+  background-image:
+    radial-gradient(circle, rgba(255, 255, 255, 0.66) 0 1px, transparent 1.5px),
+    radial-gradient(circle, rgba(255, 255, 255, 0.38) 0 1px, transparent 1.5px);
+  background-position: 3vw 54vh, 23vw 8vh;
+  background-size: 21vw 24vh, 27vw 31vh;
+  opacity: 0.5;
+}
+
+.landing-shell::after {
+  content: '';
+  position: absolute;
+  left: -10%;
+  right: -10%;
+  bottom: -24%;
+  z-index: -1;
+  height: 42%;
+  border-radius: 50% 50% 0 0;
+  background:
+    radial-gradient(ellipse at 50% 0%, rgba(255, 218, 232, 0.12), transparent 46%),
+    linear-gradient(180deg, rgba(89, 56, 73, 0.52), rgba(18, 8, 20, 0.92));
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.landing-topbar {
+  position: fixed;
+  top: 60px;
+  left: 16px;
+  right: 16px;
+  z-index: 8;
   display: flex;
-  flex-direction: column;
-  gap: 24px;
-  text-align: left;
+  justify-content: space-between;
+  pointer-events: none;
+}
+
+.landing-topbar span,
+.landing-skin-selector span {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 28px;
+  padding: 6px 14px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.06);
+  color: rgba(255, 255, 255, 0.84);
+  font-size: 0.55rem;
+  font-weight: 600;
+  letter-spacing: 0.2em;
+  backdrop-filter: blur(20px);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.08);
 }
 
 .landing-hero {
+  min-height: 100svh;
+  position: relative;
   display: grid;
-  grid-template-columns: minmax(0, 0.9fr) minmax(360px, 1.1fr);
-  min-height: 520px;
-  border-block: 1px solid var(--border);
+  place-items: center;
 }
 
-.landing-copy {
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  gap: 18px;
-  padding: clamp(28px, 5vw, 64px) clamp(18px, 4vw, 44px);
-  border-right: 1px solid var(--border);
+.landing-title-block {
+  position: fixed;
+  top: 38px;
+  left: 50%;
+  z-index: 7;
+  translate: -50% 0;
+  pointer-events: none;
 }
 
 .landing-kicker {
-  width: fit-content;
-  margin: 0;
-  padding: 5px 9px;
-  border: 1px solid var(--accent-border);
-  border-radius: 6px;
-  background: var(--accent-bg);
-  color: var(--accent);
-  font-size: 0.72rem;
-  font-weight: 700;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
+  margin: 28px 0 0;
+  color: rgba(255, 255, 255, 0.44);
+  font-size: 0.55rem;
+  letter-spacing: 0.34em;
 }
 
 .landing-title {
-  max-width: 520px;
   margin: 0;
-  color: var(--text-h);
-  font-size: clamp(2.1rem, 3.4vw, 3rem);
-  line-height: 1.02;
-  letter-spacing: 0;
-}
-
-.landing-title span {
-  display: block;
+  color: transparent;
+  font-size: 0;
 }
 
 .landing-lead {
-  max-width: 520px;
-  margin: 0;
-  color: var(--text);
-  font-size: 0.98rem;
-  line-height: 1.85;
-}
-
-.landing-actions {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  gap: 12px;
-}
-
-.landing-signin {
-  min-height: 44px;
-  padding-inline: 22px;
-  border-color: transparent;
-  background: var(--text-h);
-  color: var(--bg);
-  font-weight: 700;
-}
-
-.landing-signin:hover {
-  background: color-mix(in srgb, var(--text-h) 88%, var(--accent));
-}
-
-.landing-action-note {
-  color: var(--text);
-  font-size: 0.82rem;
+  width: max-content;
+  max-width: calc(100vw - 40px);
+  margin: 7px auto 0;
+  color: rgba(255, 255, 255, 0.48);
+  font-size: 0.62rem;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
 }
 
 .landing-showcase {
-  position: relative;
-  min-height: 520px;
+  position: absolute;
+  inset: 0;
   overflow: hidden;
-  background:
-    linear-gradient(135deg, rgba(255, 255, 255, 0.78), rgba(244, 243, 236, 0.35)),
-    radial-gradient(circle at 80% 18%, rgba(78, 196, 167, 0.16), transparent 34%),
-    radial-gradient(circle at 20% 78%, rgba(255, 128, 161, 0.18), transparent 36%);
 }
 
-.landing-showcase::before,
-.landing-showcase::after {
-  content: '';
+.landing-stage {
   position: absolute;
-  inset-inline: 0;
-  height: 1px;
-  background: var(--border);
-}
-
-.landing-showcase::before {
-  top: 28%;
-}
-
-.landing-showcase::after {
-  bottom: 22%;
-}
-
-.landing-orbit-base {
-  position: absolute;
-  right: clamp(18px, 6vw, 88px);
-  bottom: 12px;
-  width: min(50vw, 330px);
-  max-width: 70%;
-  opacity: 0.9;
-  filter: drop-shadow(0 28px 28px rgba(47, 33, 67, 0.18));
+  left: 10%;
+  right: 10%;
+  bottom: 7%;
+  height: 16%;
+  border-radius: 50%;
+  background: radial-gradient(ellipse at 50% 45%, rgba(255, 232, 242, 0.2), rgba(50, 29, 43, 0.34) 56%, transparent 72%);
+  filter: blur(2px);
 }
 
 .landing-charm {
   position: absolute;
-  width: clamp(90px, 14vw, 150px);
-  aspect-ratio: 0.58;
-  border: 1px solid rgba(255, 255, 255, 0.72);
-  border-radius: 50% 50% 46% 46% / 18% 18% 42% 42%;
+  width: var(--w, 96px);
+  height: calc(var(--w, 96px) * 0.28);
+  border-radius: 999px;
+  background: linear-gradient(90deg, #fff3bf 0 10%, #f8d94d 11% 16%, var(--tone, #f4c1d7) 17% 100%);
   box-shadow:
-    inset 0 -18px 22px rgba(0, 0, 0, 0.16),
-    inset 0 16px 20px rgba(255, 255, 255, 0.42),
-    0 28px 34px rgba(48, 32, 68, 0.2);
-  transform-origin: center;
-  animation: landing-float 5.5s ease-in-out infinite;
+    inset 4px 0 8px rgba(255, 255, 255, 0.42),
+    inset -5px -3px 10px rgba(28, 10, 22, 0.2),
+    0 18px 28px rgba(0, 0, 0, 0.3),
+    0 0 16px rgba(248, 217, 77, 0.26);
+  transform: translate3d(0, 0, 0) rotate(var(--r, 0deg)) scaleY(var(--sy, 1));
+  animation: landing-orbit var(--d, 8s) ease-in-out infinite;
 }
 
-.landing-charm::before {
-  content: '';
+.landing-charm-face {
   position: absolute;
-  inset: 9% 12% auto;
-  height: 22%;
-  border-radius: 999px;
-  background: rgba(255, 255, 255, 0.42);
-  filter: blur(1px);
-}
-
-.landing-charm-shine {
-  position: absolute;
-  inset: 13% 22% auto auto;
-  width: 18%;
-  height: 58%;
-  border-radius: 999px;
-  background: linear-gradient(180deg, rgba(255, 255, 255, 0.72), transparent);
-  transform: rotate(11deg);
-}
-
-.landing-charm-rose {
-  top: 66px;
-  right: clamp(142px, 24vw, 270px);
-  background:
-    linear-gradient(150deg, rgba(255, 255, 255, 0.48), transparent 24%),
-    linear-gradient(165deg, #ffe2ea, #e64e7a 48%, #721f4d);
-  transform: rotate(-13deg);
+  inset: 12% 12% 18% 24%;
+  border-radius: inherit;
+  background: linear-gradient(90deg, rgba(255, 255, 255, 0.5), transparent 48%);
+  opacity: 0.52;
 }
 
 .landing-charm-pearl {
-  top: 166px;
-  right: clamp(52px, 12vw, 144px);
-  background:
-    linear-gradient(130deg, rgba(255, 255, 255, 0.68), transparent 26%),
-    linear-gradient(170deg, #fff8e6, #c8f0df 52%, #3d9e90);
-  transform: rotate(9deg);
-  animation-delay: -1.2s;
+  --w: 118px;
+  --r: 90deg;
+  --sy: 0.36;
+  --tone: #e4e8ef;
+  --d: 8.4s;
+  left: 28%;
+  top: 12%;
 }
 
-.landing-charm-ink {
-  top: 256px;
-  right: clamp(190px, 31vw, 352px);
-  background:
-    linear-gradient(145deg, rgba(255, 255, 255, 0.35), transparent 28%),
-    linear-gradient(160deg, #d9d7ff, #5e57c9 48%, #171532);
-  transform: rotate(16deg);
-  animation-delay: -2.4s;
+.landing-charm-rose {
+  --w: 92px;
+  --r: -26deg;
+  --sy: 0.24;
+  --tone: #ffe6ef;
+  --d: 7.8s;
+  left: 40%;
+  top: 16%;
 }
 
-.landing-detection-frame {
-  position: absolute;
-  left: clamp(20px, 5vw, 62px);
-  bottom: 54px;
-  width: min(38vw, 230px);
-  min-width: 168px;
-  padding: 14px;
-  border: 1px solid rgba(8, 6, 13, 0.16);
-  border-radius: 8px;
-  background: rgba(255, 255, 255, 0.68);
-  box-shadow: var(--shadow);
-  display: grid;
-  gap: 10px;
+.landing-charm-lilac {
+  --w: 160px;
+  --r: -35deg;
+  --sy: 0.44;
+  --tone: #a9a6f7;
+  --d: 9s;
+  right: 31%;
+  top: 10%;
 }
 
-.landing-detection-frame span {
-  display: block;
-  height: 9px;
-  border-radius: 999px;
-  background: linear-gradient(90deg, rgba(170, 59, 255, 0.72), rgba(78, 196, 167, 0.72));
+.landing-charm-opal {
+  --w: 112px;
+  --r: 56deg;
+  --sy: 0.78;
+  --tone: #e9e7bd;
+  --d: 8.6s;
+  right: 30%;
+  top: 18%;
 }
 
-.landing-detection-frame span:nth-child(2) {
-  width: 74%;
-  background: rgba(8, 6, 13, 0.16);
+.landing-charm-champagne {
+  --w: 126px;
+  --r: 79deg;
+  --sy: 0.36;
+  --tone: #c676db;
+  --d: 8.1s;
+  right: 22%;
+  top: 22%;
 }
 
-.landing-detection-frame span:nth-child(3) {
-  width: 58%;
-  background: rgba(8, 6, 13, 0.12);
+.landing-charm-mint {
+  --w: 134px;
+  --r: 10deg;
+  --sy: 0.26;
+  --tone: #dac8ff;
+  --d: 7.5s;
+  left: 25%;
+  top: 36%;
 }
 
-.landing-steps {
-  display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-  border: 1px solid var(--border);
-  border-radius: 8px;
-  overflow: hidden;
+.landing-charm-coral {
+  --w: 150px;
+  --r: -18deg;
+  --sy: 0.22;
+  --tone: #f7deef;
+  --d: 8.9s;
+  left: 39%;
+  top: 34%;
 }
 
-.landing-steps article {
-  min-height: 164px;
-  padding: 20px;
-  background: var(--social-bg);
+.landing-charm-ivory {
+  --w: 88px;
+  --r: -48deg;
+  --sy: 0.28;
+  --tone: #f6aacb;
+  --d: 9.2s;
+  right: 34%;
+  top: 41%;
 }
 
-.landing-steps article + article {
-  border-left: 1px solid var(--border);
+.landing-charm-violet {
+  --w: 176px;
+  --r: -2deg;
+  --sy: 0.58;
+  --tone: #8d73d0;
+  --d: 8.3s;
+  left: 17%;
+  top: 48%;
 }
 
-.landing-step-index {
-  display: block;
-  margin-bottom: 16px;
-  color: var(--accent);
-  font-family: var(--mono);
-  font-size: 0.72rem;
+.landing-charm-blush {
+  --w: 126px;
+  --r: 66deg;
+  --sy: 0.72;
+  --tone: #ffd2dd;
+  --d: 8.8s;
+  right: 16%;
+  top: 52%;
 }
 
-.landing-steps h3 {
+.landing-charm-shell {
+  --w: 160px;
+  --r: -8deg;
+  --sy: 0.5;
+  --tone: #f8edf4;
+  --d: 7.9s;
+  left: 37%;
+  bottom: 23%;
+}
+
+.landing-charm-moon {
+  --w: 98px;
+  --r: -62deg;
+  --sy: 0.5;
+  --tone: #f6f0fb;
+  --d: 9.4s;
+  left: 48%;
+  bottom: 13%;
+}
+
+.landing-panel {
+  position: fixed;
+  left: 50%;
+  bottom: 88px;
+  z-index: 9;
+  width: min(420px, calc(100vw - 32px));
+  padding: 18px 20px 20px;
+  translate: -50% 0;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 20px;
+  background: rgba(18, 10, 24, 0.54);
+  color: rgba(255, 255, 255, 0.72);
+  backdrop-filter: blur(22px);
+  box-shadow: 0 24px 60px rgba(0, 0, 0, 0.34);
+}
+
+.landing-panel-kicker {
   margin: 0 0 8px;
-  color: var(--text-h);
-  font-size: 1rem;
-  line-height: 1.2;
+  color: #f8bbd0;
+  font-size: 0.58rem;
+  font-weight: 700;
+  letter-spacing: 0.32em;
 }
 
-.landing-steps p {
+.landing-panel h3 {
+  margin: 0 0 8px;
+  color: rgba(255, 255, 255, 0.94);
+  font-size: clamp(1.15rem, 3vw, 1.55rem);
+  line-height: 1.35;
+  letter-spacing: 0;
+}
+
+.landing-panel p {
   margin: 0;
-  color: var(--text);
-  font-size: 0.82rem;
-  line-height: 1.65;
+  font-size: 0.78rem;
+  line-height: 1.75;
 }
 
-@keyframes landing-float {
+.landing-actions {
+  display: flex;
+  justify-content: center;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-top: 14px;
+}
+
+.landing-signin {
+  min-height: 42px;
+  padding-inline: 20px;
+  border-color: rgba(255, 255, 255, 0.88);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.94);
+  color: #050308;
+  font-weight: 800;
+  box-shadow: 0 0 24px rgba(255, 255, 255, 0.22);
+}
+
+.landing-signin:hover {
+  background: white;
+}
+
+.landing-action-note {
+  width: 100%;
+  color: rgba(255, 255, 255, 0.46);
+  font-size: 0.68rem;
+}
+
+.landing-legal-links {
+  display: flex;
+  justify-content: center;
+  gap: 4px;
+  margin-top: 8px;
+  color: rgba(255, 255, 255, 0.35);
+  font-size: 0.68rem;
+}
+
+.landing-legal-links a {
+  color: inherit;
+  text-decoration: none;
+}
+
+.landing-legal-links a:hover {
+  color: rgba(255, 255, 255, 0.68);
+}
+
+.landing-skin-selector {
+  position: fixed;
+  left: 50%;
+  bottom: 22px;
+  z-index: 10;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 7px;
+  width: min(520px, calc(100vw - 24px));
+  translate: -50% 0;
+}
+
+.landing-skin-selector span.active {
+  background: rgba(255, 255, 255, 0.96);
+  color: #050308;
+  border-color: rgba(255, 255, 255, 0.96);
+}
+
+.is-signed-out .auth-config-note {
+  color: rgba(255, 255, 255, 0.58);
+}
+
+@keyframes landing-orbit {
   0%,
   100% {
     translate: 0 0;
   }
   50% {
-    translate: 0 -14px;
-  }
-}
-
-@media (prefers-color-scheme: dark) {
-  .landing-signin {
-    background: #f3f4f6;
-    color: #16171d;
-  }
-
-  .landing-showcase {
-    background:
-      linear-gradient(135deg, rgba(31, 32, 40, 0.94), rgba(22, 23, 29, 0.72)),
-      radial-gradient(circle at 80% 18%, rgba(78, 196, 167, 0.17), transparent 34%),
-      radial-gradient(circle at 20% 78%, rgba(255, 128, 161, 0.14), transparent 36%);
-  }
-
-  .landing-detection-frame {
-    background: rgba(31, 32, 40, 0.76);
-    border-color: rgba(243, 244, 246, 0.14);
-  }
-
-  .landing-detection-frame span:nth-child(2),
-  .landing-detection-frame span:nth-child(3) {
-    background: rgba(243, 244, 246, 0.18);
+    translate: 0 -18px;
   }
 }
 
 @media (max-width: 820px) {
   .is-signed-out #app-title {
-    align-self: center;
-    margin-left: 0;
+    font-size: 0.96rem;
   }
 
-  .landing-hero {
-    grid-template-columns: 1fr;
-    min-height: auto;
+  .landing-topbar {
+    top: 58px;
   }
 
-  .landing-copy {
-    border-right: none;
-    border-bottom: 1px solid var(--border);
-  }
-
-  .landing-showcase {
-    min-height: 440px;
-  }
-
-  .landing-orbit-base {
-    width: min(72vw, 290px);
+  .landing-shell::after {
+    bottom: -18%;
+    height: 34%;
   }
 
   .landing-charm {
-    width: clamp(78px, 22vw, 118px);
-  }
-
-  .landing-charm-rose {
-    top: 54px;
-    right: 45%;
+    width: calc(var(--w, 96px) * 0.78);
   }
 
   .landing-charm-pearl {
-    top: 134px;
-    right: 13%;
+    left: 12%;
+    top: 19%;
   }
 
-  .landing-charm-ink {
-    top: 222px;
-    right: 50%;
+  .landing-charm-rose {
+    left: 46%;
+    top: 16%;
   }
 
-  .landing-detection-frame {
-    width: 48vw;
-    min-width: 162px;
+  .landing-charm-lilac {
+    right: 5%;
+    top: 15%;
   }
 
-  .landing-steps {
-    grid-template-columns: 1fr;
+  .landing-charm-opal {
+    right: 23%;
+    top: 28%;
   }
 
-  .landing-steps article {
-    min-height: auto;
+  .landing-charm-champagne {
+    right: 7%;
+    top: 39%;
   }
 
-  .landing-steps article + article {
-    border-left: none;
-    border-top: 1px solid var(--border);
+  .landing-charm-mint {
+    left: 7%;
+    top: 39%;
+  }
+
+  .landing-charm-coral {
+    left: 39%;
+    top: 47%;
+  }
+
+  .landing-charm-ivory {
+    right: 30%;
+    top: 57%;
+  }
+
+  .landing-charm-violet {
+    left: 14%;
+    top: 59%;
+  }
+
+  .landing-charm-blush {
+    right: 7%;
+    top: 61%;
+  }
+
+  .landing-charm-shell {
+    left: 34%;
+    bottom: 24%;
+  }
+
+  .landing-charm-moon {
+    left: 62%;
+    bottom: 18%;
+  }
+
+  .landing-panel {
+    bottom: 92px;
+  }
+
+  .landing-skin-selector {
+    bottom: 18px;
   }
 }
 
 @media (max-width: 480px) {
-  .landing-shell {
-    gap: 18px;
+  .landing-topbar {
+    left: 12px;
+    right: 12px;
   }
 
-  .landing-title {
-    font-size: 2rem;
-    line-height: 1.08;
+  .landing-topbar span,
+  .landing-skin-selector span {
+    min-height: 26px;
+    padding: 6px 11px;
+    font-size: 0.5rem;
+  }
+
+  .landing-title-block {
+    top: 34px;
+  }
+
+  .landing-kicker {
+    font-size: 0.48rem;
+  }
+
+  .landing-lead {
+    display: none;
+  }
+
+  .landing-panel {
+    bottom: 98px;
+    padding: 16px;
   }
 
   .landing-actions {
@@ -497,11 +671,6 @@
 
   .landing-signin {
     width: 100%;
-  }
-
-  .landing-action-note {
-    width: 100%;
-    text-align: center;
   }
 }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -22,7 +22,6 @@ import { fileToGenerativePart, urlToGenerativePart, generateNailTagsFromImage } 
 import { isAiTagSuggestionEnabled } from './lib/featureFlags'
 import { isFirebaseConfigComplete, missingFirebaseEnvKeys } from './lib/firebaseConfigStatus'
 import ErrorBanner from './components/ErrorBanner'
-import heroImage from './assets/hero.png'
 const PrivacyPolicyPage = lazy(() => import('./components/PrivacyPolicyPage'))
 const TermsOfServicePage = lazy(() => import('./components/TermsOfServicePage'))
 const NailImageDetailViewer = lazy(() => import('./components/NailImageDetailViewer'))
@@ -983,17 +982,36 @@ function App() {
         </div>
       )}
       {user === null && (
-        <div className="landing-shell" aria-label="Nailous preview">
+        <div className="landing-shell" aria-label="Nailous jewelry box preview">
+          <div className="landing-topbar" aria-hidden="true">
+            <span>SPHERE</span>
+            <span>20 / 30</span>
+          </div>
+
           <section className="landing-hero">
-            <div className="landing-copy">
-              <p className="landing-kicker">Nail charm studio</p>
-              <h2 className="landing-title">
-                <span>ネイルを、</span>
-                <span>浮かぶ作品に。</span>
-              </h2>
-              <p className="landing-lead">
-                Nailous はネイル写真をただ保存するだけでなく、形・色・質感を読み取り、
-                共有しやすい美しいビューへ育てていくための場所です。
+            <div className="landing-title-block">
+              <p className="landing-kicker">YOUR NAIL COLLECTION</p>
+              <h2 className="landing-title">NAILOUS</h2>
+              <p className="landing-lead">Glass case for every nail you loved.</p>
+            </div>
+
+            <div className="landing-showcase" aria-hidden="true">
+              {[
+                'pearl', 'rose', 'lilac', 'opal', 'champagne', 'mint',
+                'coral', 'ivory', 'violet', 'blush', 'shell', 'moon',
+              ].map(charm => (
+                <span key={charm} className={`landing-charm landing-charm-${charm}`}>
+                  <span className="landing-charm-face" />
+                </span>
+              ))}
+              <div className="landing-stage" />
+            </div>
+
+            <div className="landing-panel">
+              <p className="landing-panel-kicker">GLASS CASE</p>
+              <h3>ネイルを宝石箱のように集める。</h3>
+              <p>
+                写真を保存するだけでなく、形・色・艶が浮かぶコレクションとして眺められるホームへ。
               </p>
               <div className="landing-actions">
                 <button
@@ -1006,47 +1024,23 @@ function App() {
                 </button>
                 <span className="landing-action-note">保存・比較・共有をはじめる</span>
               </div>
+              <div className="landing-legal-links">
+                <a href="/terms" onClick={(e) => handleLinkClick(e, '/terms')}>利用規約</a>
+                <span>・</span>
+                <a href="/privacy" onClick={(e) => handleLinkClick(e, '/privacy')}>プライバシーポリシー</a>
+              </div>
               {!isFirebaseConfigComplete && (
                 <p className="auth-config-note">{firebaseConfigErrorMessage}</p>
               )}
             </div>
-
-            <div className="landing-showcase" aria-hidden="true">
-              <img className="landing-orbit-base" src={heroImage} alt="" />
-              <div className="landing-charm landing-charm-rose">
-                <span className="landing-charm-shine" />
-              </div>
-              <div className="landing-charm landing-charm-pearl">
-                <span className="landing-charm-shine" />
-              </div>
-              <div className="landing-charm landing-charm-ink">
-                <span className="landing-charm-shine" />
-              </div>
-              <div className="landing-detection-frame">
-                <span />
-                <span />
-                <span />
-              </div>
-            </div>
           </section>
 
-          <section className="landing-steps" aria-label="Nailous experience">
-            <article>
-              <span className="landing-step-index">01</span>
-              <h3>View</h3>
-              <p>チップだけが浮くショーウィンドウのように、写真からネイルの主役感を引き出します。</p>
-            </article>
-            <article>
-              <span className="landing-step-index">02</span>
-              <h3>Detect</h3>
-              <p>輪郭・長さ・艶・立体感を扱えるように、まずは手動補正しやすい検出体験から育てます。</p>
-            </article>
-            <article>
-              <span className="landing-step-index">03</span>
-              <h3>Share</h3>
-              <p>お気に入りのビューをコレクションやSNSへ運びやすい形で整えていきます。</p>
-            </article>
-          </section>
+          <div className="landing-skin-selector" aria-hidden="true">
+            <span className="active">Glass</span>
+            <span>Snow Globe</span>
+            <span>Velvet</span>
+            <span>Showcase</span>
+          </div>
         </div>
       )}
       {user && (


### PR DESCRIPTION
## Summary
- Reworks the signed-out home into a full-screen jewelry-box inspired Nailous experience
- References https://ksc0000.github.io/nail-report/prototype/jewelry-box.html for the dark glass-case mood, floating nail collection, quiet mode/count controls, and restrained bottom selector
- Keeps auth, data storage, legal routes, Firebase rules, and dependencies unchanged

## What felt worth borrowing from the sample
- The product starts with emotion and collection value before explanation
- The UI chrome stays quiet so the floating nail pieces are the subject
- Count/mode/skin controls make it feel like an actual product surface, not a landing page
- Dark glass-case contrast makes nail color and shine feel more precious

## Verification
- npm run lint
- npm run build
- npm test
- bash scripts/qa-preflight.sh (passes with existing JS bundle size warning)
- Playwright visual checks at 1280x900 and 390x844

Claude review was not requested or triggered.