### PR TITLE
[codex] Add static Book Appointment screen

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1385,6 +1385,147 @@
   font-weight: 800;
 }
 
+.appointment-screen {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 18px;
+  border: 1px solid color-mix(in srgb, var(--border) 70%, var(--jb-rose));
+  border-radius: 10px;
+  background:
+    radial-gradient(circle at 86% 16%, rgba(248, 217, 77, 0.14), transparent 28%),
+    linear-gradient(145deg, rgba(255, 255, 255, 0.92), rgba(248, 244, 248, 0.74));
+  box-shadow: 0 18px 42px rgba(36, 20, 41, 0.07);
+}
+
+.appointment-header {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: start;
+  gap: 12px;
+}
+
+.appointment-header h3 {
+  margin: 0 0 6px;
+  color: var(--text-h);
+  font-size: clamp(1.18rem, 3vw, 1.5rem);
+  line-height: 1.25;
+}
+
+.appointment-header p {
+  max-width: 620px;
+  margin: 0;
+  color: var(--text);
+  font-size: 0.84rem;
+  line-height: 1.65;
+}
+
+.appointment-badge {
+  display: inline-flex;
+  align-items: center;
+  min-height: 28px;
+  padding: 4px 10px;
+  border: 1px solid color-mix(in srgb, var(--jb-rose) 30%, var(--border));
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.76);
+  color: var(--text-h);
+  font-size: 0.68rem;
+  font-weight: 800;
+  white-space: nowrap;
+}
+
+.appointment-panel {
+  display: grid;
+  grid-template-columns: minmax(220px, 0.45fr) minmax(0, 1fr);
+  gap: 12px;
+}
+
+.appointment-memo-card {
+  min-height: 180px;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  padding: 16px;
+  border: 1px solid color-mix(in srgb, var(--jb-gold) 22%, var(--border));
+  border-radius: 8px;
+  background:
+    linear-gradient(145deg, rgba(255, 255, 255, 0.82), rgba(255, 239, 246, 0.54)),
+    rgba(255, 255, 255, 0.58);
+}
+
+.appointment-memo-top {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: 8px;
+  color: var(--text-h);
+  font-size: 0.82rem;
+  font-weight: 800;
+}
+
+.appointment-memo-top small {
+  color: var(--jb-rose);
+  font-size: 0.68rem;
+  font-weight: 800;
+}
+
+.appointment-memo-lines {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.appointment-memo-lines span {
+  height: 10px;
+  border-radius: 999px;
+  background: linear-gradient(90deg, rgba(248, 217, 77, 0.26), rgba(255, 255, 255, 0.7));
+}
+
+.appointment-memo-lines span:nth-child(2) {
+  width: 82%;
+}
+
+.appointment-memo-lines span:nth-child(3) {
+  width: 58%;
+}
+
+.appointment-memo-card p {
+  margin: auto 0 0;
+  color: var(--text);
+  font-size: 0.82rem;
+  line-height: 1.65;
+}
+
+.appointment-plan-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.appointment-plan-slot {
+  min-height: 78px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 4px;
+  padding: 12px;
+  border: 1px solid color-mix(in srgb, var(--border) 74%, var(--jb-gold));
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.64);
+}
+
+.appointment-plan-slot span {
+  color: var(--text-h);
+  font-size: 0.9rem;
+  font-weight: 800;
+}
+
+.appointment-plan-slot small {
+  color: var(--text);
+  font-size: 0.72rem;
+  line-height: 1.45;
+}
+
 .nail-design-meta {
   display: flex;
   flex-wrap: wrap;
@@ -2180,6 +2321,19 @@
   }
 
   .saved-designs-data-slots {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .appointment-header,
+  .appointment-panel {
+    grid-template-columns: 1fr;
+  }
+
+  .appointment-badge {
+    justify-self: start;
+  }
+
+  .appointment-plan-grid {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -77,6 +77,7 @@ const INSPIRATION_CATEGORIES = ['All', 'Daily', 'Event', 'Season', 'Salon'] as c
 type InspirationCategory = typeof INSPIRATION_CATEGORIES[number]
 
 const SAVED_DESIGN_FIELDS = ['Image', 'Shape', 'Color', 'Tags', 'Memo'] as const
+const APPOINTMENT_PLAN_FIELDS = ['Salon', 'Date', 'Budget', 'Request'] as const
 
 const sortByDate = (items: NailItemDoc[]): NailItemDoc[] =>
   [...items].sort((a, b) => {
@@ -1428,6 +1429,41 @@ function App() {
               <div className="saved-designs-data-slots" aria-label="後続接続予定の項目">
                 {SAVED_DESIGN_FIELDS.map(field => (
                   <span key={field}>{field}</span>
+                ))}
+              </div>
+            </div>
+          </section>
+          <section className="appointment-screen" aria-labelledby="appointment-title">
+            <div className="appointment-header">
+              <div>
+                <p className="nail-design-kicker">BOOK APPOINTMENT</p>
+                <h3 id="appointment-title">次の来店を、デザインから考える。</h3>
+                <p>
+                  実予約や決済ではなく、サロンに持っていく内容を整理するための計画サーフェスです。
+                  後続フェーズでデザイン詳細やメモ保存に接続します。
+                </p>
+              </div>
+              <span className="appointment-badge">Planning only</span>
+            </div>
+            <div className="appointment-panel">
+              <div className="appointment-memo-card">
+                <div className="appointment-memo-top">
+                  <span>Next visit memo</span>
+                  <small>No booking/payment</small>
+                </div>
+                <div className="appointment-memo-lines" aria-hidden="true">
+                  <span />
+                  <span />
+                  <span />
+                </div>
+                <p>希望の形、色、予算、相談したいことを一箇所にまとめるための下書き領域です。</p>
+              </div>
+              <div className="appointment-plan-grid" aria-label="予約計画の項目">
+                {APPOINTMENT_PLAN_FIELDS.map(field => (
+                  <div key={field} className="appointment-plan-slot">
+                    <span>{field}</span>
+                    <small>後続フェーズで入力欄に接続</small>
+                  </div>
                 ))}
               </div>
             </div>


### PR DESCRIPTION
## Summary
- Add a static Book Appointment planning surface to the signed-in Jewelry Box flow.
- Show a next-visit memo card and future data slots for salon/date/budget/request.
- Clearly mark the surface as planning-only with no booking or payment behavior.

## Validation
- npm run lint
- npm run build
- npm test
- bash scripts/qa-preflight.sh

Closes #270
