### PR TITLE
[codex] Add optional appointment fields

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -172,6 +172,9 @@ interface ExportedNailItem {
   title: string
   tags: string
   memo: string
+  salonName: string
+  price: string
+  appointmentDate: string
   imageUrl: string
   imageSource: string
   createdAt: string
@@ -188,13 +191,28 @@ const formatNailItemForExport = (item: NailItemDoc): ExportedNailItem => ({
   title: item.title,
   tags: item.tags.join(';'),
   memo: item.memo ?? '',
+  salonName: item.salonName ?? '',
+  price: item.price ?? '',
+  appointmentDate: item.appointmentDate ?? '',
   imageUrl: item.imageUrl ?? '',
   imageSource: item.imageSource ?? 'unknown',
   createdAt: formatTimestampForExport(item.createdAt),
   updatedAt: formatTimestampForExport(item.updatedAt),
 })
 
-const CSV_HEADERS = ['id', 'title', 'tags', 'memo', 'imageUrl', 'imageSource', 'createdAt', 'updatedAt'] as const
+const CSV_HEADERS = [
+  'id',
+  'title',
+  'tags',
+  'memo',
+  'salonName',
+  'price',
+  'appointmentDate',
+  'imageUrl',
+  'imageSource',
+  'createdAt',
+  'updatedAt',
+] as const
 
 const escapeCsvCell = (value: string): string => {
   if (/[",\n\r]/.test(value)) return `"${value.replace(/"/g, '""')}"`

--- a/src/lib/firestoreModel.ts
+++ b/src/lib/firestoreModel.ts
@@ -10,6 +10,9 @@ export interface NailItem {
   mainColor?: string
   texture?: string
   decorationParts?: string[]
+  salonName?: string
+  price?: string
+  appointmentDate?: string
   imageSource?: 'upload' | 'camera' | 'unknown'
   createdAt: Timestamp | null
   updatedAt: Timestamp | null
@@ -28,14 +31,20 @@ export interface NailItemInput {
   mainColor?: string
   texture?: string
   decorationParts?: string[]
+  salonName?: string
+  price?: string
+  appointmentDate?: string
   imageSource?: 'upload' | 'camera' | 'unknown'
 }
 
-const buildOptionalDesignFields = (input: NailItemInput) => ({
+const buildOptionalNailItemFields = (input: NailItemInput) => ({
   ...(input.shape !== undefined ? { shape: input.shape } : {}),
   ...(input.mainColor !== undefined ? { mainColor: input.mainColor } : {}),
   ...(input.texture !== undefined ? { texture: input.texture } : {}),
   ...(input.decorationParts !== undefined ? { decorationParts: input.decorationParts } : {}),
+  ...(input.salonName !== undefined ? { salonName: input.salonName } : {}),
+  ...(input.price !== undefined ? { price: input.price } : {}),
+  ...(input.appointmentDate !== undefined ? { appointmentDate: input.appointmentDate } : {}),
 })
 
 export const toNailItemDoc = (id: string, data: NailItem): NailItemDoc => ({
@@ -49,7 +58,7 @@ export const buildCreateNailItemData = (input: NailItemInput, timestamp: unknown
   thumbnailUrl: input.imageUrl,
   tags: input.tags,
   memo: input.memo,
-  ...buildOptionalDesignFields(input),
+  ...buildOptionalNailItemFields(input),
   imageSource: input.imageSource ?? 'unknown',
   createdAt: timestamp,
   updatedAt: timestamp,
@@ -61,7 +70,7 @@ export const buildUpdateNailItemData = (input: NailItemInput, timestamp: unknown
   thumbnailUrl: input.imageUrl,
   tags: input.tags,
   memo: input.memo,
-  ...buildOptionalDesignFields(input),
+  ...buildOptionalNailItemFields(input),
   imageSource: input.imageSource ?? 'unknown',
   updatedAt: timestamp,
 })

--- a/tests/firestoreModel.test.ts
+++ b/tests/firestoreModel.test.ts
@@ -22,6 +22,13 @@ const designInput: NailItemInput = {
   decorationParts: ['pearl', 'gold-line'],
 }
 
+const appointmentInput: NailItemInput = {
+  ...input,
+  salonName: 'Aoyama Nail',
+  price: '12000',
+  appointmentDate: '2026-07-12',
+}
+
 test('buildCreateNailItemData creates the Firestore write payload', () => {
   const timestamp = Symbol('serverTimestamp')
   assert.deepEqual(buildCreateNailItemData(input, timestamp), {
@@ -60,6 +67,23 @@ test('buildCreateNailItemData includes optional nail design fields when provided
   })
 })
 
+test('buildCreateNailItemData includes optional appointment fields when provided', () => {
+  const timestamp = Symbol('serverTimestamp')
+  assert.deepEqual(buildCreateNailItemData(appointmentInput, timestamp), {
+    title: appointmentInput.title,
+    imageUrl: appointmentInput.imageUrl,
+    thumbnailUrl: appointmentInput.imageUrl,
+    tags: appointmentInput.tags,
+    memo: appointmentInput.memo,
+    salonName: 'Aoyama Nail',
+    price: '12000',
+    appointmentDate: '2026-07-12',
+    imageSource: 'camera',
+    createdAt: timestamp,
+    updatedAt: timestamp,
+  })
+})
+
 test('buildUpdateNailItemData omits createdAt and refreshes updatedAt', () => {
   const timestamp = Symbol('serverTimestamp')
   assert.deepEqual(buildUpdateNailItemData(input, timestamp), {
@@ -85,6 +109,22 @@ test('buildUpdateNailItemData includes optional nail design fields when provided
     mainColor: 'blush',
     texture: 'gloss',
     decorationParts: ['pearl', 'gold-line'],
+    imageSource: 'camera',
+    updatedAt: timestamp,
+  })
+})
+
+test('buildUpdateNailItemData includes optional appointment fields when provided', () => {
+  const timestamp = Symbol('serverTimestamp')
+  assert.deepEqual(buildUpdateNailItemData(appointmentInput, timestamp), {
+    title: appointmentInput.title,
+    imageUrl: appointmentInput.imageUrl,
+    thumbnailUrl: appointmentInput.imageUrl,
+    tags: appointmentInput.tags,
+    memo: appointmentInput.memo,
+    salonName: 'Aoyama Nail',
+    price: '12000',
+    appointmentDate: '2026-07-12',
     imageSource: 'camera',
     updatedAt: timestamp,
   })
@@ -117,4 +157,7 @@ test('toNailItemDoc safely maps old documents without optional nail design field
   assert.equal(result.mainColor, undefined)
   assert.equal(result.texture, undefined)
   assert.equal(result.decorationParts, undefined)
+  assert.equal(result.salonName, undefined)
+  assert.equal(result.price, undefined)
+  assert.equal(result.appointmentDate, undefined)
 })


### PR DESCRIPTION
## Summary
- Add optional `salonName`, `price`, and `appointmentDate` fields to NailItem and NailItemInput.
- Include appointment fields in Firestore create/update payloads only when present.
- Include appointment fields in CSV/JSON export output and add unit coverage.

## Validation
- npm run lint
- npm test
- npm run build

Closes #274