### PR TITLE
[codex] Add premium skeleton loading cards

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -4040,23 +4040,42 @@
 /* Loading skeletons */
 
 .nail-skeleton-card {
+  position: relative;
   display: flex;
   flex-direction: column;
-  border: 1px solid var(--border);
-  border-radius: 10px;
+  border: 1px solid color-mix(in srgb, var(--jb-gold) 20%, var(--border));
+  border-radius: 8px;
   overflow: hidden;
-  background: var(--social-bg);
-  min-height: 280px;
+  background:
+    linear-gradient(145deg, rgba(255, 255, 255, 0.9), rgba(250, 245, 250, 0.68)),
+    rgba(255, 255, 255, 0.66);
+  min-height: 360px;
   pointer-events: none;
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.8),
+    0 18px 34px rgba(54, 30, 42, 0.1);
+}
+
+.nail-skeleton-card::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background:
+    linear-gradient(125deg, rgba(255, 255, 255, 0.28), transparent 34% 72%, rgba(248, 217, 77, 0.1)),
+    radial-gradient(circle at 84% 0%, rgba(248, 217, 77, 0.16), transparent 34%);
 }
 
 .nail-skeleton-thumb {
   aspect-ratio: 4 / 3;
-  background: var(--border);
+  background:
+    radial-gradient(circle at 50% 40%, rgba(255, 239, 246, 0.66), transparent 40%),
+    radial-gradient(ellipse at 50% 86%, rgba(86, 55, 72, 0.14), transparent 58%),
+    linear-gradient(145deg, rgba(255, 255, 255, 0.68), rgba(245, 238, 246, 0.36));
 }
 
 .nail-skeleton-body {
-  padding: 10px 12px;
+  padding: 12px 14px 10px;
   flex: 1;
   display: flex;
   flex-direction: column;
@@ -4066,8 +4085,8 @@
 .nail-skeleton-title {
   height: 1.2rem;
   width: 70%;
-  background: var(--border);
-  border-radius: 4px;
+  background: rgba(66, 42, 56, 0.12);
+  border-radius: 999px;
 }
 
 .nail-skeleton-tags {
@@ -4078,16 +4097,35 @@
 .nail-skeleton-tag {
   height: 1rem;
   width: 40px;
-  background: var(--accent-bg);
+  background:
+    linear-gradient(135deg, rgba(255, 255, 255, 0.72), rgba(248, 217, 77, 0.16)),
+    var(--accent-bg);
   border-radius: 9999px;
 }
 
 .nail-skeleton-date {
   height: 0.8rem;
   width: 50%;
-  background: var(--border);
-  border-radius: 4px;
+  background: rgba(66, 42, 56, 0.1);
+  border-radius: 999px;
   margin-top: auto;
+}
+
+.nail-skeleton-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 6px;
+  padding: 10px 12px 12px;
+  border-top: 1px solid color-mix(in srgb, var(--jb-gold) 16%, var(--border));
+  background: rgba(255, 255, 255, 0.34);
+}
+
+.nail-skeleton-action {
+  width: 72px;
+  height: 34px;
+  border-radius: 6px;
+  background: rgba(255, 255, 255, 0.72);
+  border: 1px solid color-mix(in srgb, var(--jb-gold) 18%, var(--border));
 }
 
 .shimmer {
@@ -4105,11 +4143,12 @@
   background-image: linear-gradient(
     90deg,
     rgba(255, 255, 255, 0) 0,
-    rgba(255, 255, 255, 0.2) 20%,
-    rgba(255, 255, 255, 0.5) 60%,
+    rgba(255, 255, 255, 0.24) 20%,
+    rgba(248, 217, 77, 0.3) 48%,
+    rgba(255, 255, 255, 0.55) 62%,
     rgba(255, 255, 255, 0)
   );
-  animation: shimmer 2s infinite;
+  animation: shimmer 2.1s infinite;
   content: '';
 }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1806,6 +1806,10 @@ function App() {
                       </div>
                       <div className="nail-skeleton-date shimmer" />
                     </div>
+                    <div className="nail-skeleton-actions">
+                      <div className="nail-skeleton-action shimmer" />
+                      <div className="nail-skeleton-action shimmer" />
+                    </div>
                   </li>
                 ))}
               </ul>


### PR DESCRIPTION
## Summary
- Upgrade the nail card skeletons to match the premium card grid dimensions and glass/gold styling.
- Add skeleton action rows so loading cards reserve the same vertical rhythm as loaded cards.
- Keep shimmer animation reduced-motion compatible.

## Validation
- npm run lint
- npm run build
- npm test
- bash scripts/qa-preflight.sh

Closes #287
