### PR TITLE
[codex] Stabilize floating nail charm placement

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -3307,46 +3307,42 @@
 
 .nail-charm-shell {
   position: absolute;
-  width: 74px;
+  left: var(--charm-left, 50%);
+  top: var(--charm-top, 28%);
+  width: calc(var(--charm-base-width, 74px) * var(--charm-mode-scale, 1));
   aspect-ratio: 0.48;
+  opacity: calc(var(--charm-opacity, 1) * var(--charm-mode-opacity, 1));
   filter: drop-shadow(0 20px 16px rgba(0, 0, 0, 0.26));
+  transform:
+    translateX(var(--charm-translate-x, 0))
+    translateY(var(--charm-mode-y, 0))
+    rotate(var(--charm-rotation, 0deg));
   animation: nail-charm-float 4.8s ease-in-out infinite;
+  animation-delay: var(--charm-delay, 0s);
 }
 
 .nail-charm-shell--left {
-  left: 20%;
-  top: 32%;
-  transform: rotate(-10deg);
-  animation-delay: -1.4s;
+  --charm-translate-x: 0;
 }
 
 .nail-charm-shell--center {
-  left: 50%;
-  top: 23%;
-  width: 86px;
-  transform: translateX(-50%);
-  animation-delay: -0.3s;
+  --charm-translate-x: -50%;
 }
 
 .nail-charm-shell--right {
-  right: 18%;
-  top: 36%;
-  transform: rotate(11deg);
-  animation-delay: -2.2s;
+  --charm-translate-x: -100%;
 }
 
 .nail-detail-dialog.display-mode-snow-globe .nail-charm-shell--left {
-  left: 16%;
-  top: 40%;
+  --charm-mode-y: 5px;
 }
 
 .nail-detail-dialog.display-mode-snow-globe .nail-charm-shell--center {
-  top: 20%;
+  --charm-mode-y: -2px;
 }
 
 .nail-detail-dialog.display-mode-snow-globe .nail-charm-shell--right {
-  right: 15%;
-  top: 42%;
+  --charm-mode-y: 6px;
 }
 
 .nail-detail-dialog.display-mode-velvet .nail-charm-shell {
@@ -3354,17 +3350,15 @@
 }
 
 .nail-detail-dialog.display-mode-velvet .nail-charm-shell--left {
-  left: 18%;
-  top: 34%;
+  --charm-mode-y: 2px;
 }
 
 .nail-detail-dialog.display-mode-velvet .nail-charm-shell--center {
-  top: 24%;
+  --charm-mode-y: 1px;
 }
 
 .nail-detail-dialog.display-mode-velvet .nail-charm-shell--right {
-  right: 18%;
-  top: 34%;
+  --charm-mode-y: 2px;
 }
 
 .nail-detail-dialog.display-mode-showcase .nail-charm-orbit {
@@ -3372,22 +3366,20 @@
 }
 
 .nail-detail-dialog.display-mode-showcase .nail-charm-shell--left {
-  left: 14%;
-  top: 38%;
-  width: 66px;
-  opacity: 0.74;
+  --charm-mode-scale: 0.9;
+  --charm-mode-opacity: 0.78;
+  --charm-mode-y: 7px;
 }
 
 .nail-detail-dialog.display-mode-showcase .nail-charm-shell--center {
-  top: 16%;
-  width: 104px;
+  --charm-mode-scale: 1.2;
+  --charm-mode-y: -8px;
 }
 
 .nail-detail-dialog.display-mode-showcase .nail-charm-shell--right {
-  right: 14%;
-  top: 38%;
-  width: 66px;
-  opacity: 0.74;
+  --charm-mode-scale: 0.9;
+  --charm-mode-opacity: 0.78;
+  --charm-mode-y: 7px;
 }
 
 .nail-charm-chip {
@@ -3600,11 +3592,15 @@
   }
 
   .nail-charm-shell {
-    width: 62px;
+    width: calc(clamp(56px, var(--charm-base-width, 62px), 72px) * var(--charm-mode-scale, 1));
   }
 
   .nail-charm-shell--center {
-    width: 72px;
+    --charm-mode-scale: 1;
+  }
+
+  .nail-detail-dialog.display-mode-showcase .nail-charm-shell--center {
+    --charm-mode-scale: 1.08;
   }
 
   .nail-detail-meta {

--- a/src/components/NailImageDetailViewer.tsx
+++ b/src/components/NailImageDetailViewer.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useRef } from 'react';
+import type { CSSProperties } from 'react';
 import type { NailItemDoc } from '../lib/firestore';
 
 type DetailDisplayMode = 'Glass' | 'Snow Globe' | 'Velvet' | 'Showcase';
@@ -10,11 +11,75 @@ const DISPLAY_MODE_CLASS_NAMES: Record<DetailDisplayMode, string> = {
   Showcase: 'display-mode-showcase',
 };
 
+type CharmPosition = 'left' | 'center' | 'right';
+
+type CharmPlacement = {
+  position: CharmPosition;
+  style: CSSProperties & {
+    '--charm-left': string;
+    '--charm-top': string;
+    '--charm-base-width': string;
+    '--charm-rotation': string;
+    '--charm-opacity': string;
+    '--charm-delay': string;
+  };
+};
+
 interface NailImageDetailViewerProps {
   item: NailItemDoc;
   displayMode?: DetailDisplayMode;
   onClose: () => void;
 }
+
+const hashString = (value: string): number => {
+  let hash = 2166136261;
+  for (let i = 0; i < value.length; i += 1) {
+    hash ^= value.charCodeAt(i);
+    hash = Math.imul(hash, 16777619);
+  }
+  return hash >>> 0;
+};
+
+const seededUnit = (seed: string, salt: number): number =>
+  hashString(`${seed}:${salt}`) / 0xffffffff;
+
+const buildCharmPlacements = (seed: string): CharmPlacement[] => {
+  const base = [
+    { position: 'left', left: 17, leftRange: 8, top: 31, topRange: 12, width: 70, rotation: -13 },
+    { position: 'center', left: 50, leftRange: 5, top: 20, topRange: 8, width: 86, rotation: 1 },
+    { position: 'right', left: 72, leftRange: 8, top: 33, topRange: 12, width: 70, rotation: 13 },
+  ] satisfies Array<{
+    position: CharmPosition;
+    left: number;
+    leftRange: number;
+    top: number;
+    topRange: number;
+    width: number;
+    rotation: number;
+  }>;
+
+  return base.map((slot, index) => {
+    const signed = (salt: number) => seededUnit(seed, index * 7 + salt) - 0.5;
+    const left = slot.left + signed(1) * slot.leftRange;
+    const top = slot.top + signed(2) * slot.topRange;
+    const width = slot.width + signed(3) * 10;
+    const rotation = slot.rotation + signed(4) * 9;
+    const opacity = 0.9 + seededUnit(seed, index * 7 + 5) * 0.1;
+    const delay = -seededUnit(seed, index * 7 + 6) * 3.6;
+
+    return {
+      position: slot.position,
+      style: {
+        '--charm-left': `${left.toFixed(1)}%`,
+        '--charm-top': `${top.toFixed(1)}%`,
+        '--charm-base-width': `${width.toFixed(1)}px`,
+        '--charm-rotation': `${rotation.toFixed(1)}deg`,
+        '--charm-opacity': opacity.toFixed(2),
+        '--charm-delay': `${delay.toFixed(2)}s`,
+      },
+    };
+  });
+};
 
 const formatDate = (ts: { toDate(): Date } | null | undefined): string | null => {
   if (!ts) return null;
@@ -52,6 +117,7 @@ const NailImageDetailViewer: React.FC<NailImageDetailViewerProps> = ({
     item.updatedAt.seconds !== item.createdAt.seconds
       ? formatDate(item.updatedAt)
       : null;
+  const charmPlacements = buildCharmPlacements(item.id);
 
   return (
     <div
@@ -102,8 +168,12 @@ const NailImageDetailViewer: React.FC<NailImageDetailViewerProps> = ({
             <div className="nail-charm-stage" aria-hidden="true">
               <span className="nail-charm-orbit nail-charm-orbit--one" />
               <span className="nail-charm-orbit nail-charm-orbit--two" />
-              {['left', 'center', 'right'].map((position) => (
-                <div key={position} className={`nail-charm-shell nail-charm-shell--${position}`}>
+              {charmPlacements.map(({ position, style }) => (
+                <div
+                  key={position}
+                  className={`nail-charm-shell nail-charm-shell--${position}`}
+                  style={style}
+                >
                   <div className="nail-charm-chip">
                     <img
                       className="nail-charm-image"


### PR DESCRIPTION
## Summary
- Generate stable floating nail charm placements from each NailItem id.
- Keep the left / center / right charm lanes separated with deterministic jitter for position, size, rotation, opacity, and animation delay.
- Move charm layout values into CSS custom properties so display modes can keep their visual differences without runtime jitter.
- Preserve 390px mobile support with capped charm widths and reduced Showcase center scaling.

## Validation
- npm run lint
- npm run build
- npm test
- bash scripts/qa-preflight.sh

Closes #283
