### PR TITLE
[codex] Connect detail design to booking memo

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1615,6 +1615,93 @@
   line-height: 1.65;
 }
 
+.appointment-selected-design {
+  display: grid;
+  grid-template-columns: 78px minmax(0, 1fr);
+  gap: 12px;
+  align-items: start;
+}
+
+.appointment-selected-thumb {
+  position: relative;
+  min-height: 82px;
+  display: grid;
+  place-items: center;
+  overflow: hidden;
+  border: 1px solid color-mix(in srgb, var(--jb-gold) 24%, var(--border));
+  border-radius: 8px;
+  background:
+    radial-gradient(ellipse at 50% 82%, rgba(84, 52, 74, 0.18), transparent 58%),
+    rgba(255, 255, 255, 0.68);
+}
+
+.appointment-selected-thumb img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.appointment-selected-copy {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.appointment-selected-copy strong {
+  color: var(--text-h);
+  font-size: 0.96rem;
+  line-height: 1.3;
+  overflow-wrap: anywhere;
+}
+
+.appointment-selected-tags,
+.appointment-selected-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.appointment-selected-tags span {
+  padding: 3px 7px;
+  border: 1px solid color-mix(in srgb, var(--jb-gold) 18%, transparent);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.62);
+  color: color-mix(in srgb, var(--accent) 72%, #4b2d3d);
+  font-size: 0.66rem;
+  font-weight: 800;
+  line-height: 1.45;
+}
+
+.appointment-selected-copy p {
+  margin: 0;
+  overflow-wrap: anywhere;
+}
+
+.appointment-selected-actions button {
+  min-height: 32px;
+  padding: 6px 10px;
+  border: 1px solid color-mix(in srgb, var(--jb-gold) 24%, var(--border));
+  border-radius: 6px;
+  background: rgba(255, 255, 255, 0.72);
+  color: var(--text-h);
+  cursor: pointer;
+  font: inherit;
+  font-size: 0.7rem;
+  font-weight: 800;
+}
+
+.appointment-selected-actions button:hover,
+.appointment-selected-actions button:focus-visible {
+  border-color: color-mix(in srgb, var(--jb-gold) 48%, var(--accent-border));
+  background: rgba(255, 255, 255, 0.94);
+}
+
+.appointment-selected-actions button:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
 .appointment-plan-grid {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
@@ -3179,7 +3266,15 @@
   line-height: 1.4;
 }
 
-.nail-detail-close {
+.nail-detail-header-actions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+.nail-detail-close,
+.nail-detail-plan {
   display: inline-flex;
   align-items: center;
   gap: 6px;
@@ -3193,11 +3288,20 @@
   cursor: pointer;
 }
 
-.nail-detail-close:hover {
+.nail-detail-plan {
+  border-color: color-mix(in srgb, var(--jb-gold) 36%, var(--border));
+  background: linear-gradient(135deg, rgba(248, 217, 77, 0.22), rgba(255, 255, 255, 0.08));
+  color: var(--text-h);
+  font-weight: 800;
+}
+
+.nail-detail-close:hover,
+.nail-detail-plan:hover {
   background: rgba(255, 255, 255, 0.08);
 }
 
-.nail-detail-close:focus-visible {
+.nail-detail-close:focus-visible,
+.nail-detail-plan:focus-visible {
   outline: 2px solid var(--accent);
   outline-offset: 2px;
 }
@@ -3715,6 +3819,15 @@
     max-height: calc(100vh - 24px);
   }
 
+  .nail-detail-header {
+    align-items: flex-start;
+  }
+
+  .nail-detail-header-actions {
+    flex-direction: column;
+    align-items: flex-end;
+  }
+
   .nail-detail-image-frame,
   .nail-detail-no-image {
     min-height: 180px;
@@ -3743,6 +3856,14 @@
 
   .nail-detail-meta {
     grid-template-columns: 1fr;
+  }
+
+  .appointment-selected-design {
+    grid-template-columns: 1fr;
+  }
+
+  .appointment-selected-thumb {
+    min-height: 120px;
   }
 }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -291,6 +291,7 @@ function App() {
   const [comparisonItemIds, setComparisonItemIds] = useState<string[]>([])
   const [savedItemIds, setSavedItemIds] = useState<string[]>([])
   const [likedItemIds, setLikedItemIds] = useState<string[]>([])
+  const [bookingMemoItemId, setBookingMemoItemId] = useState<string | null>(null)
   const [nailLoading, setNailLoading] = useState(false)
   const [nailError, setNailError] = useState('')
   const [isAIGeneratingTags, setIsAIGeneratingTags] = useState(false)
@@ -425,6 +426,7 @@ function App() {
         setComparisonItemIds([])
         setSavedItemIds([])
         setLikedItemIds([])
+        setBookingMemoItemId(null)
       }
     })
   }, [isPublicSharePage])
@@ -711,6 +713,7 @@ function App() {
     setComparisonItemIds(prev => prev.filter(id => id !== itemId))
     setSavedItemIds(prev => prev.filter(id => id !== itemId))
     setLikedItemIds(prev => prev.filter(id => id !== itemId))
+    if (bookingMemoItemId === itemId) setBookingMemoItemId(null)
     setNailLoading(true)
     setNailError('')
     setBannerError('')
@@ -730,6 +733,7 @@ function App() {
 
   const editingItem = editingId ? nailItems.find(i => i.id === editingId) : null
   const detailItem = detailItemId ? nailItems.find(i => i.id === detailItemId) : null
+  const bookingMemoItem = bookingMemoItemId ? nailItems.find(i => i.id === bookingMemoItemId) : null
   const isFetching = Boolean(user && nailItemsUserId !== user.uid)
   const summary = useMemo(() => getNailSummary(nailItems), [nailItems])
   const savedPreviewItems = nailItems.filter(item => savedItemIds.includes(item.id)).slice(0, 3)
@@ -758,6 +762,15 @@ function App() {
     setLikedItemIds(prev => (
       prev.includes(itemId) ? prev.filter(id => id !== itemId) : [...prev, itemId]
     ))
+  }
+
+  const handlePlanAppointmentFromDetail = (itemId: string) => {
+    setBookingMemoItemId(itemId)
+    setDetailItemId(null)
+    setActiveAppScreen('book')
+    window.requestAnimationFrame(() => {
+      document.getElementById('nail-section')?.scrollIntoView({ block: 'start' })
+    })
   }
 
   const getShareUrl = (id: string): string =>
@@ -1034,6 +1047,7 @@ function App() {
           <NailImageDetailViewer
             item={detailItem}
             displayMode={activeDisplayMode}
+            onPlanAppointment={handlePlanAppointmentFromDetail}
             onClose={() => setDetailItemId(null)}
           />
         </Suspense>
@@ -1521,14 +1535,51 @@ function App() {
               <div className="appointment-memo-card">
                 <div className="appointment-memo-top">
                   <span>Next visit memo</span>
-                  <small>No booking/payment</small>
+                  <small>{bookingMemoItem ? 'Design selected' : 'No booking/payment'}</small>
                 </div>
-                <div className="appointment-memo-lines" aria-hidden="true">
-                  <span />
-                  <span />
-                  <span />
-                </div>
-                <p>希望の形、色、予算、相談したいことを一箇所にまとめるための下書き領域です。</p>
+                {bookingMemoItem ? (
+                  <div className="appointment-selected-design">
+                    <div className="appointment-selected-thumb" aria-hidden="true">
+                      {bookingMemoItem.imageUrl ? (
+                        <img src={bookingMemoItem.imageUrl} alt="" />
+                      ) : (
+                        <FloatingNailChip variant="empty" shape="oval" showHighlight={false} />
+                      )}
+                    </div>
+                    <div className="appointment-selected-copy">
+                      <strong>{bookingMemoItem.title}</strong>
+                      {bookingMemoItem.tags.length > 0 && (
+                        <div className="appointment-selected-tags">
+                          {bookingMemoItem.tags.slice(0, 4).map(tag => (
+                            <span key={tag}>#{tag}</span>
+                          ))}
+                        </div>
+                      )}
+                      <p>
+                        {bookingMemoItem.memo
+                          ? bookingMemoItem.memo
+                          : 'このデザインを次回来店時の相談メモとして使います。'}
+                      </p>
+                      <div className="appointment-selected-actions">
+                        <button type="button" onClick={() => handleOpenDetailCard(bookingMemoItem.id)}>
+                          詳細を見る
+                        </button>
+                        <button type="button" onClick={() => setBookingMemoItemId(null)}>
+                          選択を外す
+                        </button>
+                      </div>
+                    </div>
+                  </div>
+                ) : (
+                  <>
+                    <div className="appointment-memo-lines" aria-hidden="true">
+                      <span />
+                      <span />
+                      <span />
+                    </div>
+                    <p>希望の形、色、予算、相談したいことを一箇所にまとめるための下書き領域です。</p>
+                  </>
+                )}
               </div>
               <div className="appointment-plan-grid" aria-label="予約計画の項目">
                 {APPOINTMENT_PLAN_FIELDS.map(field => (

--- a/src/components/NailImageDetailViewer.tsx
+++ b/src/components/NailImageDetailViewer.tsx
@@ -28,6 +28,7 @@ type CharmPlacement = {
 interface NailImageDetailViewerProps {
   item: NailItemDoc;
   displayMode?: DetailDisplayMode;
+  onPlanAppointment?: (itemId: string) => void;
   onClose: () => void;
 }
 
@@ -97,6 +98,7 @@ const formatDate = (ts: { toDate(): Date } | null | undefined): string | null =>
 const NailImageDetailViewer: React.FC<NailImageDetailViewerProps> = ({
   item,
   displayMode = 'Glass',
+  onPlanAppointment,
   onClose,
 }) => {
   const closeButtonRef = useRef<HTMLButtonElement>(null);
@@ -137,16 +139,27 @@ const NailImageDetailViewer: React.FC<NailImageDetailViewerProps> = ({
             <p className="nail-detail-kicker">Jewelry Box Detail</p>
             <p className="nail-detail-close-hint">背景クリックまたはEscで閉じる</p>
           </div>
-          <button
-            ref={closeButtonRef}
-            type="button"
-            className="nail-detail-close"
-            onClick={onClose}
-            aria-label="ネイル詳細カードを閉じる"
-          >
-            <span aria-hidden="true">×</span>
-            閉じる
-          </button>
+          <div className="nail-detail-header-actions">
+            {onPlanAppointment && (
+              <button
+                type="button"
+                className="nail-detail-plan"
+                onClick={() => onPlanAppointment(item.id)}
+              >
+                来店メモに使う
+              </button>
+            )}
+            <button
+              ref={closeButtonRef}
+              type="button"
+              className="nail-detail-close"
+              onClick={onClose}
+              aria-label="ネイル詳細カードを閉じる"
+            >
+              <span aria-hidden="true">×</span>
+              閉じる
+            </button>
+          </div>
         </div>
         <div className="nail-detail-image-frame">
           {item.imageUrl ? (


### PR DESCRIPTION
## Summary
- Add a booking memo entry point to the nail detail card.
- Carry the selected design context into the Book screen as a planning memo card.
- Keep the flow planning-only: no real reservation submission and no backend write.

## Validation
- npm run lint
- npm run build
- npm test
- bash scripts/qa-preflight.sh

Closes #289
