### PR TITLE
feat: add display mode switcher skeleton

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -266,11 +266,10 @@
 }
 
 .landing-topbar span,
-.landing-skin-selector span {
+.display-mode-switcher button {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  min-height: 28px;
   padding: 6px 14px;
   border: 1px solid rgba(255, 255, 255, 0.12);
   border-radius: 999px;
@@ -281,6 +280,28 @@
   letter-spacing: 0.2em;
   backdrop-filter: blur(20px);
   box-shadow: inset 0 1px 0 var(--jb-glass);
+}
+
+.landing-topbar span {
+  min-height: 28px;
+}
+
+.display-mode-switcher button {
+  min-height: var(--tap-target-min);
+  font-family: inherit;
+  cursor: pointer;
+  transition: background 0.18s ease, color 0.18s ease, border-color 0.18s ease;
+}
+
+.display-mode-switcher button:hover,
+.display-mode-switcher button:focus-visible {
+  border-color: rgba(255, 255, 255, 0.36);
+  background: var(--jb-glass-strong);
+}
+
+.display-mode-switcher button:focus-visible {
+  outline: 2px solid var(--jb-pink);
+  outline-offset: 2px;
 }
 
 .landing-hero {
@@ -581,23 +602,46 @@
   color: rgba(255, 255, 255, 0.68);
 }
 
-.landing-skin-selector {
-  position: fixed;
-  left: 50%;
-  bottom: var(--fixed-control-safe-gap);
-  z-index: 10;
+.display-mode-switcher {
   display: flex;
   flex-wrap: wrap;
   justify-content: center;
   gap: 7px;
+}
+
+.landing-mode-switcher {
+  position: fixed;
+  left: 50%;
+  bottom: var(--fixed-control-safe-gap);
+  z-index: 10;
   width: min(520px, calc(100vw - 24px));
   translate: -50% 0;
 }
 
-.landing-skin-selector span.active {
+.display-mode-switcher button.active,
+.display-mode-switcher button[aria-pressed='true'] {
   background: rgba(255, 255, 255, 0.96);
   color: var(--jb-black);
   border-color: rgba(255, 255, 255, 0.96);
+}
+
+.studio-mode-switcher {
+  justify-content: flex-start;
+  padding: 2px 0;
+}
+
+.studio-mode-switcher button {
+  border-color: color-mix(in srgb, var(--jb-gold) 22%, var(--border));
+  background: rgba(255, 255, 255, 0.72);
+  color: var(--text-h);
+  box-shadow: 0 10px 24px rgba(36, 20, 41, 0.08);
+}
+
+.studio-mode-switcher button.active,
+.studio-mode-switcher button[aria-pressed='true'] {
+  border-color: var(--jb-gold);
+  background: linear-gradient(135deg, var(--jb-black), var(--jb-plum));
+  color: rgba(255, 255, 255, 0.94);
 }
 
 .is-signed-out .auth-config-note {
@@ -696,7 +740,7 @@
     bottom: calc(var(--fixed-control-safe-gap) + 76px);
   }
 
-  .landing-skin-selector {
+  .landing-mode-switcher {
     bottom: var(--fixed-control-safe-gap);
   }
 }
@@ -708,8 +752,7 @@
   }
 
   .landing-topbar span,
-  .landing-skin-selector span {
-    min-height: 26px;
+  .display-mode-switcher button {
     padding: 6px 11px;
     font-size: 0.5rem;
   }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -29,6 +29,9 @@ const NailImageDetailViewer = lazy(() => import('./components/NailImageDetailVie
 const NailComparisonPanel = lazy(() => import('./components/NailComparisonPanel'))
 import './App.css'
 
+const DISPLAY_MODES = ['Glass', 'Snow Globe', 'Velvet', 'Showcase'] as const
+type DisplayMode = typeof DISPLAY_MODES[number]
+
 const sortByDate = (items: NailItemDoc[]): NailItemDoc[] =>
   [...items].sort((a, b) => {
     const ta = (a.updatedAt ?? a.createdAt)?.seconds ?? 0
@@ -233,6 +236,7 @@ function App() {
   const [publicShares, setPublicShares] = useState<PublicShareDocWithId[]>([])
   const [publicSharesUserId, setPublicSharesUserId] = useState<string | null>(null)
   const [shareActionId, setShareActionId] = useState<string | null>(null)
+  const [activeDisplayMode, setActiveDisplayMode] = useState<DisplayMode>('Glass')
   const [publicShare, setPublicShare] = useState<PublicShareDocWithId | null>(null)
   const [publicShareState, setPublicShareState] = useState<PublicShareViewState>(
     isPublicSharePage ? 'loading' : 'idle'
@@ -846,6 +850,22 @@ function App() {
     </footer>
   )
 
+  const renderDisplayModeSwitcher = (className = '') => (
+    <div className={`display-mode-switcher ${className}`.trim()} role="group" aria-label="表示モード">
+      {DISPLAY_MODES.map(mode => (
+        <button
+          key={mode}
+          type="button"
+          className={mode === activeDisplayMode ? 'active' : undefined}
+          aria-pressed={mode === activeDisplayMode}
+          onClick={() => setActiveDisplayMode(mode)}
+        >
+          {mode}
+        </button>
+      ))}
+    </div>
+  )
+
   if (isPublicSharePage) {
     return (
       <section id="center">
@@ -1034,12 +1054,7 @@ function App() {
             </div>
           </section>
 
-          <div className="landing-skin-selector" aria-hidden="true">
-            <span className="active">Glass</span>
-            <span>Snow Globe</span>
-            <span>Velvet</span>
-            <span>Showcase</span>
-          </div>
+          {renderDisplayModeSwitcher('landing-mode-switcher')}
         </div>
       )}
       {user && (
@@ -1058,6 +1073,7 @@ function App() {
               <small>saved</small>
             </div>
           </section>
+          {renderDisplayModeSwitcher('studio-mode-switcher')}
           <div id="nail-form">
             <h2 className="nail-form-title">{editingId ? 'Edit charm' : 'Add to jewelry box'}</h2>
             <input


### PR DESCRIPTION
## Summary
- Replace the decorative signed-out mode labels with a real display mode switcher for Glass, Snow Globe, Velvet, and Showcase.
- Add the same visual-only switcher to the logged-in Jewelry Box studio shell.
- Style active/pressed states and keep the mode differences visual-only for this issue.

Closes #261

## Verification
- npm run lint
- npm run build
- npm test
- bash scripts/qa-preflight.sh (passes with existing JS bundle-size warning)

## Review flow
- Claude review was not requested or triggered.