### PR TITLE
[codex] Add subtle Jewelry Box motion

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -630,6 +630,10 @@
   padding: 2px 0;
 }
 
+.studio-mode-switcher button[aria-pressed='true'] {
+  animation: jewelry-mode-glow 5.6s ease-in-out infinite;
+}
+
 .studio-mode-switcher button {
   border-color: color-mix(in srgb, var(--jb-gold) 22%, var(--border));
   background: rgba(255, 255, 255, 0.72);
@@ -962,6 +966,7 @@
   box-shadow:
     inset 0 1px 0 rgba(255, 255, 255, 0.1),
     var(--jb-shadow-glow);
+  animation: jewelry-count-float 6.8s ease-in-out infinite;
 }
 
 .nail-studio-count span {
@@ -1443,7 +1448,10 @@
 }
 
 .saved-designs-chip {
+  animation-name: jewelry-chip-float;
   animation-duration: 5.4s;
+  animation-timing-function: ease-in-out;
+  animation-iteration-count: infinite;
 }
 
 .saved-designs-chip--one {
@@ -3504,6 +3512,23 @@
   transition: transform 0.22s ease, box-shadow 0.22s ease, border-color 0.22s ease, background 0.22s ease;
 }
 
+#nail-list:not(.loading) li:not(.editing):not(.nail-skeleton-card) {
+  animation: jewelry-card-float 7.8s ease-in-out infinite;
+}
+
+#nail-list:not(.loading) li:nth-child(2n) {
+  animation-delay: -1.9s;
+}
+
+#nail-list:not(.loading) li:nth-child(3n) {
+  animation-delay: -3.2s;
+}
+
+#nail-list li:hover,
+#nail-list li:focus-within {
+  animation-play-state: paused;
+}
+
 #nail-list li:hover {
   transform: translateY(-3px);
   border-color: color-mix(in srgb, var(--jb-gold) 44%, var(--accent-border));
@@ -3541,16 +3566,71 @@
   transition: transform 0.3s ease;
 }
 
+.nail-thumb-chip {
+  animation-name: jewelry-chip-float;
+  animation-timing-function: ease-in-out;
+  animation-iteration-count: infinite;
+}
+
 #nail-list li:hover .nail-thumb-img {
   transform: scale(1.05);
+}
+
+@keyframes jewelry-mode-glow {
+  0%,
+  100% {
+    box-shadow:
+      inset 0 1px 0 var(--jb-glass),
+      0 0 0 rgba(248, 217, 77, 0);
+  }
+  50% {
+    box-shadow:
+      inset 0 1px 0 var(--jb-glass),
+      0 0 16px rgba(248, 217, 77, 0.18);
+  }
+}
+
+@keyframes jewelry-count-float {
+  0%,
+  100% {
+    translate: 0 0;
+  }
+  50% {
+    translate: 0 -4px;
+  }
+}
+
+@keyframes jewelry-card-float {
+  0%,
+  100% {
+    translate: 0 0;
+  }
+  50% {
+    translate: 0 -2px;
+  }
+}
+
+@keyframes jewelry-chip-float {
+  0%,
+  100% {
+    translate: 0 0;
+  }
+  50% {
+    translate: 0 -6px;
+  }
 }
 
 @media (prefers-reduced-motion: reduce) {
   #nail-list li,
   .nail-card-body,
   .nail-card-thumb::after,
+  .studio-mode-switcher button[aria-pressed='true'],
+  .nail-studio-count,
+  .saved-designs-chip,
+  .nail-thumb-chip,
   .nail-item-actions button,
   .nail-thumb-img {
+    animation: none;
     transition: none;
   }
   #nail-list li:hover {


### PR DESCRIPTION
## Summary
- Add subtle CSS-only motion to the signed-in Jewelry Box experience.
- Animate active display mode glow, saved count float, premium card micro-float, and nail thumb chips.
- Pause card motion on hover/focus and disable new motion under `prefers-reduced-motion: reduce`.

## Validation
- npm run lint
- npm run build
- npm test
- bash scripts/qa-preflight.sh

Closes #282
