### PR TITLE
feat: add static Inspiration screen

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1060,6 +1060,148 @@
   line-height: 1.65;
 }
 
+.inspiration-screen {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 18px;
+  border: 1px solid color-mix(in srgb, var(--border) 70%, var(--jb-pink));
+  border-radius: 10px;
+  background:
+    radial-gradient(circle at 88% 8%, rgba(248, 217, 77, 0.16), transparent 26%),
+    linear-gradient(135deg, rgba(255, 255, 255, 0.9), rgba(248, 244, 248, 0.72));
+  box-shadow: 0 18px 42px rgba(36, 20, 41, 0.07);
+}
+
+.inspiration-header {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: start;
+  gap: 12px;
+}
+
+.inspiration-header h3 {
+  margin: 0 0 6px;
+  color: var(--text-h);
+  font-size: clamp(1.18rem, 3vw, 1.5rem);
+  line-height: 1.25;
+}
+
+.inspiration-header p {
+  max-width: 560px;
+  margin: 0;
+  color: var(--text);
+  font-size: 0.84rem;
+  line-height: 1.65;
+}
+
+.inspiration-badge {
+  display: inline-flex;
+  align-items: center;
+  min-height: 28px;
+  padding: 4px 10px;
+  border: 1px solid color-mix(in srgb, var(--jb-gold) 28%, var(--border));
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.72);
+  color: var(--text-h);
+  font-size: 0.68rem;
+  font-weight: 800;
+  white-space: nowrap;
+}
+
+.inspiration-card-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.inspiration-card {
+  min-width: 0;
+  overflow: hidden;
+  border: 1px solid color-mix(in srgb, var(--border) 70%, var(--jb-gold));
+  border-radius: 10px;
+  background: rgba(255, 255, 255, 0.74);
+}
+
+.inspiration-card-stage {
+  position: relative;
+  height: 118px;
+  background:
+    radial-gradient(ellipse at 50% 82%, rgba(36, 20, 41, 0.12), transparent 56%),
+    linear-gradient(160deg, #120b18, #2a1730);
+}
+
+.inspiration-card-stage span {
+  position: absolute;
+  width: 74px;
+  height: 20px;
+  border-radius: 999px;
+  background: linear-gradient(90deg, var(--jb-gold-soft) 0 14%, var(--jb-gold) 15% 20%, var(--inspiration-tone, var(--jb-pink)) 21% 100%);
+  box-shadow:
+    inset 3px 0 7px rgba(255, 255, 255, 0.48),
+    inset -4px -2px 8px rgba(28, 10, 22, 0.18),
+    0 14px 22px rgba(0, 0, 0, 0.28);
+}
+
+.inspiration-card-stage span:nth-child(1) {
+  left: 16%;
+  top: 42px;
+  transform: rotate(-18deg);
+}
+
+.inspiration-card-stage span:nth-child(2) {
+  left: 44%;
+  top: 28px;
+  transform: rotate(52deg);
+}
+
+.inspiration-card-stage span:nth-child(3) {
+  right: 10%;
+  top: 68px;
+  transform: rotate(8deg);
+}
+
+.inspiration-card--blush {
+  --inspiration-tone: #ffd6e3;
+}
+
+.inspiration-card--mint {
+  --inspiration-tone: var(--jb-mint);
+}
+
+.inspiration-card--rose {
+  --inspiration-tone: var(--jb-rose);
+}
+
+.inspiration-card-body {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 12px;
+}
+
+.inspiration-card h4 {
+  margin: 0;
+  color: var(--text-h);
+  font-size: 0.95rem;
+  line-height: 1.3;
+}
+
+.inspiration-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.inspiration-tags span {
+  padding: 2px 8px;
+  border-radius: 999px;
+  background: var(--accent-bg);
+  color: var(--accent);
+  font-size: 0.68rem;
+  font-weight: 700;
+}
+
 .nail-design-meta {
   display: flex;
   flex-wrap: wrap;
@@ -1834,6 +1976,18 @@
   .nail-design-header {
     grid-template-columns: 1fr;
     align-items: start;
+  }
+
+  .inspiration-header {
+    grid-template-columns: 1fr;
+  }
+
+  .inspiration-badge {
+    justify-self: start;
+  }
+
+  .inspiration-card-grid {
+    grid-template-columns: 1fr;
   }
 
   .nail-design-meta {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -67,6 +67,12 @@ const DECORATION_PARTS = [
 ] as const
 type DecorationPart = typeof DECORATION_PARTS[number]['id']
 
+const INSPIRATION_CARDS = [
+  { id: 'milk-glass', title: 'Milk glass', tone: 'blush', tags: ['soft', 'daily'] },
+  { id: 'aurora-mint', title: 'Aurora mint', tone: 'mint', tags: ['fresh', 'sheer'] },
+  { id: 'velvet-rose', title: 'Velvet rose', tone: 'rose', tags: ['date', 'gloss'] },
+] as const
+
 const sortByDate = (items: NailItemDoc[]): NailItemDoc[] =>
   [...items].sort((a, b) => {
     const ta = (a.updatedAt ?? a.createdAt)?.seconds ?? 0
@@ -1337,6 +1343,33 @@ function App() {
                 )}
               </div>
               {nailError && <p className="nail-error">{nailError}</p>}
+            </div>
+          </section>
+          <section className="inspiration-screen" aria-labelledby="inspiration-title">
+            <div className="inspiration-header">
+              <div>
+                <p className="nail-design-kicker">INSPIRATION</p>
+                <h3 id="inspiration-title">次のムードを探す。</h3>
+                <p>保存前のアイデアを眺めるためのExplore領域です。カードは今後、実データやカテゴリに接続します。</p>
+              </div>
+              <span className="inspiration-badge">Static preview</span>
+            </div>
+            <div className="inspiration-card-grid">
+              {INSPIRATION_CARDS.map(card => (
+                <article key={card.id} className={`inspiration-card inspiration-card--${card.tone}`}>
+                  <div className="inspiration-card-stage" aria-hidden="true">
+                    <span />
+                    <span />
+                    <span />
+                  </div>
+                  <div className="inspiration-card-body">
+                    <h4>{card.title}</h4>
+                    <div className="inspiration-tags">
+                      {card.tags.map(tag => <span key={tag}>#{tag}</span>)}
+                    </div>
+                  </div>
+                </article>
+              ))}
             </div>
           </section>
           {!isFetching && nailItems.length > 0 && (


### PR DESCRIPTION
## Summary
- Add a static Inspiration / Explore section after the Nail Design screen.
- Render dummy inspiration cards with CSS-only nail chip previews and tags.
- Keep the section data-free and avoid Firestore schema changes or external assets.
- Collapse the Explore grid to one column on small mobile widths.

Closes #266

## Verification
- npm run lint
- npm run build
- npm test
- bash scripts/qa-preflight.sh (passes with existing JS bundle-size warning)

## Review flow
- Claude review was not requested or triggered.