### PR TITLE
Map App Routing for Jewelry Box Screens

### DIFF
--- a/docs/product/PRODUCT_SPEC.md
+++ b/docs/product/PRODUCT_SPEC.md
@@ -120,9 +120,42 @@ Nailous は、ネイル写真・メモ・タグをかんたんに残し、あと
 | 画面名 | 目的 | 状態 |
 |--------|------|------|
 | ログイン画面 | Google OAuth でサインイン | ✅ 完了 |
-| コレクション一覧 | NailItem カードグリッド、検索、ソート | ✅ 完了 |
+| コレクション一覧 | Home / Jewelry Box 拠点、検索、ソート | ✅ 完了 |
 | 追加 / 編集フォーム | タイトル・タグ・メモ・画像の入力 | ✅ 完了 |
 | 空状態ガイド | 初回ユーザー向けオンボーディング | ✅ 完了 |
+| Nail Design | デザイン詳細・カタログ閲覧 | 🔲 未着手 |
+| Inspiration | デザインのヒント・トレンド | 🔲 未着手 |
+| Saved Designs | お気に入り保存済みデザイン | 🔲 未着手 |
+| Book Appointment | サロン予約連携 | 🔲 未着手 |
+| Profile | ユーザー設定・プロフィール | 🔲 未着手 |
+
+---
+
+## Routing Configuration (Jewelry Box)
+
+Nailous は現在、`window.location.pathname` を使用した簡易的なルーティングを実装しています。Jewelry Box Refresh に向けて、以下のパス構成をサポートします。
+
+| 画面名 | パス | 説明 |
+|--------|------|------|
+| Home | `/` | Jewelry Box メイン一覧・検索 |
+| Nail Design | `/design` | 特定のネイルデザイン詳細またはカタログ |
+| Inspiration | `/inspiration` | デザインのヒントやトレンド |
+| Saved Designs | `/saved` | お気に入り・保存済みデザイン一覧 |
+| Book Appointment | `/book` | サロン予約・相談ページ |
+| Profile | `/profile` | ユーザープロフィール・設定 |
+| Privacy Policy | `/privacy` | プライバシーポリシー（既存） |
+| Terms of Service | `/terms` | 利用規約（既存） |
+| Public Share | `/share/:id` | 共有コレクション閲覧ページ（既存） |
+
+---
+
+## Routing Migration Risk
+
+現在の `App.tsx` 内での手動パス管理から、将来的に React Router 等のライブラリへ移行する際の主なリスクは以下の通りです。
+
+1. **State Management Complexity**: 手動ルーティングと React state が密結合しているため、移行時にナビゲーション状態の不整合が発生しやすい。
+2. **Deep Linking**: 現在の実装ではネストされたルートや複雑なクエリパラメータの処理が限定的であり、将来の AR Try-on 等の深層機能へのリンク対応に改修が必要。
+3. **SEO / SSR**: PWA としては問題ないが、将来的に Web 検索からの流入を重視する場合、現在のクライアントサイドのみのルーティングでは不十分になる可能性がある。
 
 ---
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -201,6 +201,11 @@ function App() {
   const isPublicSharePage = sharePathId !== null
   const isPrivacyPage = pathname === '/privacy'
   const isTermsPage = pathname === '/terms'
+  const isDesignPage = pathname === '/design'
+  const isInspirationPage = pathname === '/inspiration'
+  const isSavedPage = pathname === '/saved'
+  const isBookPage = pathname === '/book'
+  const isProfilePage = pathname === '/profile'
   const [user, setUser] = useState<User | null | undefined>(
     isFirebaseConfigComplete ? undefined : null
   )
@@ -259,11 +264,21 @@ function App() {
       document.title = 'プライバシーポリシー | Nailous'
     } else if (isTermsPage) {
       document.title = '利用規約 | Nailous'
+    } else if (isDesignPage) {
+      document.title = 'Nail Design | Nailous'
+    } else if (isInspirationPage) {
+      document.title = 'Inspiration | Nailous'
+    } else if (isSavedPage) {
+      document.title = 'Saved Designs | Nailous'
+    } else if (isBookPage) {
+      document.title = 'Book Appointment | Nailous'
+    } else if (isProfilePage) {
+      document.title = 'Profile | Nailous'
     } else {
       document.title = 'Nailous'
     }
 
-    if (isPublicSharePage || isPrivacyPage || isTermsPage) {
+    if (isPublicSharePage || isPrivacyPage || isTermsPage || isDesignPage || isInspirationPage || isSavedPage || isBookPage || isProfilePage) {
       if (meta) {
         meta.setAttribute('content', 'noindex')
       } else {
@@ -284,7 +299,7 @@ function App() {
         meta.removeAttribute('content')
       }
     }
-  }, [isPublicSharePage, isPrivacyPage, isTermsPage])
+  }, [isPublicSharePage, isPrivacyPage, isTermsPage, isDesignPage, isInspirationPage, isSavedPage, isBookPage, isProfilePage])
 
   useEffect(() => {
     if (!isPublicSharePage || !sharePathId) return
@@ -845,6 +860,24 @@ function App() {
     </footer>
   )
 
+  const renderComingSoon = (title: string) => (
+    <section id="center">
+      <h1 id="app-title">Nailous</h1>
+      <div className="legal-page">
+        <h2 className="legal-title">{title}</h2>
+        <div className="legal-content">
+          <p>この機能は現在準備中です。Jewelry Box Refresh で公開予定です。</p>
+        </div>
+        <div className="legal-actions">
+          <a href="/" onClick={(e) => { e.preventDefault(); navigateTo('/') }}>
+            ホームに戻る
+          </a>
+        </div>
+      </div>
+      {renderFooter()}
+    </section>
+  )
+
   if (isPublicSharePage) {
     return (
       <section id="center">
@@ -854,6 +887,12 @@ function App() {
       </section>
     )
   }
+
+  if (isDesignPage) return renderComingSoon('Nail Design')
+  if (isInspirationPage) return renderComingSoon('Inspiration')
+  if (isSavedPage) return renderComingSoon('Saved Designs')
+  if (isBookPage) return renderComingSoon('Book Appointment')
+  if (isProfilePage) return renderComingSoon('Profile')
 
   if (isPrivacyPage) {
     return (


### PR DESCRIPTION
Organized the application routing configuration for the "Jewelry Box" refresh. This Phase 1 update maps the following new screens:

- Home: `/`
- Nail Design: `/design`
- Inspiration: `/inspiration`
- Saved Designs: `/saved`
- Book Appointment: `/book`
- Profile: `/profile`

Existing routes (`/terms`, `/privacy`, `/share/:id`) remain fully supported. The routing is implemented incrementally within `src/App.tsx` using the current manual path management strategy, avoiding new dependencies. Migration risks related to future transitions to formal routing libraries are documented in `docs/product/PRODUCT_SPEC.md`.

Fixes #254

---
*PR created automatically by Jules for task [12997743696156814433](https://jules.google.com/task/12997743696156814433) started by @ksc0000*