### PR TITLE
Enhance Firestore unit tests

### DIFF
--- a/src/__tests__/firestore.test.ts
+++ b/src/__tests__/firestore.test.ts
@@ -74,6 +74,15 @@ describe('firestore helper functions', () => {
       })
     })
 
+    it('returns empty array when no docs found', async () => {
+      vi.mocked(firestore.getDocs).mockResolvedValue({
+        docs: [],
+      } as unknown as never)
+
+      const result = await fetchNailItems(userId)
+      expect(result).toEqual([])
+    })
+
     it('throws error when getDocs fails', async () => {
       vi.mocked(firestore.getDocs).mockRejectedValue(new Error('Fetch failed'))
       await expect(fetchNailItems(userId)).rejects.toThrow('Fetch failed')
@@ -89,7 +98,16 @@ describe('firestore helper functions', () => {
       const result = await addNailItem(userId, input)
 
       expect(firestore.collection).toHaveBeenCalledWith(expect.anything(), 'users', userId, 'nailItems')
-      expect(firestore.addDoc).toHaveBeenCalled()
+      expect(firestore.addDoc).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          title: input.title,
+          tags: input.tags,
+          memo: input.memo,
+          createdAt: 'mock-timestamp',
+          updatedAt: 'mock-timestamp',
+        }),
+      )
       expect(result).toBe('new-item-id')
     })
 
@@ -104,7 +122,15 @@ describe('firestore helper functions', () => {
       await updateNailItem(userId, itemId, input)
 
       expect(firestore.doc).toHaveBeenCalledWith(expect.anything(), 'users', userId, 'nailItems', itemId)
-      expect(firestore.updateDoc).toHaveBeenCalled()
+      expect(firestore.updateDoc).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          title: input.title,
+          tags: input.tags,
+          memo: input.memo,
+          updatedAt: 'mock-timestamp',
+        }),
+      )
     })
 
     it('throws error when updateDoc fails', async () => {


### PR DESCRIPTION
This PR enhances the unit test coverage for Firestore helper functions in `src/lib/firestore.ts`. 

Key changes:
- Improved `src/__tests__/firestore.test.ts` by adding a test case for when no items are found in Firestore.
- Added more detailed assertions to verify that `addDoc` and `updateDoc` are called with the expected data objects, specifically checking for the presence of the mocked `serverTimestamp`.
- Ensured all tests pass and that the project follows linting and build standards.

Fixes #235

---
*PR created automatically by Jules for task [14997472829813943660](https://jules.google.com/task/14997472829813943660) started by @ksc0000*