### PR TITLE
[codex] Add complete refreshed empty states

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1485,6 +1485,75 @@
   line-height: 1.65;
 }
 
+.screen-empty-state {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 16px;
+  border: 1px solid color-mix(in srgb, var(--jb-gold) 22%, var(--border));
+  border-radius: 8px;
+  background:
+    radial-gradient(circle at 16% 20%, rgba(248, 217, 77, 0.14), transparent 30%),
+    rgba(255, 255, 255, 0.62);
+}
+
+.screen-empty-kicker {
+  margin: 0;
+  color: var(--jb-rose);
+  font-size: 0.66rem;
+  font-weight: 800;
+  letter-spacing: 0.16em;
+}
+
+.screen-empty-state h4 {
+  margin: 0;
+  color: var(--text-h);
+  font-size: 1rem;
+  line-height: 1.35;
+}
+
+.screen-empty-state p {
+  margin: 0;
+  color: var(--text);
+  font-size: 0.82rem;
+  line-height: 1.65;
+}
+
+.screen-empty-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 2px;
+}
+
+.screen-empty-actions button,
+.screen-empty-state button {
+  min-height: 36px;
+  padding: 7px 12px;
+  border: 1px solid color-mix(in srgb, var(--jb-gold) 24%, var(--border));
+  border-radius: 6px;
+  background: rgba(255, 255, 255, 0.74);
+  color: var(--text-h);
+  cursor: pointer;
+  font: inherit;
+  font-size: 0.72rem;
+  font-weight: 800;
+}
+
+.screen-empty-actions button:hover,
+.screen-empty-actions button:focus-visible,
+.screen-empty-state button:hover,
+.screen-empty-state button:focus-visible {
+  border-color: color-mix(in srgb, var(--jb-gold) 48%, var(--accent-border));
+  background: rgba(255, 255, 255, 0.94);
+}
+
+.screen-empty-actions button:focus-visible,
+.screen-empty-state button:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
 .saved-designs-data-slots {
   display: grid;
   grid-template-columns: 1fr;
@@ -2618,6 +2687,23 @@
   height: 4px;
   border-radius: 9999px;
   background: var(--accent);
+}
+
+.nail-empty-actions {
+  justify-content: center;
+  margin-top: 12px;
+}
+
+.nail-empty-actions button {
+  border-color: rgba(255, 255, 255, 0.18);
+  background: rgba(255, 255, 255, 0.1);
+  color: rgba(255, 255, 255, 0.92);
+}
+
+.nail-empty-actions button:hover,
+.nail-empty-actions button:focus-visible {
+  border-color: color-mix(in srgb, var(--jb-gold) 48%, rgba(255, 255, 255, 0.18));
+  background: rgba(255, 255, 255, 0.16);
 }
 
 @keyframes empty-chip-float {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1470,6 +1470,16 @@ function App() {
                 </article>
               ))}
             </div>
+            {nailItems.length === 0 && (
+              <div className="screen-empty-state">
+                <p className="screen-empty-kicker">FIRST INSPIRATION</p>
+                <h4>気になるムードを見つけたら、まず一つ記録しましょう。</h4>
+                <p>Explore は次の候補を眺める場所です。自分の写真が増えると、ここから保存・比較・来店メモへつなげやすくなります。</p>
+                <button type="button" onClick={() => handleSelectAppScreen('design')}>
+                  ネイルを記録する
+                </button>
+              </div>
+            )}
           </section>
           )}
           {activeAppScreen === 'saved' && (
@@ -1508,6 +1518,16 @@ function App() {
                       ? savedPreviewItems.map(item => item.title).join(' / ')
                       : '写真・形・色・タグが接続されると、ここにお気に入りのネイルカードが並びます。'}
                   </p>
+                  {savedItemIds.length === 0 && (
+                    <div className="screen-empty-actions">
+                      <button type="button" onClick={() => handleSelectAppScreen('home')}>
+                        宝石箱を見る
+                      </button>
+                      <button type="button" onClick={() => handleSelectAppScreen('design')}>
+                        最初のデザインを記録
+                      </button>
+                    </div>
+                  )}
                 </div>
               </div>
               <div className="saved-designs-data-slots" aria-label="後続接続予定の項目">
@@ -1578,6 +1598,14 @@ function App() {
                       <span />
                     </div>
                     <p>希望の形、色、予算、相談したいことを一箇所にまとめるための下書き領域です。</p>
+                    <div className="screen-empty-actions">
+                      <button type="button" onClick={() => handleSelectAppScreen('home')}>
+                        デザインを選ぶ
+                      </button>
+                      <button type="button" onClick={() => handleSelectAppScreen('design')}>
+                        新しく記録する
+                      </button>
+                    </div>
                   </>
                 )}
               </div>
@@ -1920,6 +1948,14 @@ function App() {
                 <li>タイトル・写真・タグ・メモを記録できます</li>
                 <li>タグや検索でいつでも素早く見つかります</li>
               </ul>
+              <div className="screen-empty-actions nail-empty-actions">
+                <button type="button" onClick={() => handleSelectAppScreen('design')}>
+                  最初のネイルを記録
+                </button>
+                <button type="button" onClick={() => handleSelectAppScreen('inspiration')}>
+                  ムードを探す
+                </button>
+              </div>
             </div>
           ) : filteredItems.length === 0 ? (
             <p className="nail-search-empty">条件に一致するアイテムがありません。</p>


### PR DESCRIPTION
## Summary
- Add Jewelry Box tone empty-state guidance for Home, Explore, Saved, and Book.
- Add next-step actions that move users toward Design, Home, or Explore without backend changes.
- Keep empty states responsive and scoped to existing refreshed screens.

## Validation
- npm run lint
- npm run build
- npm test
- bash scripts/qa-preflight.sh

Closes #295