### PR TITLE
Audit NailItem type and Firestore persistence structure

### DIFF
--- a/docs/product/NAIL_ITEM_SCHEMA_AUDIT.md
+++ b/docs/product/NAIL_ITEM_SCHEMA_AUDIT.md
@@ -1,0 +1,64 @@
+# NailItem Schema Audit
+
+This document provides a detailed audit of the `NailItem` data model and its Firestore persistence structure as of the Jewelry Box Phase 1 refresh.
+
+## Data Model (TypeScript)
+
+The primary interface is defined in `src/lib/firestoreModel.ts`.
+
+```typescript
+export interface NailItem {
+  title: string
+  imageUrl: string
+  thumbnailUrl: string
+  tags: string[]
+  memo: string
+  imageSource?: 'upload' | 'camera' | 'unknown'
+  createdAt: Timestamp | null
+  updatedAt: Timestamp | null
+}
+
+export interface NailItemDoc extends NailItem {
+  id: string
+}
+```
+
+## Firestore Persistence Structure
+
+### Document Path
+`users/{userId}/nailItems/{itemId}`
+
+### Field Details
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `title` | `string` | Yes | The name or title of the nail design. |
+| `imageUrl` | `string` | Yes | URL to the full-resolution image in Firebase Storage. |
+| `thumbnailUrl` | `string` | Yes | URL to the thumbnail image. Currently mirrored from `imageUrl`. |
+| `tags` | `string[]` | Yes | Array of tags (e.g., "pink", "office"). Max 10 tags. |
+| `memo` | `string` | Yes | User notes about the item (e.g., salon name, price). |
+| `imageSource` | `string` | No* | One of `'upload'`, `'camera'`, or `'unknown'`. |
+| `createdAt` | `Timestamp` | Yes | Firestore server timestamp of creation. |
+| `updatedAt` | `Timestamp` | Yes | Firestore server timestamp of last update. |
+
+*\* Note: Defaults to `'unknown'` in creation/update logic if not provided.*
+
+## Backward Compatibility Requirements
+
+1.  **Optional Fields:** The `imageSource` field was added in a later sub-phase. Legacy documents created before this addition may lack this field. The application code must handle its absence (e.g., defaulting to 'unknown').
+2.  **Memo Field:** The `memo` field was also an incremental addition. While now treated as required in the interface, code handles empty strings for legacy data.
+3.  **Public Shares:** The `publicShares` collection stores snapshots of `NailItem` data. Specifically, `PublicShareItemSnapshot` includes `id`, `title`, `tags`, and `createdAt`. Any schema change to `NailItem` that should be reflected in shared views must also consider the snapshot structure in `src/lib/publicShares.ts`.
+
+## Human Gate for Schema Changes
+
+**G3 (DB Schema Change):** Any modification to the Firestore schema, including adding new required fields, changing field types, or altering the document hierarchy, requires explicit human approval.
+
+Future fields proposed for 3D Preview (Phase 8+) such as `shape`, `color`, `texture`, `modelId`, etc., must not be implemented without triggering this gate. Refer to `docs/product/FIRESTORE_3D_SCHEMA_DESIGN.md` for the proposed design.
+
+## Verification Checklist for Future Changes
+- [ ] Update `NailItem` and `NailItemInput` interfaces in `src/lib/firestoreModel.ts`.
+- [ ] Update build helpers (`buildCreateNailItemData`, `buildUpdateNailItemData`).
+- [ ] Check impact on data export logic (CSV/JSON) in `src/App.tsx`.
+- [ ] Check impact on public share snapshots in `src/lib/publicShares.ts`.
+- [ ] Verify backward compatibility for existing documents.
+- [ ] Update Firestore Security Rules if necessary (requires Human Gate G4).

--- a/docs/product/PRODUCT_SPEC.md
+++ b/docs/product/PRODUCT_SPEC.md
@@ -143,6 +143,7 @@ Firestore (default) / users/{userId}/nailItems/{itemId}
 | `thumbnailUrl` | `string` | ✅ | Firebase Storage URL | サムネイル画像（初期は imageUrl と同値でも可） |
 | `tags` | `string[]` | ✅ | 最大 10 件、空配列可 | スタイル・色・シーン等のタグ |
 | `memo` | `string` | ✅ | 最大 500 文字、空文字可 | サロン名・価格・シーン等のメモ |
+| `imageSource` | `string` | | upload / camera / unknown | 画像の取得元 |
 | `createdAt` | `Timestamp` | ✅ | サーバータイムスタンプ | 作成日時 |
 | `updatedAt` | `Timestamp` | ✅ | サーバータイムスタンプ | 更新日時 |
 
@@ -155,6 +156,7 @@ interface NailItem {
   thumbnailUrl: string
   tags: string[]
   memo: string
+  imageSource?: 'upload' | 'camera' | 'unknown'
   createdAt: Timestamp
   updatedAt: Timestamp
 }
@@ -223,6 +225,7 @@ interface NailItem {
 | ドキュメント | 内容 |
 |---|---|
 | [ROADMAP.md](./ROADMAP.md) | 開発ロードマップ |
+| [NAIL_ITEM_SCHEMA_AUDIT.md](./NAIL_ITEM_SCHEMA_AUDIT.md) | NailItem スキーマ詳細監査 |
 | [3D_ASSET_DELIVERY_STRATEGY.md](./3D_ASSET_DELIVERY_STRATEGY.md) | 3D アセット配信戦略 |
 | [FIRESTORE_3D_SCHEMA_DESIGN.md](./FIRESTORE_3D_SCHEMA_DESIGN.md) | Phase 8 以降の Firestore 3D フィールド設計 |
 | [ACCEPTANCE_CRITERIA.md](./ACCEPTANCE_CRITERIA.md) | タスク完了基準 |


### PR DESCRIPTION
This PR documents the current `NailItem` schema and its Firestore persistence structure as part of the Jewelry Box Phase 1 refresh. It includes field definitions, storage paths, backward compatibility notes, and explicitly calls out the human gate requirement for schema changes.

Fixes #256

---
*PR created automatically by Jules for task [3156146401508192878](https://jules.google.com/task/3156146401508192878) started by @ksc0000*