### PR TITLE
feat: add nail shape selection controls

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1080,6 +1080,114 @@
   font-weight: 700;
 }
 
+.nail-control-heading {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 6px 12px;
+}
+
+.nail-control-heading span {
+  color: var(--text-h);
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+.nail-control-heading small {
+  color: #888;
+  font-size: 0.72rem;
+  line-height: 1.45;
+}
+
+.nail-shape-control {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 12px;
+  border: 1px solid color-mix(in srgb, var(--border) 72%, var(--jb-gold));
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.54);
+}
+
+.nail-shape-options {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(104px, 1fr));
+  gap: 8px;
+}
+
+.nail-shape-option {
+  min-height: var(--tap-target-min);
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 10px;
+  border: 1px solid color-mix(in srgb, var(--border) 76%, var(--jb-pink));
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.72);
+  color: var(--text-h);
+  font: inherit;
+  font-size: 0.78rem;
+  font-weight: 700;
+  cursor: pointer;
+  transition: border-color 0.18s ease, box-shadow 0.18s ease, transform 0.18s ease;
+}
+
+.nail-shape-option:hover,
+.nail-shape-option:focus-visible {
+  border-color: var(--accent-border);
+  box-shadow: 0 10px 22px rgba(170, 59, 255, 0.1);
+}
+
+.nail-shape-option:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.nail-shape-option--selected {
+  border-color: var(--jb-gold);
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.96), rgba(255, 242, 184, 0.42));
+  box-shadow:
+    inset 0 0 0 1px rgba(248, 217, 77, 0.24),
+    0 12px 26px rgba(36, 20, 41, 0.12);
+}
+
+.nail-shape-preview {
+  width: 32px;
+  height: 18px;
+  flex: 0 0 auto;
+  background:
+    linear-gradient(90deg, var(--jb-gold-soft) 0 16%, var(--jb-gold) 17% 22%, var(--jb-pink) 23% 100%);
+  box-shadow:
+    inset 3px 0 6px rgba(255, 255, 255, 0.54),
+    inset -4px -2px 8px rgba(36, 20, 41, 0.14),
+    0 8px 16px rgba(36, 20, 41, 0.16);
+}
+
+.nail-shape-preview--round {
+  border-radius: 999px;
+}
+
+.nail-shape-preview--square {
+  border-radius: 5px;
+}
+
+.nail-shape-preview--almond {
+  border-radius: 68% 100% 100% 68% / 58% 84% 84% 58%;
+}
+
+.nail-shape-preview--coffin {
+  clip-path: polygon(9% 12%, 100% 0, 100% 100%, 9% 88%, 0 68%, 0 32%);
+  border-radius: 4px;
+}
+
+.nail-shape-preview--stiletto {
+  clip-path: polygon(0 26%, 78% 0, 100% 50%, 78% 100%, 0 74%);
+  border-radius: 999px;
+}
+
 #nail-form {
   position: relative;
   overflow: hidden;
@@ -1412,6 +1520,10 @@
 
   .nail-design-meta {
     justify-content: flex-start;
+  }
+
+  .nail-shape-options {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 
   #nail-list {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -32,6 +32,15 @@ import './App.css'
 const DISPLAY_MODES = ['Glass', 'Snow Globe', 'Velvet', 'Showcase'] as const
 type DisplayMode = typeof DISPLAY_MODES[number]
 
+const NAIL_SHAPES = [
+  { id: 'round', label: 'Round' },
+  { id: 'square', label: 'Square' },
+  { id: 'almond', label: 'Almond' },
+  { id: 'coffin', label: 'Coffin' },
+  { id: 'stiletto', label: 'Stiletto' },
+] as const
+type NailShape = typeof NAIL_SHAPES[number]['id']
+
 const sortByDate = (items: NailItemDoc[]): NailItemDoc[] =>
   [...items].sort((a, b) => {
     const ta = (a.updatedAt ?? a.createdAt)?.seconds ?? 0
@@ -212,6 +221,7 @@ function App() {
   const [nailTitle, setNailTitle] = useState('')
   const [nailTags, setNailTags] = useState('')
   const [nailMemo, setNailMemo] = useState('')
+  const [selectedNailShape, setSelectedNailShape] = useState<NailShape>('round')
   const [nailImageFile, setNailImageFile] = useState<File | null>(null)
   const [nailImagePreview, setNailImagePreview] = useState<string | null>(null)
   const [nailImageSource, setNailImageSource] = useState<'upload' | 'camera' | 'unknown'>('unknown')
@@ -487,6 +497,7 @@ function App() {
     setNailTitle('')
     setNailTags('')
     setNailMemo('')
+    setSelectedNailShape('round')
     setNailImageFile(null)
     clearPreview()
     clearImageInputs()
@@ -588,6 +599,7 @@ function App() {
     setNailTitle(item.title)
     setNailTags(item.tags.join(', '))
     setNailMemo(item.memo ?? '')
+    setSelectedNailShape('round')
     setNailImageSource(item.imageSource ?? 'unknown')
     setNailImageFile(null)
     clearPreview()
@@ -1107,6 +1119,26 @@ function App() {
               <p className="nail-input-note">
                 タグはカンマ区切りで最大{MAX_NAIL_TAGS}個、1つ{MAX_NAIL_TAG_LENGTH}文字まで。
               </p>
+              <div className="nail-shape-control" role="group" aria-label="ネイル形状">
+                <div className="nail-control-heading">
+                  <span>Shape</span>
+                  <small>ビュー用の選択。保存連携は後続フェーズで追加します。</small>
+                </div>
+                <div className="nail-shape-options">
+                  {NAIL_SHAPES.map(shape => (
+                    <button
+                      key={shape.id}
+                      type="button"
+                      className={`nail-shape-option${selectedNailShape === shape.id ? ' nail-shape-option--selected' : ''}`}
+                      aria-pressed={selectedNailShape === shape.id}
+                      onClick={() => setSelectedNailShape(shape.id)}
+                    >
+                      <span className={`nail-shape-preview nail-shape-preview--${shape.id}`} aria-hidden="true" />
+                      <span>{shape.label}</span>
+                    </button>
+                  ))}
+                </div>
+              </div>
               {isAiTagSuggestionEnabled && (nailImageFile || editingItem?.imageUrl) && (
                 <button
                   type="button"


### PR DESCRIPTION
## Summary
- Add Round, Square, Almond, Coffin, and Stiletto shape controls to the Nail Design screen.
- Add clear selected/pressed states with shape previews and 390px-safe wrapping.
- Keep the selection local and visual-only; Firestore saving remains deferred to the data integration phase.

Closes #263

## Verification
- npm run lint
- npm run build
- npm test
- bash scripts/qa-preflight.sh (passes with existing JS bundle-size warning)

## Review flow
- Claude review was not requested or triggered.