### PR TITLE
[codex] Clarify Jewelry Box detail card interaction

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -2741,6 +2741,12 @@
   cursor: pointer;
 }
 
+.nail-card-thumb:focus-visible,
+.nail-card-body:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: -4px;
+}
+
 .nail-card-thumb::after {
   content: '';
   position: absolute;
@@ -2974,7 +2980,17 @@
   color: var(--accent);
 }
 
+.nail-detail-close-hint {
+  margin: 4px 0 0;
+  color: var(--text);
+  font-size: 0.72rem;
+  line-height: 1.4;
+}
+
 .nail-detail-close {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
   padding: 6px 12px;
   border: 1px solid var(--border);
   border-radius: 6px;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useRef, useMemo, lazy, Suspense } from 'react'
+import type { KeyboardEvent as ReactKeyboardEvent } from 'react'
 import { auth, signInWithGoogle, signOutUser, onAuthStateChanged } from './lib/auth'
 import type { User } from './lib/auth'
 import { addNailItem, updateNailItem, deleteNailItem, fetchNailItems } from './lib/firestore'
@@ -316,6 +317,16 @@ function App() {
     window.requestAnimationFrame(() => {
       document.getElementById('nail-section')?.scrollIntoView({ block: 'start' })
     })
+  }
+
+  const handleOpenDetailCard = (itemId: string) => {
+    setDetailItemId(itemId)
+  }
+
+  const handleDetailCardKeyDown = (event: ReactKeyboardEvent, itemId: string) => {
+    if (event.key !== 'Enter' && event.key !== ' ') return
+    event.preventDefault()
+    handleOpenDetailCard(itemId)
   }
 
   useEffect(() => () => {
@@ -1850,7 +1861,11 @@ function App() {
                   >
                     <div
                       className="nail-card-thumb"
-                      onClick={() => setDetailItemId(item.id)}
+                      role="button"
+                      tabIndex={0}
+                      aria-label={`${item.title} の詳細カードを開く`}
+                      onClick={() => handleOpenDetailCard(item.id)}
+                      onKeyDown={(event) => handleDetailCardKeyDown(event, item.id)}
                     >
                       <div className="nail-thumb-placeholder" aria-hidden={Boolean(item.imageUrl)}>
                         <div className="nail-thumb-showcase">
@@ -1886,7 +1901,11 @@ function App() {
                     </div>
                     <div
                       className="nail-card-body"
-                      onClick={() => setDetailItemId(item.id)}
+                      role="button"
+                      tabIndex={0}
+                      aria-label={`${item.title} の詳細カードを開く`}
+                      onClick={() => handleOpenDetailCard(item.id)}
+                      onKeyDown={(event) => handleDetailCardKeyDown(event, item.id)}
                     >
                       <span className="nail-item-title">{item.title}</span>
                       {item.tags.length > 0 && (
@@ -1909,7 +1928,7 @@ function App() {
                       <button
                         type="button"
                         className="nail-action-primary"
-                        onClick={() => setDetailItemId(item.id)}
+                        onClick={() => handleOpenDetailCard(item.id)}
                       >詳しく見る</button>
                       <button
                         type="button"

--- a/src/components/NailImageDetailViewer.tsx
+++ b/src/components/NailImageDetailViewer.tsx
@@ -53,14 +53,18 @@ const NailImageDetailViewer: React.FC<NailImageDetailViewerProps> = ({ item, onC
         onClick={(e) => e.stopPropagation()}
       >
         <div className="nail-detail-header">
-          <p className="nail-detail-kicker">ネイル詳細</p>
+          <div>
+            <p className="nail-detail-kicker">Jewelry Box Detail</p>
+            <p className="nail-detail-close-hint">背景クリックまたはEscで閉じる</p>
+          </div>
           <button
             ref={closeButtonRef}
             type="button"
             className="nail-detail-close"
             onClick={onClose}
-            aria-label="ネイル詳細を閉じる"
+            aria-label="ネイル詳細カードを閉じる"
           >
+            <span aria-hidden="true">×</span>
             閉じる
           </button>
         </div>


### PR DESCRIPTION
## Summary
- Make nail card image/body taps explicitly open the Jewelry Box detail card.
- Add keyboard Enter/Space support and visible focus for the card tap areas.
- Clarify the detail card close affordance while preserving Escape, backdrop click, and existing detail viewer behavior.

## Validation
- npm run lint
- npm run build
- npm test
- bash scripts/qa-preflight.sh

Closes #284
