### PR TITLE
[codex] Connect core screens through bottom navigation

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -800,6 +800,83 @@
   gap: 18px;
 }
 
+#center.is-signed-in {
+  padding-bottom: calc(132px + var(--fixed-control-safe-gap));
+}
+
+.app-bottom-nav {
+  position: fixed;
+  left: 50%;
+  bottom: var(--fixed-control-safe-gap);
+  z-index: 18;
+  width: min(920px, calc(100vw - 24px));
+  display: grid;
+  grid-template-columns: repeat(6, minmax(0, 1fr));
+  gap: 4px;
+  padding: 8px;
+  border: 1px solid color-mix(in srgb, var(--jb-gold) 28%, var(--jb-glass-border));
+  border-radius: 12px;
+  background:
+    linear-gradient(145deg, rgba(255, 255, 255, 0.88), rgba(248, 244, 248, 0.72)),
+    rgba(255, 255, 255, 0.76);
+  box-shadow: 0 18px 42px rgba(36, 20, 41, 0.2);
+  transform: translateX(-50%);
+  backdrop-filter: blur(18px);
+}
+
+.app-bottom-nav button {
+  min-width: 0;
+  min-height: var(--tap-target-min);
+  display: inline-flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
+  padding: 6px 4px;
+  border: 1px solid transparent;
+  border-radius: 8px;
+  background: transparent;
+  color: var(--text);
+  cursor: pointer;
+  font: inherit;
+  font-size: 0.68rem;
+  font-weight: 800;
+  line-height: 1.1;
+  text-align: center;
+}
+
+.app-bottom-nav button:hover,
+.app-bottom-nav button:focus-visible {
+  border-color: color-mix(in srgb, var(--jb-gold) 30%, var(--border));
+  background: rgba(255, 255, 255, 0.64);
+}
+
+.app-bottom-nav button:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.app-bottom-nav button.active,
+.app-bottom-nav button[aria-current='page'] {
+  border-color: color-mix(in srgb, var(--jb-gold) 46%, var(--jb-glass-border));
+  background: linear-gradient(135deg, var(--jb-black), var(--jb-plum));
+  color: rgba(255, 255, 255, 0.94);
+  box-shadow: 0 10px 24px rgba(36, 20, 41, 0.16);
+}
+
+.app-bottom-nav-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 999px;
+  background: currentColor;
+  opacity: 0.5;
+}
+
+.app-bottom-nav button.active .app-bottom-nav-dot,
+.app-bottom-nav button[aria-current='page'] .app-bottom-nav-dot {
+  opacity: 1;
+}
+
 .nail-studio-hero {
   position: relative;
   overflow: hidden;
@@ -2442,6 +2519,23 @@
 }
 
 @media (max-width: 480px) {
+  #center.is-signed-in {
+    padding-bottom: calc(140px + var(--fixed-control-safe-gap));
+  }
+
+  .app-bottom-nav {
+    width: min(var(--mobile-viewport-target), calc(100vw - 12px));
+    gap: 2px;
+    padding: 6px;
+    border-radius: 10px;
+  }
+
+  .app-bottom-nav button {
+    min-height: 42px;
+    padding: 5px 2px;
+    font-size: 0.6rem;
+  }
+
   .nail-studio-hero {
     grid-template-columns: 1fr;
     padding: 18px;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -79,6 +79,15 @@ type InspirationCategory = typeof INSPIRATION_CATEGORIES[number]
 const SAVED_DESIGN_FIELDS = ['Image', 'Shape', 'Color', 'Tags', 'Memo'] as const
 const APPOINTMENT_PLAN_FIELDS = ['Salon', 'Date', 'Budget', 'Request'] as const
 const PROFILE_ACTIONS = ['Data management', 'Privacy', 'Terms'] as const
+const APP_SCREENS = [
+  { id: 'home', label: 'Home' },
+  { id: 'design', label: 'Design' },
+  { id: 'inspiration', label: 'Explore' },
+  { id: 'saved', label: 'Saved' },
+  { id: 'book', label: 'Book' },
+  { id: 'profile', label: 'Profile' },
+] as const
+type AppScreenId = typeof APP_SCREENS[number]['id']
 
 const sortByDate = (items: NailItemDoc[]): NailItemDoc[] =>
   [...items].sort((a, b) => {
@@ -290,6 +299,7 @@ function App() {
   const [publicSharesUserId, setPublicSharesUserId] = useState<string | null>(null)
   const [shareActionId, setShareActionId] = useState<string | null>(null)
   const [activeDisplayMode, setActiveDisplayMode] = useState<DisplayMode>('Glass')
+  const [activeAppScreen, setActiveAppScreen] = useState<AppScreenId>('home')
   const [publicShare, setPublicShare] = useState<PublicShareDocWithId | null>(null)
   const [publicShareState, setPublicShareState] = useState<PublicShareViewState>(
     isPublicSharePage ? 'loading' : 'idle'
@@ -300,6 +310,13 @@ function App() {
   const cameraInputRef = useRef<HTMLInputElement>(null)
   const dataModalCloseButtonRef = useRef<HTMLButtonElement>(null)
   const previewUrlRef = useRef<string | null>(null)
+
+  const handleSelectAppScreen = (screenId: AppScreenId) => {
+    setActiveAppScreen(screenId)
+    window.requestAnimationFrame(() => {
+      document.getElementById('nail-section')?.scrollIntoView({ block: 'start' })
+    })
+  }
 
   useEffect(() => () => {
     if (previewUrlRef.current) URL.revokeObjectURL(previewUrlRef.current)
@@ -648,6 +665,7 @@ function App() {
 
   const handleStartEdit = (item: NailItemDoc) => {
     setEditingId(item.id)
+    setActiveAppScreen('design')
     setNailTitle(item.title)
     setNailTags(item.tags.join(', '))
     setNailMemo(item.memo ?? '')
@@ -966,7 +984,7 @@ function App() {
   }
 
   return (
-    <section id="center" className={user ? undefined : 'is-signed-out'}>
+    <section id="center" className={user ? 'is-signed-in' : 'is-signed-out'}>
       <h1 id="app-title">Nailous</h1>
       <ErrorBanner
         message={firebaseConfigErrorMessage || bannerError}
@@ -1126,22 +1144,27 @@ function App() {
       )}
       {user && (
         <div id="nail-section">
-          <section className="nail-studio-hero" aria-labelledby="studio-title">
-            <div>
-              <p className="nail-studio-kicker">JEWELRY BOX STUDIO</p>
-              <h2 id="studio-title">ネイルを一つずつ、宝石箱へ。</h2>
-              <p>
-                追加した写真はあとから浮遊ビュー・比較・共有へつながります。
-                まずは今日のネイルを一つ、コレクションに入れておきましょう。
-              </p>
-            </div>
-            <div className="nail-studio-count" aria-label={`保存済みネイル ${nailItems.length} 件`}>
-              <span>{nailItems.length}</span>
-              <small>saved</small>
-            </div>
-          </section>
-          {renderDisplayModeSwitcher('studio-mode-switcher')}
-          <section className="nail-design-screen" aria-labelledby="nail-design-title">
+          {activeAppScreen === 'home' && (
+            <>
+              <section className="nail-studio-hero" aria-labelledby="studio-title">
+                <div>
+                  <p className="nail-studio-kicker">JEWELRY BOX STUDIO</p>
+                  <h2 id="studio-title">ネイルを一つずつ、宝石箱へ。</h2>
+                  <p>
+                    追加した写真はあとから浮遊ビュー・比較・共有へつながります。
+                    まずは今日のネイルを一つ、コレクションに入れておきましょう。
+                  </p>
+                </div>
+                <div className="nail-studio-count" aria-label={`保存済みネイル ${nailItems.length} 件`}>
+                  <span>{nailItems.length}</span>
+                  <small>saved</small>
+                </div>
+              </section>
+              {renderDisplayModeSwitcher('studio-mode-switcher')}
+            </>
+          )}
+          {activeAppScreen === 'design' && (
+            <section className="nail-design-screen" aria-labelledby="nail-design-title">
             <div className="nail-design-header">
               <div>
                 <p className="nail-design-kicker">NAIL DESIGN</p>
@@ -1353,6 +1376,8 @@ function App() {
               {nailError && <p className="nail-error">{nailError}</p>}
             </div>
           </section>
+          )}
+          {activeAppScreen === 'inspiration' && (
           <section className="inspiration-screen" aria-labelledby="inspiration-title">
             <div className="inspiration-header">
               <div>
@@ -1394,6 +1419,8 @@ function App() {
               ))}
             </div>
           </section>
+          )}
+          {activeAppScreen === 'saved' && (
           <section className="saved-designs-screen" aria-labelledby="saved-designs-title">
             <div className="saved-designs-header">
               <div>
@@ -1434,6 +1461,8 @@ function App() {
               </div>
             </div>
           </section>
+          )}
+          {activeAppScreen === 'book' && (
           <section className="appointment-screen" aria-labelledby="appointment-title">
             <div className="appointment-header">
               <div>
@@ -1469,6 +1498,8 @@ function App() {
               </div>
             </div>
           </section>
+          )}
+          {activeAppScreen === 'profile' && (
           <section className="profile-screen" aria-labelledby="profile-title">
             <div className="profile-header">
               <div>
@@ -1523,6 +1554,9 @@ function App() {
               </div>
             </div>
           </section>
+          )}
+          {activeAppScreen === 'home' && (
+          <>
           {!isFetching && nailItems.length > 0 && (
             <div id="nail-summary">
               <h3 className="summary-heading">コレクション概要</h3>
@@ -1893,6 +1927,26 @@ function App() {
               })}
             </ul>
           )}
+          </>
+          )}
+          <nav className="app-bottom-nav" aria-label="Jewelry Box screens">
+            {APP_SCREENS.map(screen => {
+              const isActive = activeAppScreen === screen.id
+              return (
+                <button
+                  key={screen.id}
+                  type="button"
+                  className={isActive ? 'active' : undefined}
+                  aria-current={isActive ? 'page' : undefined}
+                  aria-pressed={isActive}
+                  onClick={() => handleSelectAppScreen(screen.id)}
+                >
+                  <span className="app-bottom-nav-dot" aria-hidden="true" />
+                  <span>{screen.label}</span>
+                </button>
+              )
+            })}
+          </nav>
         </div>
       )}
       {renderFooter()}


### PR DESCRIPTION
## Summary
- Add authenticated bottom navigation for the six Jewelry Box core screens.
- Move Home, Design, Explore, Saved, Book, and Profile behind active screen selection while keeping legal and public share routes outside the authenticated shell.
- Keep existing collection, share, compare, search, edit, and delete flows accessible through Home/Design.

## Validation
- npm run lint
- npm run build
- npm test
- bash scripts/qa-preflight.sh

Closes #272
