### PR TITLE
refactor: extract floating nail chip component

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -316,6 +316,16 @@
   opacity: 0.52;
 }
 
+.landing-charm--almond,
+.nail-empty-chip--almond {
+  border-radius: 72% 100% 100% 72% / 58% 82% 82% 58%;
+}
+
+.landing-charm--square,
+.nail-empty-chip--square {
+  border-radius: 18px 26px 26px 18px;
+}
+
 .landing-charm-pearl {
   --w: 118px;
   --r: 90deg;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -22,6 +22,7 @@ import { fileToGenerativePart, urlToGenerativePart, generateNailTagsFromImage } 
 import { isAiTagSuggestionEnabled } from './lib/featureFlags'
 import { isFirebaseConfigComplete, missingFirebaseEnvKeys } from './lib/firebaseConfigStatus'
 import ErrorBanner from './components/ErrorBanner'
+import FloatingNailChip from './components/FloatingNailChip'
 const PrivacyPolicyPage = lazy(() => import('./components/PrivacyPolicyPage'))
 const TermsOfServicePage = lazy(() => import('./components/TermsOfServicePage'))
 const NailImageDetailViewer = lazy(() => import('./components/NailImageDetailViewer'))
@@ -1000,9 +1001,7 @@ function App() {
                 'pearl', 'rose', 'lilac', 'opal', 'champagne', 'mint',
                 'coral', 'ivory', 'violet', 'blush', 'shell', 'moon',
               ].map(charm => (
-                <span key={charm} className={`landing-charm landing-charm-${charm}`}>
-                  <span className="landing-charm-face" />
-                </span>
+                <FloatingNailChip key={charm} className={`landing-charm-${charm}`} />
               ))}
               <div className="landing-stage" />
             </div>
@@ -1425,9 +1424,9 @@ function App() {
           ) : nailItems.length === 0 ? (
             <div className="nail-empty">
               <div className="nail-empty-stage" aria-hidden="true">
-                <span className="nail-empty-chip nail-empty-chip--one" />
-                <span className="nail-empty-chip nail-empty-chip--two" />
-                <span className="nail-empty-chip nail-empty-chip--three" />
+                <FloatingNailChip variant="empty" className="nail-empty-chip--one" showHighlight={false} />
+                <FloatingNailChip variant="empty" className="nail-empty-chip--two" showHighlight={false} />
+                <FloatingNailChip variant="empty" className="nail-empty-chip--three" showHighlight={false} />
               </div>
               <p className="nail-empty-main">まだ宝石箱は空です</p>
               <p className="nail-empty-sub">タイトルと写真を追加すると、最初のネイルチャームがここに並びます</p>

--- a/src/components/FloatingNailChip.tsx
+++ b/src/components/FloatingNailChip.tsx
@@ -1,0 +1,55 @@
+import type { CSSProperties } from 'react'
+
+type FloatingNailChipShape = 'oval' | 'almond' | 'square'
+
+interface FloatingNailChipPosition {
+  top?: string
+  right?: string
+  bottom?: string
+  left?: string
+}
+
+interface FloatingNailChipProps {
+  variant?: 'landing' | 'empty'
+  color?: string
+  shape?: FloatingNailChipShape
+  position?: FloatingNailChipPosition
+  width?: string
+  rotation?: string
+  scaleY?: string
+  duration?: string
+  className?: string
+  showHighlight?: boolean
+}
+
+const FloatingNailChip = ({
+  variant = 'landing',
+  color,
+  shape = 'oval',
+  position,
+  width,
+  rotation,
+  scaleY,
+  duration,
+  className = '',
+  showHighlight = variant === 'landing',
+}: FloatingNailChipProps) => {
+  const style = {
+    ...(color ? { '--tone': color } : {}),
+    ...(width ? { '--w': width } : {}),
+    ...(rotation ? { '--r': rotation } : {}),
+    ...(scaleY ? { '--sy': scaleY } : {}),
+    ...(duration ? { '--d': duration } : {}),
+    ...position,
+  } as CSSProperties
+  const baseClassName = variant === 'empty' ? 'nail-empty-chip' : 'landing-charm'
+  const classes = [baseClassName, `${baseClassName}--${shape}`, className].filter(Boolean).join(' ')
+
+  return (
+    <span className={classes} style={style} aria-hidden="true">
+      {showHighlight ? <span className={`${baseClassName}-face`} /> : null}
+    </span>
+  )
+}
+
+export default FloatingNailChip


### PR DESCRIPTION
## Summary
- Add a reusable `FloatingNailChip` component for Jewelry Box floating nail visuals.
- Preserve the existing landing and empty-state chip styles while routing both through the shared component.
- Support color, shape, position, width, rotation, scale, and duration props without adding any 3D or animation dependency.
- Keep existing `prefers-reduced-motion` CSS behavior in place.

Closes #259

## Verification
- npm run lint
- npm run build
- npm test
- bash scripts/qa-preflight.sh (passes with existing JS bundle-size warning)

## Review flow
- Claude review was not requested or triggered.