### PR TITLE
refactor: organize Jewelry Box CSS sections

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,3 +1,5 @@
+/* App shell and authentication */
+
 #center {
   display: flex;
   flex-direction: column;
@@ -127,6 +129,8 @@
   color: var(--accent) !important;
   font-weight: 600;
 }
+
+/* Signed-out Jewelry Box home */
 
 #root:has(.is-signed-out) {
   width: 100%;
@@ -680,6 +684,8 @@
   }
 }
 
+/* Logged-in Jewelry Box studio */
+
 #nail-section {
   width: 100%;
   max-width: 920px;
@@ -757,6 +763,8 @@
   letter-spacing: 0.2em;
   text-transform: uppercase;
 }
+
+/* Public share route */
 
 #public-share-page {
   width: 100%;
@@ -866,6 +874,8 @@
   font-size: 0.74rem;
   color: #888;
 }
+
+/* Collection search and add/edit form */
 
 #nail-search {
   margin-bottom: 16px;
@@ -1194,6 +1204,8 @@
   }
 }
 
+/* Nail collection cards */
+
 #nail-list {
   list-style: none;
   padding: 0;
@@ -1340,6 +1352,8 @@
   padding: 8px 12px;
   border-top: 1px solid var(--border);
 }
+
+/* Detail viewer and floating charm preview */
 
 .nail-detail-backdrop {
   position: fixed;
@@ -1735,6 +1749,8 @@
     animation: none;
   }
 }
+
+/* Collection summary, comparison, sharing, and filters */
 
 #nail-summary {
   background: var(--social-bg);
@@ -2398,6 +2414,8 @@
   }
 }
 
+/* Accessibility utilities */
+
 .sr-only {
   position: absolute;
   width: 1px;
@@ -2411,7 +2429,8 @@
   border-width: 0;
 }
 
-/* Loading Skeleton */
+/* Loading skeletons */
+
 .nail-skeleton-card {
   display: flex;
   flex-direction: column;
@@ -2571,7 +2590,8 @@
   text-decoration: underline;
 }
 
-/* Legal Pages */
+/* Legal pages and footer */
+
 .legal-page {
   width: 100%;
   max-width: 720px;
@@ -2677,6 +2697,8 @@
     gap: 12px;
   }
 }
+
+/* AI tag suggestion */
 
 .ai-tag-btn {
   margin-top: 4px;

--- a/src/index.css
+++ b/src/index.css
@@ -1,3 +1,5 @@
+/* Base theme tokens */
+
 :root {
   --text: #6b6375;
   --text-h: #08060d;
@@ -50,6 +52,8 @@
   }
 }
 
+/* Dark-mode token overrides */
+
 @media (prefers-color-scheme: dark) {
   :root {
     --text: #9ca3af;
@@ -73,6 +77,8 @@
   }
 }
 
+/* Root layout and base elements */
+
 #root {
   width: 1126px;
   max-width: 100%;
@@ -88,6 +94,8 @@
 body {
   margin: 0;
 }
+
+/* Typography and inline primitives */
 
 h1,
 h2 {


### PR DESCRIPTION
## Summary
- Add section boundaries for app shell/auth, signed-out Jewelry Box home, logged-in studio, public share, forms, cards, detail viewer, summary/share/filter, accessibility, skeletons, legal/footer, and AI tag styles.
- Add matching top-level organization comments in `src/index.css` for theme tokens, dark-mode overrides, base layout, and typography primitives.
- Keep this as a non-behavioral CSS organization pass.

Closes #251

## Verification
- npm run lint
- npm run build
- npm test
- bash scripts/qa-preflight.sh (passes with existing JS bundle-size warning)

## Review flow
- Claude review was not requested or triggered.