### PR TITLE
feat: define mobile layout baseline

### DIFF
--- a/docs/product/PRODUCT_SPEC.md
+++ b/docs/product/PRODUCT_SPEC.md
@@ -126,6 +126,24 @@ Nailous は、ネイル写真・メモ・タグをかんたんに残し、あと
 
 ---
 
+## Mobile Layout Baseline
+
+Jewelry Box Refresh のモバイルUIは、アプリの主利用端末をスマートフォンと見なし、390px 幅を主要な設計基準にする。iPhone SE 相当の 320px 級は下限の回帰確認対象とし、情報量を減らすのではなく、1カラム化・折り返し・安全余白で破綻を避ける。
+
+| 項目 | 基準 |
+|------|------|
+| Primary mobile width | 390px（iPhone 12/13/14/15 系の標準幅を想定） |
+| Compact minimum check | 320px（iPhone SE 相当で主要CTA・フォーム・カードが操作可能） |
+| Tap target | 主要ボタン・フォーム送信・共有/エクスポート操作は 44px 以上 |
+| Fixed controls | 下部固定UIは `env(safe-area-inset-bottom)` を加味し、コンテンツ下端と重ねない |
+| Logged-out home | Jewelry Box の浮遊ビューを維持しつつ、390pxではサインインCTAを1カラムで表示 |
+| Logged-in studio | 390px以下ではヒーロー・フォーム・カードを1カラム化し、横スクロールを発生させない |
+| Desktop | 既存の中央寄せ最大幅と2カラムカード表示を維持し、モバイル基準の追加で情報密度を落とさない |
+
+実装上の共通基準は `src/index.css` の `--mobile-viewport-target`、`--mobile-viewport-compact`、`--tap-target-min`、`--fixed-control-safe-gap` に集約する。下部固定ナビゲーションを追加する場合も、この安全余白を再利用する。
+
+---
+
 ## Data Model Overview
 
 ### NailItem（Firestore — Phase 1 以降）

--- a/src/App.css
+++ b/src/App.css
@@ -7,12 +7,12 @@
   place-content: start;
   place-items: center;
   flex-grow: 1;
-  padding: 32px 20px 48px;
+  padding: 32px 20px calc(48px + var(--fixed-control-safe-gap));
 }
 
 @media (max-width: 480px) {
   #center {
-    padding: 20px 16px 40px;
+    padding: 20px 16px calc(40px + var(--fixed-control-safe-gap));
     gap: 16px;
   }
 }
@@ -46,6 +46,7 @@
 }
 
 .auth-user button {
+  min-height: var(--tap-target-min);
   padding: 6px 12px;
   border: 1px solid var(--border);
   border-radius: 6px;
@@ -70,6 +71,7 @@
 }
 
 .auth-signin {
+  min-height: var(--tap-target-min);
   padding: 8px 20px;
   border: 1px solid var(--border);
   border-radius: 6px;
@@ -437,7 +439,7 @@
 .landing-panel {
   position: fixed;
   left: 50%;
-  bottom: 88px;
+  bottom: calc(var(--fixed-control-safe-gap) + 66px);
   z-index: 9;
   width: min(420px, calc(100vw - 32px));
   padding: 18px 20px 20px;
@@ -481,7 +483,7 @@
 }
 
 .landing-signin {
-  min-height: 42px;
+  min-height: var(--tap-target-min);
   padding-inline: 20px;
   border-color: rgba(255, 255, 255, 0.88);
   border-radius: 999px;
@@ -511,6 +513,9 @@
 }
 
 .landing-legal-links a {
+  display: inline-flex;
+  align-items: center;
+  min-height: 32px;
   color: inherit;
   text-decoration: none;
 }
@@ -522,7 +527,7 @@
 .landing-skin-selector {
   position: fixed;
   left: 50%;
-  bottom: 22px;
+  bottom: var(--fixed-control-safe-gap);
   z-index: 10;
   display: flex;
   flex-wrap: wrap;
@@ -631,11 +636,11 @@
   }
 
   .landing-panel {
-    bottom: 92px;
+    bottom: calc(var(--fixed-control-safe-gap) + 76px);
   }
 
   .landing-skin-selector {
-    bottom: 18px;
+    bottom: var(--fixed-control-safe-gap);
   }
 }
 
@@ -665,7 +670,7 @@
   }
 
   .landing-panel {
-    bottom: 98px;
+    bottom: calc(var(--fixed-control-safe-gap) + 82px);
     padding: 16px;
   }
 
@@ -1024,6 +1029,7 @@
 }
 
 .btn-primary {
+  min-height: var(--tap-target-min);
   background: linear-gradient(135deg, var(--accent), var(--jb-rose));
   color: #fff;
   border: 1px solid transparent;
@@ -2252,6 +2258,7 @@
 }
 
 .btn-export {
+  min-height: var(--tap-target-min);
   padding: 7px 16px;
   border: 1px solid var(--accent-border);
   border-radius: 6px;

--- a/src/index.css
+++ b/src/index.css
@@ -32,6 +32,10 @@
   --jb-text-muted-on-dark: rgba(255, 255, 255, 0.48);
   --jb-shadow-glow: 0 0 28px rgba(248, 187, 208, 0.14);
   --jb-shadow-panel: 0 24px 60px rgba(0, 0, 0, 0.34);
+  --mobile-viewport-target: 390px;
+  --mobile-viewport-compact: 320px;
+  --tap-target-min: 44px;
+  --fixed-control-safe-gap: max(16px, env(safe-area-inset-bottom));
 
   --sans: system-ui, 'Segoe UI', Roboto, sans-serif;
   --heading: system-ui, 'Segoe UI', Roboto, sans-serif;


### PR DESCRIPTION
## Summary
- Document the Jewelry Box mobile layout baseline around 390px, iPhone SE-class 320px checks, 44px tap targets, safe-area-aware fixed controls, and desktop expectations.
- Add shared CSS baseline variables for target/compact widths, tap target minimums, and fixed-control safe gap.
- Apply the mobile baseline to auth buttons, primary/export actions, and signed-out fixed controls so future bottom navigation can reuse the same rules.

Closes #252

## Verification
- npm run lint
- npm run build
- npm test
- bash scripts/qa-preflight.sh (passes with existing JS bundle-size warning)

## Review flow
- Claude review was not requested or triggered.