### PR TITLE
feat: add nail color and texture controls

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1188,6 +1188,136 @@
   border-radius: 999px;
 }
 
+.nail-appearance-control {
+  display: grid;
+  grid-template-columns: minmax(0, 1.15fr) minmax(0, 1fr);
+  gap: 10px;
+}
+
+.nail-color-control,
+.nail-texture-control {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 12px;
+  border: 1px solid color-mix(in srgb, var(--border) 72%, var(--jb-pink));
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.5);
+}
+
+.nail-color-options,
+.nail-texture-options {
+  display: grid;
+  gap: 8px;
+}
+
+.nail-color-options {
+  grid-template-columns: repeat(auto-fit, minmax(92px, 1fr));
+}
+
+.nail-texture-options {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.nail-color-option,
+.nail-texture-option {
+  min-height: var(--tap-target-min);
+  border: 1px solid color-mix(in srgb, var(--border) 76%, var(--jb-pink));
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.72);
+  color: var(--text-h);
+  font: inherit;
+  font-size: 0.76rem;
+  font-weight: 700;
+  cursor: pointer;
+  transition: border-color 0.18s ease, box-shadow 0.18s ease, transform 0.18s ease;
+}
+
+.nail-color-option {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 9px;
+}
+
+.nail-texture-option {
+  padding: 8px 10px;
+}
+
+.nail-color-option:hover,
+.nail-color-option:focus-visible,
+.nail-texture-option:hover,
+.nail-texture-option:focus-visible {
+  border-color: var(--accent-border);
+  box-shadow: 0 10px 22px rgba(170, 59, 255, 0.1);
+}
+
+.nail-color-option:focus-visible,
+.nail-texture-option:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.nail-color-option--selected,
+.nail-texture-option--selected {
+  border-color: var(--jb-gold);
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.96), rgba(255, 242, 184, 0.42));
+  box-shadow:
+    inset 0 0 0 1px rgba(248, 217, 77, 0.24),
+    0 12px 26px rgba(36, 20, 41, 0.12);
+}
+
+.nail-color-swatch {
+  width: 24px;
+  height: 24px;
+  flex: 0 0 auto;
+  border: 1px solid rgba(255, 255, 255, 0.66);
+  border-radius: 999px;
+  box-shadow:
+    inset 3px 3px 8px rgba(255, 255, 255, 0.44),
+    inset -4px -4px 8px rgba(36, 20, 41, 0.12),
+    0 6px 12px rgba(36, 20, 41, 0.14);
+}
+
+.nail-color-swatch--blush {
+  background: #ffd6e3;
+}
+
+.nail-color-swatch--rose {
+  background: var(--jb-rose);
+}
+
+.nail-color-swatch--lavender {
+  background: var(--jb-lavender);
+}
+
+.nail-color-swatch--mint {
+  background: var(--jb-mint);
+}
+
+.nail-color-swatch--champagne {
+  background: var(--jb-gold-soft);
+}
+
+.nail-texture-option--gloss {
+  background-image: linear-gradient(135deg, rgba(255, 255, 255, 0.92), rgba(255, 214, 227, 0.44));
+}
+
+.nail-texture-option--matte {
+  background-image: linear-gradient(135deg, rgba(248, 244, 248, 0.9), rgba(225, 220, 229, 0.7));
+}
+
+.nail-texture-option--glitter {
+  background-image:
+    radial-gradient(circle at 22% 28%, rgba(248, 217, 77, 0.78) 0 2px, transparent 2px),
+    radial-gradient(circle at 76% 62%, rgba(255, 255, 255, 0.9) 0 1.5px, transparent 1.5px),
+    linear-gradient(135deg, rgba(255, 242, 184, 0.74), rgba(248, 187, 208, 0.56));
+}
+
+.nail-texture-option--chrome {
+  background-image: linear-gradient(115deg, #fff 0 18%, #b1a7ff 32%, #f8d94d 54%, #ec407a 72%, #fff 100%);
+}
+
 #nail-form {
   position: relative;
   overflow: hidden;
@@ -1523,6 +1653,15 @@
   }
 
   .nail-shape-options {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .nail-appearance-control {
+    grid-template-columns: 1fr;
+  }
+
+  .nail-color-options,
+  .nail-texture-options {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -41,6 +41,23 @@ const NAIL_SHAPES = [
 ] as const
 type NailShape = typeof NAIL_SHAPES[number]['id']
 
+const NAIL_COLORS = [
+  { id: 'blush', label: 'Blush' },
+  { id: 'rose', label: 'Rose' },
+  { id: 'lavender', label: 'Lavender' },
+  { id: 'mint', label: 'Mint' },
+  { id: 'champagne', label: 'Champagne' },
+] as const
+type NailColor = typeof NAIL_COLORS[number]['id']
+
+const NAIL_TEXTURES = [
+  { id: 'gloss', label: 'Gloss' },
+  { id: 'matte', label: 'Matte' },
+  { id: 'glitter', label: 'Glitter' },
+  { id: 'chrome', label: 'Chrome' },
+] as const
+type NailTexture = typeof NAIL_TEXTURES[number]['id']
+
 const sortByDate = (items: NailItemDoc[]): NailItemDoc[] =>
   [...items].sort((a, b) => {
     const ta = (a.updatedAt ?? a.createdAt)?.seconds ?? 0
@@ -222,6 +239,8 @@ function App() {
   const [nailTags, setNailTags] = useState('')
   const [nailMemo, setNailMemo] = useState('')
   const [selectedNailShape, setSelectedNailShape] = useState<NailShape>('round')
+  const [selectedNailColor, setSelectedNailColor] = useState<NailColor>('blush')
+  const [selectedNailTexture, setSelectedNailTexture] = useState<NailTexture>('gloss')
   const [nailImageFile, setNailImageFile] = useState<File | null>(null)
   const [nailImagePreview, setNailImagePreview] = useState<string | null>(null)
   const [nailImageSource, setNailImageSource] = useState<'upload' | 'camera' | 'unknown'>('unknown')
@@ -498,6 +517,8 @@ function App() {
     setNailTags('')
     setNailMemo('')
     setSelectedNailShape('round')
+    setSelectedNailColor('blush')
+    setSelectedNailTexture('gloss')
     setNailImageFile(null)
     clearPreview()
     clearImageInputs()
@@ -600,6 +621,8 @@ function App() {
     setNailTags(item.tags.join(', '))
     setNailMemo(item.memo ?? '')
     setSelectedNailShape('round')
+    setSelectedNailColor('blush')
+    setSelectedNailTexture('gloss')
     setNailImageSource(item.imageSource ?? 'unknown')
     setNailImageFile(null)
     clearPreview()
@@ -1137,6 +1160,47 @@ function App() {
                       <span>{shape.label}</span>
                     </button>
                   ))}
+                </div>
+              </div>
+              <div className="nail-appearance-control">
+                <div className="nail-color-control" role="group" aria-label="メインカラー">
+                  <div className="nail-control-heading">
+                    <span>Color</span>
+                    <small>メインカラー</small>
+                  </div>
+                  <div className="nail-color-options">
+                    {NAIL_COLORS.map(color => (
+                      <button
+                        key={color.id}
+                        type="button"
+                        className={`nail-color-option${selectedNailColor === color.id ? ' nail-color-option--selected' : ''}`}
+                        aria-pressed={selectedNailColor === color.id}
+                        onClick={() => setSelectedNailColor(color.id)}
+                      >
+                        <span className={`nail-color-swatch nail-color-swatch--${color.id}`} aria-hidden="true" />
+                        <span>{color.label}</span>
+                      </button>
+                    ))}
+                  </div>
+                </div>
+                <div className="nail-texture-control" role="group" aria-label="質感">
+                  <div className="nail-control-heading">
+                    <span>Texture</span>
+                    <small>仕上げ</small>
+                  </div>
+                  <div className="nail-texture-options">
+                    {NAIL_TEXTURES.map(texture => (
+                      <button
+                        key={texture.id}
+                        type="button"
+                        className={`nail-texture-option nail-texture-option--${texture.id}${selectedNailTexture === texture.id ? ' nail-texture-option--selected' : ''}`}
+                        aria-pressed={selectedNailTexture === texture.id}
+                        onClick={() => setSelectedNailTexture(texture.id)}
+                      >
+                        {texture.label}
+                      </button>
+                    ))}
+                  </div>
                 </div>
               </div>
               {isAiTagSuggestionEnabled && (nailImageFile || editingItem?.imageUrl) && (


### PR DESCRIPTION
## Summary
- Add color swatch controls for Blush, Rose, Lavender, Mint, and Champagne.
- Add texture controls for Gloss, Matte, Glitter, and Chrome.
- Keep color and texture local/visual-only for now; Firestore saving remains deferred to the data integration phase.
- Ensure the controls collapse cleanly for 390px mobile layouts.

Closes #264

## Verification
- npm run lint
- npm run build
- npm test
- bash scripts/qa-preflight.sh (passes with existing JS bundle-size warning)

## Review flow
- Claude review was not requested or triggered.