### PR TITLE
[codex] Add 390px layout guard

### DIFF
--- a/docs/operations/PRODUCTION_SMOKE_TEST_CHECKLIST.md
+++ b/docs/operations/PRODUCTION_SMOKE_TEST_CHECKLIST.md
@@ -32,6 +32,12 @@ For Jewelry Box Refresh release readiness, use the [Jewelry Box Refresh Release 
 | Privacy/Terms | Open Privacy Policy and Terms links once implemented. | Links are visible, routes load, and text matches the approved policy draft. |
 | Error fallback | Temporarily test with a failed network or invalid share URL if practical. | User-facing error states are understandable and do not expose sensitive details. |
 
+## 390px Width QA Notes
+
+- 2026-06-24 Codex pass: added a root `box-sizing: border-box` guard so the centered app shell keeps padding inside the 390px viewport width.
+- Automated scope: CSS/layout review plus build, lint, unit tests, and QA preflight.
+- Remaining human/device scope: signed-in Jewelry Box screens with real auth and test NailItems at 390px width, including Home, Design, Explore, Saved, Book, and Profile.
+
 ## Go / No-Go
 
 - Go: all critical flows pass, or only documented non-blocking issues remain.

--- a/src/App.css
+++ b/src/App.css
@@ -7,6 +7,7 @@
   place-content: start;
   place-items: center;
   flex-grow: 1;
+  box-sizing: border-box;
   padding: 32px 20px calc(48px + var(--fixed-control-safe-gap));
 }
 


### PR DESCRIPTION
## Summary
- Add a root `box-sizing: border-box` guard to keep app shell padding inside narrow 390px viewports.
- Record the Codex 390px QA scope and remaining human/device QA scope in the production smoke checklist.

## Notes
- This supports #290 but intentionally does not close it because signed-in Jewelry Box screens still need human/device verification with real auth and test NailItems.

## Validation
- npm run lint
- npm run build
- npm test
- bash scripts/qa-preflight.sh

Refs #290
