### PR TITLE
[codex] Add static Profile screen

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1526,6 +1526,173 @@
   line-height: 1.45;
 }
 
+.profile-screen {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 18px;
+  border: 1px solid color-mix(in srgb, var(--border) 68%, var(--jb-gold));
+  border-radius: 10px;
+  background:
+    radial-gradient(circle at 16% 12%, rgba(248, 217, 77, 0.16), transparent 28%),
+    linear-gradient(145deg, rgba(255, 255, 255, 0.94), rgba(247, 241, 248, 0.74));
+  box-shadow: 0 18px 42px rgba(36, 20, 41, 0.07);
+}
+
+.profile-header {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: start;
+  gap: 12px;
+}
+
+.profile-header h3 {
+  margin: 0 0 6px;
+  color: var(--text-h);
+  font-size: clamp(1.18rem, 3vw, 1.5rem);
+  line-height: 1.25;
+}
+
+.profile-header p {
+  max-width: 620px;
+  margin: 0;
+  color: var(--text);
+  font-size: 0.84rem;
+  line-height: 1.65;
+}
+
+.profile-badge {
+  display: inline-flex;
+  align-items: center;
+  min-height: 28px;
+  padding: 4px 10px;
+  border: 1px solid color-mix(in srgb, var(--jb-gold) 32%, var(--border));
+  border-radius: 999px;
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.86), rgba(248, 217, 77, 0.16));
+  color: var(--text-h);
+  font-size: 0.68rem;
+  font-weight: 800;
+  white-space: nowrap;
+}
+
+.profile-panel {
+  display: grid;
+  grid-template-columns: minmax(240px, 0.52fr) minmax(0, 1fr);
+  gap: 12px;
+  align-items: stretch;
+}
+
+.profile-card {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  gap: 14px;
+  align-items: center;
+  padding: 16px;
+  border: 1px solid color-mix(in srgb, var(--jb-gold) 24%, var(--border));
+  border-radius: 8px;
+  background:
+    linear-gradient(145deg, rgba(255, 255, 255, 0.84), rgba(255, 239, 246, 0.48)),
+    rgba(255, 255, 255, 0.58);
+}
+
+.profile-avatar {
+  width: 56px;
+  aspect-ratio: 1;
+  display: grid;
+  place-items: center;
+  border: 1px solid color-mix(in srgb, var(--jb-gold) 38%, var(--border));
+  border-radius: 50%;
+  background: linear-gradient(135deg, var(--jb-black), var(--jb-plum));
+  color: rgba(255, 255, 255, 0.94);
+  font-size: 1.2rem;
+  font-weight: 800;
+  box-shadow: 0 12px 26px rgba(36, 20, 41, 0.16);
+}
+
+.profile-identity {
+  min-width: 0;
+}
+
+.profile-identity h4 {
+  margin: 0 0 4px;
+  color: var(--text-h);
+  font-size: 1rem;
+  line-height: 1.25;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.profile-identity p {
+  margin: 0;
+  color: var(--text);
+  font-size: 0.78rem;
+  line-height: 1.45;
+  overflow-wrap: anywhere;
+}
+
+.profile-actions {
+  grid-column: 1 / -1;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.profile-actions button {
+  min-height: 36px;
+  padding: 7px 12px;
+  border: 1px solid color-mix(in srgb, var(--jb-gold) 22%, var(--border));
+  border-radius: 6px;
+  background: rgba(255, 255, 255, 0.72);
+  color: var(--text-h);
+  cursor: pointer;
+  font: inherit;
+  font-size: 0.74rem;
+  font-weight: 800;
+}
+
+.profile-actions button:hover,
+.profile-actions button:focus-visible {
+  border-color: color-mix(in srgb, var(--jb-gold) 48%, var(--accent-border));
+  background: rgba(255, 255, 255, 0.94);
+}
+
+.profile-actions button:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.profile-stats-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.profile-stat {
+  min-height: 112px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 4px;
+  padding: 12px;
+  border: 1px solid color-mix(in srgb, var(--border) 74%, var(--jb-gold));
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.64);
+}
+
+.profile-stat span {
+  color: var(--text-h);
+  font-size: clamp(1.35rem, 4vw, 1.75rem);
+  font-weight: 800;
+  line-height: 1;
+}
+
+.profile-stat small {
+  color: var(--text);
+  font-size: 0.72rem;
+  font-weight: 800;
+}
+
 .nail-design-meta {
   display: flex;
   flex-wrap: wrap;
@@ -2334,6 +2501,19 @@
   }
 
   .appointment-plan-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .profile-header,
+  .profile-panel {
+    grid-template-columns: 1fr;
+  }
+
+  .profile-badge {
+    justify-self: start;
+  }
+
+  .profile-stats-grid {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -78,6 +78,7 @@ type InspirationCategory = typeof INSPIRATION_CATEGORIES[number]
 
 const SAVED_DESIGN_FIELDS = ['Image', 'Shape', 'Color', 'Tags', 'Memo'] as const
 const APPOINTMENT_PLAN_FIELDS = ['Salon', 'Date', 'Budget', 'Request'] as const
+const PROFILE_ACTIONS = ['Data management', 'Privacy', 'Terms'] as const
 
 const sortByDate = (items: NailItemDoc[]): NailItemDoc[] =>
   [...items].sort((a, b) => {
@@ -1465,6 +1466,60 @@ function App() {
                     <small>後続フェーズで入力欄に接続</small>
                   </div>
                 ))}
+              </div>
+            </div>
+          </section>
+          <section className="profile-screen" aria-labelledby="profile-title">
+            <div className="profile-header">
+              <div>
+                <p className="nail-design-kicker">PROFILE</p>
+                <h3 id="profile-title">あなたの宝石箱の状態。</h3>
+                <p>
+                  アカウント情報を増やさず、いま保存されているネイル・共有・データ管理への導線をまとめます。
+                </p>
+              </div>
+              <span className="profile-badge">Static summary</span>
+            </div>
+            <div className="profile-panel">
+              <div className="profile-card">
+                <div className="profile-avatar" aria-hidden="true">
+                  {(user.displayName ?? user.email ?? 'N').slice(0, 1).toUpperCase()}
+                </div>
+                <div className="profile-identity">
+                  <h4>{user.displayName ?? 'Nailous user'}</h4>
+                  <p>{user.email ?? 'Google account connected'}</p>
+                </div>
+                <div className="profile-actions" aria-label="プロフィール関連リンク">
+                  {PROFILE_ACTIONS.map(action => {
+                    if (action === 'Data management') {
+                      return (
+                        <button key={action} type="button" onClick={() => setIsDataModalOpen(true)}>
+                          {action}
+                        </button>
+                      )
+                    }
+                    const path = action === 'Privacy' ? '/privacy' : '/terms'
+                    return (
+                      <button key={action} type="button" onClick={() => navigateTo(path)}>
+                        {action}
+                      </button>
+                    )
+                  })}
+                </div>
+              </div>
+              <div className="profile-stats-grid" aria-label="プロフィール概要">
+                <div className="profile-stat">
+                  <span>{nailItems.length}</span>
+                  <small>Saved nails</small>
+                </div>
+                <div className="profile-stat">
+                  <span>{publicShares.length}</span>
+                  <small>Share links</small>
+                </div>
+                <div className="profile-stat">
+                  <span>{summary.withImageCount}</span>
+                  <small>With images</small>
+                </div>
               </div>
             </div>
           </section>


### PR DESCRIPTION
## Summary
- Add a static Profile summary surface to the signed-in Jewelry Box flow.
- Show existing account identity, saved nail count, public share count, and image count without adding account fields.
- Include links to data management, privacy, and terms so settings/data management are considered.

## Validation
- npm run lint
- npm run build
- npm test
- bash scripts/qa-preflight.sh

Closes #271
