### PR TITLE
feat: add Inspiration category tabs

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1109,6 +1109,48 @@
   white-space: nowrap;
 }
 
+.inspiration-category-tabs {
+  display: flex;
+  gap: 8px;
+  overflow-x: auto;
+  overscroll-behavior-inline: contain;
+  padding: 2px 0 6px;
+  scrollbar-width: thin;
+}
+
+.inspiration-category-tabs button {
+  min-height: var(--tap-target-min);
+  flex: 0 0 auto;
+  padding: 8px 14px;
+  border: 1px solid color-mix(in srgb, var(--border) 72%, var(--jb-pink));
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.7);
+  color: var(--text-h);
+  font: inherit;
+  font-size: 0.76rem;
+  font-weight: 800;
+  cursor: pointer;
+  transition: border-color 0.18s ease, background 0.18s ease, color 0.18s ease;
+}
+
+.inspiration-category-tabs button:hover,
+.inspiration-category-tabs button:focus-visible {
+  border-color: var(--accent-border);
+}
+
+.inspiration-category-tabs button:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.inspiration-category-tabs button.active,
+.inspiration-category-tabs button[aria-selected='true'] {
+  border-color: var(--jb-gold);
+  background: linear-gradient(135deg, var(--jb-black), var(--jb-plum));
+  color: rgba(255, 255, 255, 0.94);
+  box-shadow: 0 10px 24px rgba(36, 20, 41, 0.14);
+}
+
 .inspiration-card-grid {
   display: grid;
   grid-template-columns: repeat(3, minmax(0, 1fr));

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -73,6 +73,9 @@ const INSPIRATION_CARDS = [
   { id: 'velvet-rose', title: 'Velvet rose', tone: 'rose', tags: ['date', 'gloss'] },
 ] as const
 
+const INSPIRATION_CATEGORIES = ['All', 'Daily', 'Event', 'Season', 'Salon'] as const
+type InspirationCategory = typeof INSPIRATION_CATEGORIES[number]
+
 const sortByDate = (items: NailItemDoc[]): NailItemDoc[] =>
   [...items].sort((a, b) => {
     const ta = (a.updatedAt ?? a.createdAt)?.seconds ?? 0
@@ -257,6 +260,7 @@ function App() {
   const [selectedNailColor, setSelectedNailColor] = useState<NailColor>('blush')
   const [selectedNailTexture, setSelectedNailTexture] = useState<NailTexture>('gloss')
   const [selectedDecorationParts, setSelectedDecorationParts] = useState<DecorationPart[]>([])
+  const [activeInspirationCategory, setActiveInspirationCategory] = useState<InspirationCategory>('All')
   const [nailImageFile, setNailImageFile] = useState<File | null>(null)
   const [nailImagePreview, setNailImagePreview] = useState<string | null>(null)
   const [nailImageSource, setNailImageSource] = useState<'upload' | 'camera' | 'unknown'>('unknown')
@@ -1353,6 +1357,20 @@ function App() {
                 <p>保存前のアイデアを眺めるためのExplore領域です。カードは今後、実データやカテゴリに接続します。</p>
               </div>
               <span className="inspiration-badge">Static preview</span>
+            </div>
+            <div className="inspiration-category-tabs" role="tablist" aria-label="Inspiration categories">
+              {INSPIRATION_CATEGORIES.map(category => (
+                <button
+                  key={category}
+                  type="button"
+                  role="tab"
+                  className={activeInspirationCategory === category ? 'active' : undefined}
+                  aria-selected={activeInspirationCategory === category}
+                  onClick={() => setActiveInspirationCategory(category)}
+                >
+                  {category}
+                </button>
+              ))}
             </div>
             <div className="inspiration-card-grid">
               {INSPIRATION_CARDS.map(card => (


### PR DESCRIPTION
## Summary
- Add horizontal, scroll-safe Inspiration category tabs for All, Daily, Event, Season, and Salon.
- Add clear active/selected styling with accessible tab semantics.
- Keep the tabs local/visual-only with no data fetching.

Closes #267

## Verification
- npm run lint
- npm run build
- npm test
- bash scripts/qa-preflight.sh (passes with existing JS bundle-size warning)

## Review flow
- Claude review was not requested or triggered.