### PR TITLE
feat: add decoration parts controls

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1318,6 +1318,194 @@
   background-image: linear-gradient(115deg, #fff 0 18%, #b1a7ff 32%, #f8d94d 54%, #ec407a 72%, #fff 100%);
 }
 
+.nail-decoration-control {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 12px;
+  border: 1px solid color-mix(in srgb, var(--border) 72%, var(--jb-gold));
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.5);
+}
+
+.nail-decoration-options {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(112px, 1fr));
+  gap: 8px;
+}
+
+.nail-decoration-option {
+  min-height: var(--tap-target-min);
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 10px;
+  border: 1px solid color-mix(in srgb, var(--border) 76%, var(--jb-pink));
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.72);
+  color: var(--text-h);
+  font: inherit;
+  font-size: 0.76rem;
+  font-weight: 700;
+  cursor: pointer;
+  transition: border-color 0.18s ease, box-shadow 0.18s ease, transform 0.18s ease;
+}
+
+.nail-decoration-option:hover,
+.nail-decoration-option:focus-visible {
+  border-color: var(--accent-border);
+  box-shadow: 0 10px 22px rgba(170, 59, 255, 0.1);
+}
+
+.nail-decoration-option:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.nail-decoration-option--selected {
+  border-color: var(--jb-gold);
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.96), rgba(255, 242, 184, 0.42));
+  box-shadow:
+    inset 0 0 0 1px rgba(248, 217, 77, 0.24),
+    0 12px 26px rgba(36, 20, 41, 0.12);
+}
+
+.nail-decoration-preview {
+  width: 32px;
+  height: 24px;
+  flex: 0 0 auto;
+  position: relative;
+  display: block;
+  border-radius: 8px;
+  background: rgba(248, 244, 248, 0.76);
+  box-shadow: inset 0 0 0 1px rgba(36, 20, 41, 0.08);
+}
+
+.nail-decoration-preview span {
+  position: absolute;
+  display: block;
+}
+
+.nail-decoration-option--pearl .nail-decoration-preview span {
+  width: 8px;
+  height: 8px;
+  border-radius: 999px;
+  background: radial-gradient(circle at 32% 28%, #fff, #f0edf4 58%, #d9d3df);
+  box-shadow: 0 2px 5px rgba(36, 20, 41, 0.18);
+}
+
+.nail-decoration-option--pearl .nail-decoration-preview span:nth-child(1) {
+  left: 6px;
+  top: 8px;
+}
+
+.nail-decoration-option--pearl .nail-decoration-preview span:nth-child(2) {
+  left: 14px;
+  top: 5px;
+}
+
+.nail-decoration-option--pearl .nail-decoration-preview span:nth-child(3) {
+  left: 20px;
+  top: 11px;
+}
+
+.nail-decoration-option--stone .nail-decoration-preview span {
+  width: 9px;
+  height: 9px;
+  transform: rotate(45deg);
+  background: linear-gradient(135deg, #fff, var(--jb-lavender));
+  box-shadow: 0 2px 5px rgba(36, 20, 41, 0.18);
+}
+
+.nail-decoration-option--stone .nail-decoration-preview span:nth-child(1) {
+  left: 5px;
+  top: 7px;
+}
+
+.nail-decoration-option--stone .nail-decoration-preview span:nth-child(2) {
+  left: 17px;
+  top: 8px;
+}
+
+.nail-decoration-option--stone .nail-decoration-preview span:nth-child(3) {
+  display: none;
+}
+
+.nail-decoration-option--line .nail-decoration-preview span {
+  width: 26px;
+  height: 3px;
+  left: 3px;
+  border-radius: 999px;
+  background: var(--jb-gold);
+  box-shadow: 0 1px 4px rgba(248, 217, 77, 0.4);
+}
+
+.nail-decoration-option--line .nail-decoration-preview span:nth-child(1) {
+  top: 6px;
+  transform: rotate(-10deg);
+}
+
+.nail-decoration-option--line .nail-decoration-preview span:nth-child(2) {
+  top: 14px;
+  transform: rotate(8deg);
+}
+
+.nail-decoration-option--line .nail-decoration-preview span:nth-child(3) {
+  display: none;
+}
+
+.nail-decoration-option--foil .nail-decoration-preview span {
+  width: 10px;
+  height: 8px;
+  background: linear-gradient(135deg, #fff7cf, var(--jb-gold), #fff);
+  clip-path: polygon(12% 0, 100% 18%, 84% 100%, 0 78%);
+}
+
+.nail-decoration-option--foil .nail-decoration-preview span:nth-child(1) {
+  left: 5px;
+  top: 6px;
+}
+
+.nail-decoration-option--foil .nail-decoration-preview span:nth-child(2) {
+  left: 17px;
+  top: 10px;
+  transform: rotate(22deg);
+}
+
+.nail-decoration-option--foil .nail-decoration-preview span:nth-child(3) {
+  display: none;
+}
+
+.nail-decoration-option--ribbon .nail-decoration-preview span {
+  background: var(--jb-rose);
+}
+
+.nail-decoration-option--ribbon .nail-decoration-preview span:nth-child(1),
+.nail-decoration-option--ribbon .nail-decoration-preview span:nth-child(2) {
+  width: 12px;
+  height: 10px;
+  top: 7px;
+  border-radius: 8px 2px 8px 2px;
+}
+
+.nail-decoration-option--ribbon .nail-decoration-preview span:nth-child(1) {
+  left: 5px;
+  transform: rotate(32deg);
+}
+
+.nail-decoration-option--ribbon .nail-decoration-preview span:nth-child(2) {
+  right: 5px;
+  transform: rotate(-32deg);
+}
+
+.nail-decoration-option--ribbon .nail-decoration-preview span:nth-child(3) {
+  width: 6px;
+  height: 6px;
+  left: 13px;
+  top: 9px;
+  border-radius: 999px;
+}
+
 #nail-form {
   position: relative;
   overflow: hidden;
@@ -1661,7 +1849,8 @@
   }
 
   .nail-color-options,
-  .nail-texture-options {
+  .nail-texture-options,
+  .nail-decoration-options {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -58,6 +58,15 @@ const NAIL_TEXTURES = [
 ] as const
 type NailTexture = typeof NAIL_TEXTURES[number]['id']
 
+const DECORATION_PARTS = [
+  { id: 'pearl', label: 'Pearl' },
+  { id: 'stone', label: 'Stone' },
+  { id: 'line', label: 'Gold Line' },
+  { id: 'foil', label: 'Foil' },
+  { id: 'ribbon', label: 'Ribbon' },
+] as const
+type DecorationPart = typeof DECORATION_PARTS[number]['id']
+
 const sortByDate = (items: NailItemDoc[]): NailItemDoc[] =>
   [...items].sort((a, b) => {
     const ta = (a.updatedAt ?? a.createdAt)?.seconds ?? 0
@@ -241,6 +250,7 @@ function App() {
   const [selectedNailShape, setSelectedNailShape] = useState<NailShape>('round')
   const [selectedNailColor, setSelectedNailColor] = useState<NailColor>('blush')
   const [selectedNailTexture, setSelectedNailTexture] = useState<NailTexture>('gloss')
+  const [selectedDecorationParts, setSelectedDecorationParts] = useState<DecorationPart[]>([])
   const [nailImageFile, setNailImageFile] = useState<File | null>(null)
   const [nailImagePreview, setNailImagePreview] = useState<string | null>(null)
   const [nailImageSource, setNailImageSource] = useState<'upload' | 'camera' | 'unknown'>('unknown')
@@ -519,6 +529,7 @@ function App() {
     setSelectedNailShape('round')
     setSelectedNailColor('blush')
     setSelectedNailTexture('gloss')
+    setSelectedDecorationParts([])
     setNailImageFile(null)
     clearPreview()
     clearImageInputs()
@@ -556,6 +567,12 @@ function App() {
     } finally {
       setIsAIGeneratingTags(false)
     }
+  }
+
+  const handleToggleDecorationPart = (part: DecorationPart) => {
+    setSelectedDecorationParts(prev =>
+      prev.includes(part) ? prev.filter(p => p !== part) : [...prev, part]
+    )
   }
 
   const handleSubmitNailItem = async () => {
@@ -623,6 +640,7 @@ function App() {
     setSelectedNailShape('round')
     setSelectedNailColor('blush')
     setSelectedNailTexture('gloss')
+    setSelectedDecorationParts([])
     setNailImageSource(item.imageSource ?? 'unknown')
     setNailImageFile(null)
     clearPreview()
@@ -1201,6 +1219,33 @@ function App() {
                       </button>
                     ))}
                   </div>
+                </div>
+              </div>
+              <div className="nail-decoration-control" role="group" aria-label="デコレーションパーツ">
+                <div className="nail-control-heading">
+                  <span>Deco Parts</span>
+                  <small>複数選択できます。保存連携は後続フェーズで追加します。</small>
+                </div>
+                <div className="nail-decoration-options">
+                  {DECORATION_PARTS.map(part => {
+                    const isSelected = selectedDecorationParts.includes(part.id)
+                    return (
+                      <button
+                        key={part.id}
+                        type="button"
+                        className={`nail-decoration-option nail-decoration-option--${part.id}${isSelected ? ' nail-decoration-option--selected' : ''}`}
+                        aria-pressed={isSelected}
+                        onClick={() => handleToggleDecorationPart(part.id)}
+                      >
+                        <span className="nail-decoration-preview" aria-hidden="true">
+                          <span />
+                          <span />
+                          <span />
+                        </span>
+                        <span>{part.label}</span>
+                      </button>
+                    )
+                  })}
                 </div>
               </div>
               {isAiTagSuggestionEnabled && (nailImageFile || editingItem?.imageUrl) && (


### PR DESCRIPTION
## Summary
- Add a CSS-only decoration parts grid for Pearl, Stone, Gold Line, Foil, and Ribbon.
- Support multi-select local state with clear selected/pressed styling.
- Avoid external packages, paid assets, and Firestore/data-model changes.
- Keep the controls responsive for 390px mobile layouts.

Closes #265

## Verification
- npm run lint
- npm run build
- npm test
- bash scripts/qa-preflight.sh (passes with existing JS bundle-size warning)

## Review flow
- Claude review was not requested or triggered.