### PR TITLE
feat: add static Nail Design screen

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1024,6 +1024,62 @@
   border-radius: 6px;
 }
 
+.nail-design-screen {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.nail-design-header {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 14px;
+  align-items: end;
+}
+
+.nail-design-kicker {
+  margin: 0 0 6px;
+  color: var(--jb-rose);
+  font-size: 0.68rem;
+  font-weight: 800;
+  letter-spacing: 0.24em;
+}
+
+.nail-design-header h3 {
+  margin: 0 0 6px;
+  color: var(--text-h);
+  font-size: clamp(1.18rem, 3vw, 1.5rem);
+  line-height: 1.25;
+}
+
+.nail-design-header p {
+  max-width: 560px;
+  margin: 0;
+  color: var(--text);
+  font-size: 0.84rem;
+  line-height: 1.65;
+}
+
+.nail-design-meta {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 6px;
+}
+
+.nail-design-meta span {
+  display: inline-flex;
+  align-items: center;
+  min-height: 28px;
+  padding: 4px 10px;
+  border: 1px solid color-mix(in srgb, var(--jb-gold) 24%, var(--border));
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.68);
+  color: var(--text-h);
+  font-size: 0.68rem;
+  font-weight: 700;
+}
+
 #nail-form {
   position: relative;
   overflow: hidden;
@@ -1347,6 +1403,15 @@
 
   #nail-form {
     padding: 14px;
+  }
+
+  .nail-design-header {
+    grid-template-columns: 1fr;
+    align-items: start;
+  }
+
+  .nail-design-meta {
+    justify-content: flex-start;
   }
 
   #nail-list {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1074,116 +1074,130 @@ function App() {
             </div>
           </section>
           {renderDisplayModeSwitcher('studio-mode-switcher')}
-          <div id="nail-form">
-            <h2 className="nail-form-title">{editingId ? 'Edit charm' : 'Add to jewelry box'}</h2>
-            <input
-              type="text"
-              value={nailTitle}
-              onChange={e => setNailTitle(e.target.value)}
-              placeholder="Title *"
-              className="nail-input"
-              maxLength={MAX_NAIL_TITLE_LENGTH}
-            />
-            <input
-              type="text"
-              value={nailTags}
-              onChange={e => setNailTags(e.target.value)}
-              placeholder="Tags (comma separated, max 10)"
-              className="nail-input"
-            />
-            <p className="nail-input-note">
-              タグはカンマ区切りで最大{MAX_NAIL_TAGS}個、1つ{MAX_NAIL_TAG_LENGTH}文字まで。
-            </p>
-            {isAiTagSuggestionEnabled && (nailImageFile || editingItem?.imageUrl) && (
-              <button
-                type="button"
-                className="ai-tag-btn"
-                onClick={handleGenerateTagsWithAI}
-                disabled={isAIGeneratingTags}
-              >
-                {isAIGeneratingTags ? 'AIがタグを生成中...' : '✨ 画像からAIでタグを生成'}
-              </button>
-            )}
-            <textarea
-              value={nailMemo}
-              onChange={e => setNailMemo(e.target.value)}
-              placeholder="Memo (salon, price, scene...)"
-              className="nail-textarea"
-              rows={3}
-              maxLength={500}
-            />
-            <div className="nail-file-area">
-              <div className="nail-file-options">
-                <label className="nail-file-option">
-                  <span>アルバムから選択</span>
-                  <input
-                    ref={uploadInputRef}
-                    type="file"
-                    accept="image/jpeg,image/png,image/webp"
-                    onChange={handleNailFileChange}
-                    className="nail-file-input"
-                  />
-                </label>
-                <label className="nail-file-option">
-                  <span>カメラで撮影</span>
-                  <input
-                    ref={cameraInputRef}
-                    type="file"
-                    accept="image/*"
-                    capture="environment"
-                    onChange={handleNailFileChange}
-                    className="nail-file-input"
-                  />
-                </label>
+          <section className="nail-design-screen" aria-labelledby="nail-design-title">
+            <div className="nail-design-header">
+              <div>
+                <p className="nail-design-kicker">NAIL DESIGN</p>
+                <h3 id="nail-design-title">次のネイルを記録する。</h3>
+                <p>写真・タグ・メモをまとめて、あとから浮遊ビューや共有に使える形で保存します。</p>
               </div>
-              <p className="nail-file-note">カメラが起動しない場合は、アルバムから画像を選択してください。</p>
-              {isAiTagSuggestionEnabled && (
-                <p className="nail-file-privacy-note">
-                  写真は非公開で保存されます。「AIでタグを生成」ボタンを押した場合のみ、画像が一時的にAIによる解析へ送信されます（AIの学習には使用されません）。
-                </p>
-              )}
-              {nailImageFile && nailImagePreview && (
-                <div className="nail-file-preview-area">
-                  <img
-                    className="nail-file-preview"
-                    src={nailImagePreview}
-                    alt="選択画像のプレビュー"
-                  />
-                  <div className="nail-file-info-row">
-                    <span className="nail-file-info">
-                      {nailImageFile.name}（{(nailImageFile.size / 1024 / 1024).toFixed(1)}MB）
-                    </span>
-                    <button
-                      type="button"
-                      className="nail-file-remove"
-                      onClick={handleRemoveFile}
-                    >
-                      削除
-                    </button>
-                  </div>
-                </div>
-              )}
-              {editingItem?.imageUrl && !nailImageFile && (
-                <p className="nail-file-note">現在の画像を維持します。変更するには新しい画像を選択してください。</p>
-              )}
+              <div className="nail-design-meta" aria-label="保存できる情報">
+                <span>Photo</span>
+                <span>Tags</span>
+                <span>Memo</span>
+              </div>
             </div>
-            <div className="nail-form-actions">
-              <button
-                type="button"
-                className="btn-primary"
-                onClick={handleSubmitNailItem}
-                disabled={nailLoading || nailTitle.trim() === ''}
-              >
-                {nailLoading ? 'Saving...' : editingId ? 'Update' : 'Add'}
-              </button>
-              {editingId && (
-                <button type="button" onClick={resetForm} disabled={nailLoading}>
-                  Cancel
+            <div id="nail-form">
+              <h2 className="nail-form-title">{editingId ? 'Edit charm' : 'Add to jewelry box'}</h2>
+              <input
+                type="text"
+                value={nailTitle}
+                onChange={e => setNailTitle(e.target.value)}
+                placeholder="Title *"
+                className="nail-input"
+                maxLength={MAX_NAIL_TITLE_LENGTH}
+              />
+              <input
+                type="text"
+                value={nailTags}
+                onChange={e => setNailTags(e.target.value)}
+                placeholder="Tags (comma separated, max 10)"
+                className="nail-input"
+              />
+              <p className="nail-input-note">
+                タグはカンマ区切りで最大{MAX_NAIL_TAGS}個、1つ{MAX_NAIL_TAG_LENGTH}文字まで。
+              </p>
+              {isAiTagSuggestionEnabled && (nailImageFile || editingItem?.imageUrl) && (
+                <button
+                  type="button"
+                  className="ai-tag-btn"
+                  onClick={handleGenerateTagsWithAI}
+                  disabled={isAIGeneratingTags}
+                >
+                  {isAIGeneratingTags ? 'AIがタグを生成中...' : '✨ 画像からAIでタグを生成'}
                 </button>
               )}
+              <textarea
+                value={nailMemo}
+                onChange={e => setNailMemo(e.target.value)}
+                placeholder="Memo (salon, price, scene...)"
+                className="nail-textarea"
+                rows={3}
+                maxLength={500}
+              />
+              <div className="nail-file-area">
+                <div className="nail-file-options">
+                  <label className="nail-file-option">
+                    <span>アルバムから選択</span>
+                    <input
+                      ref={uploadInputRef}
+                      type="file"
+                      accept="image/jpeg,image/png,image/webp"
+                      onChange={handleNailFileChange}
+                      className="nail-file-input"
+                    />
+                  </label>
+                  <label className="nail-file-option">
+                    <span>カメラで撮影</span>
+                    <input
+                      ref={cameraInputRef}
+                      type="file"
+                      accept="image/*"
+                      capture="environment"
+                      onChange={handleNailFileChange}
+                      className="nail-file-input"
+                    />
+                  </label>
+                </div>
+                <p className="nail-file-note">カメラが起動しない場合は、アルバムから画像を選択してください。</p>
+                {isAiTagSuggestionEnabled && (
+                  <p className="nail-file-privacy-note">
+                    写真は非公開で保存されます。「AIでタグを生成」ボタンを押した場合のみ、画像が一時的にAIによる解析へ送信されます（AIの学習には使用されません）。
+                  </p>
+                )}
+                {nailImageFile && nailImagePreview && (
+                  <div className="nail-file-preview-area">
+                    <img
+                      className="nail-file-preview"
+                      src={nailImagePreview}
+                      alt="選択画像のプレビュー"
+                    />
+                    <div className="nail-file-info-row">
+                      <span className="nail-file-info">
+                        {nailImageFile.name}（{(nailImageFile.size / 1024 / 1024).toFixed(1)}MB）
+                      </span>
+                      <button
+                        type="button"
+                        className="nail-file-remove"
+                        onClick={handleRemoveFile}
+                      >
+                        削除
+                      </button>
+                    </div>
+                  </div>
+                )}
+                {editingItem?.imageUrl && !nailImageFile && (
+                  <p className="nail-file-note">現在の画像を維持します。変更するには新しい画像を選択してください。</p>
+                )}
+              </div>
+              <div className="nail-form-actions">
+                <button
+                  type="button"
+                  className="btn-primary"
+                  onClick={handleSubmitNailItem}
+                  disabled={nailLoading || nailTitle.trim() === ''}
+                >
+                  {nailLoading ? 'Saving...' : editingId ? 'Update' : 'Add'}
+                </button>
+                {editingId && (
+                  <button type="button" onClick={resetForm} disabled={nailLoading}>
+                    Cancel
+                  </button>
+                )}
+              </div>
+              {nailError && <p className="nail-error">{nailError}</p>}
             </div>
-            {nailError && <p className="nail-error">{nailError}</p>}
-          </div>
+          </section>
           {!isFetching && nailItems.length > 0 && (
             <div id="nail-summary">
               <h3 className="summary-heading">コレクション概要</h3>


### PR DESCRIPTION
## Summary
- Add a static Nail Design screen shell around the existing add/edit form.
- Preserve the existing form fields, upload/camera inputs, preview, save, edit, cancel, and error behavior.
- Add responsive header/meta layout so the screen collapses cleanly at 390px and below.

Closes #262

## Verification
- npm run lint
- npm run build
- npm test
- bash scripts/qa-preflight.sh (passes with existing JS bundle-size warning)

## Review flow
- Claude review was not requested or triggered.