### PR TITLE
[codex] Add premium nail card grid UI

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1988,8 +1988,8 @@
   padding: 0;
   margin: 0;
   display: grid;
-  grid-template-columns: repeat(2, 1fr);
-  gap: 12px;
+  grid-template-columns: repeat(auto-fit, minmax(230px, 1fr));
+  gap: 14px;
 }
 
 @media (max-width: 480px) {
@@ -2061,12 +2061,31 @@
 }
 
 #nail-list li {
+  position: relative;
   display: flex;
   flex-direction: column;
-  border: 1px solid var(--border);
-  border-radius: 10px;
+  min-height: 360px;
+  border: 1px solid color-mix(in srgb, var(--jb-gold) 24%, var(--border));
+  border-radius: 8px;
   overflow: hidden;
-  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.06);
+  background:
+    linear-gradient(145deg, rgba(255, 255, 255, 0.94), rgba(250, 245, 250, 0.76)),
+    rgba(255, 255, 255, 0.72);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.82),
+    0 18px 36px rgba(54, 30, 42, 0.12);
+  isolation: isolate;
+}
+
+#nail-list li::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  z-index: -1;
+  pointer-events: none;
+  background:
+    linear-gradient(125deg, rgba(255, 255, 255, 0.36), transparent 32% 72%, rgba(248, 217, 77, 0.14)),
+    radial-gradient(circle at 84% 0%, rgba(248, 217, 77, 0.2), transparent 34%);
 }
 
 #nail-list li.editing {
@@ -2082,7 +2101,10 @@
   position: relative;
   aspect-ratio: 4 / 3;
   overflow: hidden;
-  background: var(--border);
+  background:
+    radial-gradient(circle at 50% 40%, rgba(255, 239, 246, 0.72), transparent 40%),
+    radial-gradient(ellipse at 50% 86%, rgba(86, 55, 72, 0.2), transparent 58%),
+    linear-gradient(145deg, rgba(255, 255, 255, 0.74), rgba(245, 238, 246, 0.38));
   cursor: pointer;
 }
 
@@ -2090,10 +2112,69 @@
   position: absolute;
   inset: 0;
   display: flex;
+  flex-direction: column;
   align-items: center;
   justify-content: center;
-  font-size: 0.75rem;
-  color: #aaa;
+  gap: 8px;
+  padding: 18px;
+  box-sizing: border-box;
+  color: rgba(55, 42, 52, 0.58);
+  font-size: 0.66rem;
+  font-weight: 700;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+.has-image .nail-thumb-placeholder {
+  opacity: 0;
+}
+
+.nail-thumb-showcase {
+  position: relative;
+  width: min(172px, 82%);
+  height: 112px;
+}
+
+.nail-thumb-showcase::after {
+  content: '';
+  position: absolute;
+  left: 10%;
+  right: 10%;
+  bottom: 12px;
+  height: 28px;
+  border-radius: 50%;
+  background: radial-gradient(ellipse at 50% 50%, rgba(77, 48, 64, 0.2), transparent 70%);
+  filter: blur(1px);
+}
+
+.nail-thumb-chip {
+  animation-duration: 5.2s;
+}
+
+.nail-thumb-chip--one {
+  --chip-color: var(--jb-lavender);
+  left: 6%;
+  top: 42px;
+  width: 112px;
+  transform: rotate(-16deg) scaleY(0.62);
+}
+
+.nail-thumb-chip--two {
+  --chip-color: #f8dfe9;
+  left: 36%;
+  top: 20px;
+  width: 86px;
+  transform: rotate(20deg) scaleY(0.74);
+  animation-delay: -1.5s;
+}
+
+.nail-thumb-chip--three {
+  --chip-color: var(--jb-mint);
+  right: 8%;
+  top: 62px;
+  width: 90px;
+  transform: rotate(54deg) scaleY(0.78);
+  animation-delay: -2.4s;
 }
 
 .nail-thumb-img {
@@ -2102,20 +2183,21 @@
   width: 100%;
   height: 100%;
   object-fit: cover;
+  z-index: 1;
 }
 
 .nail-card-body {
-  padding: 10px 12px;
+  padding: 12px 14px 10px;
   flex: 1;
   display: flex;
   flex-direction: column;
-  gap: 6px;
+  gap: 8px;
   cursor: pointer;
 }
 
 .nail-item-title {
-  font-size: 0.9rem;
-  font-weight: 600;
+  font-size: 0.94rem;
+  font-weight: 800;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -2136,7 +2218,7 @@
 
 .nail-item-date {
   font-size: 0.72rem;
-  color: #888;
+  color: rgba(55, 42, 52, 0.54);
   margin: 0;
   margin-top: auto;
 }
@@ -2149,9 +2231,12 @@
 
 .nail-tag {
   font-size: 0.7rem;
-  padding: 2px 8px;
-  background: var(--accent-bg);
-  color: var(--accent);
+  padding: 3px 8px;
+  background:
+    linear-gradient(135deg, rgba(255, 255, 255, 0.78), rgba(248, 217, 77, 0.12)),
+    var(--accent-bg);
+  color: color-mix(in srgb, var(--accent) 76%, #4b2d3d);
+  border: 1px solid color-mix(in srgb, var(--jb-gold) 18%, transparent);
   border-radius: 9999px;
   line-height: 1.6;
 }
@@ -2161,8 +2246,41 @@
   flex-wrap: wrap;
   gap: 6px;
   justify-content: flex-end;
-  padding: 8px 12px;
-  border-top: 1px solid var(--border);
+  padding: 10px 12px 12px;
+  border-top: 1px solid color-mix(in srgb, var(--jb-gold) 18%, var(--border));
+  background: rgba(255, 255, 255, 0.42);
+}
+
+.nail-item-actions button {
+  min-height: 34px;
+  border: 1px solid color-mix(in srgb, var(--jb-gold) 22%, var(--border));
+  border-radius: 6px;
+  background: rgba(255, 255, 255, 0.72);
+  color: var(--text);
+  cursor: pointer;
+  font-size: 0.72rem;
+  font-weight: 700;
+}
+
+.nail-item-actions button:hover,
+.nail-item-actions button:focus-visible {
+  border-color: color-mix(in srgb, var(--jb-gold) 48%, var(--accent-border));
+  background: rgba(255, 255, 255, 0.94);
+}
+
+.nail-item-actions button:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.nail-item-actions button:disabled {
+  cursor: not-allowed;
+  opacity: 0.55;
+}
+
+.nail-item-actions .nail-action-primary {
+  background: linear-gradient(135deg, var(--jb-gold-soft), rgba(255, 255, 255, 0.92));
+  color: #5a3b10;
 }
 
 /* Detail viewer and floating charm preview */

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1672,6 +1672,7 @@ function App() {
                   <li
                     key={item.id}
                     className={[
+                      item.imageUrl ? 'has-image' : 'no-image',
                       editingId === item.id ? 'editing' : '',
                       isCompareSelected ? 'comparison-selected' : '',
                     ].filter(Boolean).join(' ')}
@@ -1680,7 +1681,29 @@ function App() {
                       className="nail-card-thumb"
                       onClick={() => setDetailItemId(item.id)}
                     >
-                      <div className="nail-thumb-placeholder">No image</div>
+                      <div className="nail-thumb-placeholder" aria-hidden={Boolean(item.imageUrl)}>
+                        <div className="nail-thumb-showcase">
+                          <FloatingNailChip
+                            variant="empty"
+                            shape="almond"
+                            className="nail-thumb-chip nail-thumb-chip--one"
+                            showHighlight={false}
+                          />
+                          <FloatingNailChip
+                            variant="empty"
+                            shape="oval"
+                            className="nail-thumb-chip nail-thumb-chip--two"
+                            showHighlight={false}
+                          />
+                          <FloatingNailChip
+                            variant="empty"
+                            shape="square"
+                            className="nail-thumb-chip nail-thumb-chip--three"
+                            showHighlight={false}
+                          />
+                        </div>
+                        <span>No image</span>
+                      </div>
                       {item.imageUrl && (
                         <img
                           className="nail-thumb-img"
@@ -1714,6 +1737,7 @@ function App() {
                     <div className="nail-item-actions">
                       <button
                         type="button"
+                        className="nail-action-primary"
                         onClick={() => setDetailItemId(item.id)}
                       >詳しく見る</button>
                       <button


### PR DESCRIPTION
## Summary
- Refresh the nail collection list into a responsive premium card grid.
- Add a gold/glass card treatment with stronger title, tag, and action affordances.
- Replace the no-image text-only state with a small floating nail-chip showcase while preserving image cards.

## Validation
- npm run lint
- npm run build
- npm test
- bash scripts/qa-preflight.sh

Closes #268
