### PR TITLE
[codex] Display saved designs from existing items

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1409,6 +1409,13 @@
   white-space: nowrap;
 }
 
+.saved-designs-source-note {
+  margin: -4px 0 0;
+  color: color-mix(in srgb, var(--text) 78%, var(--jb-rose));
+  font-size: 0.72rem;
+  font-weight: 700;
+}
+
 .saved-designs-surface {
   display: grid;
   grid-template-columns: minmax(0, 1fr) minmax(164px, 0.42fr);
@@ -1571,6 +1578,106 @@
   color: color-mix(in srgb, var(--text-h) 82%, var(--jb-rose));
   font-size: 0.72rem;
   font-weight: 800;
+}
+
+.saved-designs-card-list {
+  display: grid;
+  gap: 8px;
+}
+
+.saved-design-card {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 10px;
+  border: 1px solid color-mix(in srgb, var(--border) 70%, var(--jb-gold));
+  border-radius: 8px;
+  background:
+    radial-gradient(circle at 12% 18%, rgba(248, 217, 77, 0.12), transparent 34%),
+    rgba(255, 255, 255, 0.68);
+}
+
+.saved-design-card-main {
+  display: grid;
+  grid-template-columns: 58px minmax(0, 1fr);
+  gap: 10px;
+  align-items: center;
+  width: 100%;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: inherit;
+  cursor: pointer;
+  font: inherit;
+  text-align: left;
+}
+
+.saved-design-card-main:focus-visible,
+.saved-design-card-actions button:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.saved-design-card-thumb {
+  min-height: 58px;
+  display: grid;
+  place-items: center;
+  overflow: hidden;
+  border: 1px solid color-mix(in srgb, var(--jb-gold) 24%, var(--border));
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.72);
+}
+
+.saved-design-card-thumb img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.saved-design-card-copy {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+}
+
+.saved-design-card-copy strong {
+  color: var(--text-h);
+  font-size: 0.86rem;
+  line-height: 1.3;
+  overflow-wrap: anywhere;
+}
+
+.saved-design-card-copy span {
+  color: var(--text);
+  font-size: 0.72rem;
+  line-height: 1.45;
+  overflow-wrap: anywhere;
+}
+
+.saved-design-card-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.saved-design-card-actions button {
+  min-height: 30px;
+  padding: 5px 9px;
+  border: 1px solid color-mix(in srgb, var(--jb-gold) 24%, var(--border));
+  border-radius: 6px;
+  background: rgba(255, 255, 255, 0.72);
+  color: var(--text-h);
+  cursor: pointer;
+  font: inherit;
+  font-size: 0.68rem;
+  font-weight: 800;
+}
+
+.saved-design-card-actions button:hover,
+.saved-design-card-actions button:focus-visible {
+  border-color: color-mix(in srgb, var(--jb-gold) 48%, var(--accent-border));
+  background: rgba(255, 255, 255, 0.94);
 }
 
 .appointment-screen {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -785,7 +785,8 @@ function App() {
   const bookingMemoItem = bookingMemoItemId ? nailItems.find(i => i.id === bookingMemoItemId) : null
   const isFetching = Boolean(user && nailItemsUserId !== user.uid)
   const summary = useMemo(() => getNailSummary(nailItems), [nailItems])
-  const savedPreviewItems = nailItems.filter(item => savedItemIds.includes(item.id)).slice(0, 3)
+  const savedDesignItems = nailItems.filter(item => savedItemIds.includes(item.id))
+  const savedPreviewItems = savedDesignItems.slice(0, 3)
 
   const filteredItems = nailItems.filter(item => {
     if (searchQuery.trim()) {
@@ -1538,12 +1539,15 @@ function App() {
                 <p className="nail-design-kicker">SAVED DESIGNS</p>
                 <h3 id="saved-designs-title">また使いたいデザインを集める。</h3>
                 <p>
-                  お気に入りの組み合わせをあとで見返すための静的サーフェスです。
-                  後続フェーズで保存済みネイルやいいね状態に接続します。
+                  カード上の Save から選んだ既存 NailItem をここに並べます。
+                  現在は端末セッション内の保存状態として扱い、後続フェーズで永続化します。
                 </p>
               </div>
-              <span className="saved-designs-badge">{savedItemIds.length} saved</span>
+              <span className="saved-designs-badge">{savedDesignItems.length} saved</span>
             </div>
+            <p className="saved-designs-source-note">
+              Data source: existing NailItems + session-local Save state
+            </p>
             <div className="saved-designs-surface">
               <div className="saved-designs-empty">
                 <div className="saved-designs-empty-stage" aria-hidden="true">
@@ -1561,13 +1565,13 @@ function App() {
                   />
                 </div>
                 <div>
-                  <h4>{savedItemIds.length > 0 ? '保存したデザイン' : '保存デザインはまだありません'}</h4>
+                  <h4>{savedDesignItems.length > 0 ? '保存したデザイン' : '保存デザインはまだありません'}</h4>
                   <p>
-                    {savedItemIds.length > 0
+                    {savedDesignItems.length > 0
                       ? savedPreviewItems.map(item => item.title).join(' / ')
                       : '写真・形・色・タグが接続されると、ここにお気に入りのネイルカードが並びます。'}
                   </p>
-                  {savedItemIds.length === 0 && (
+                  {savedDesignItems.length === 0 && (
                     <div className="screen-empty-actions">
                       <button type="button" onClick={() => handleSelectAppScreen('home')}>
                         宝石箱を見る
@@ -1579,11 +1583,43 @@ function App() {
                   )}
                 </div>
               </div>
-              <div className="saved-designs-data-slots" aria-label="後続接続予定の項目">
-                {SAVED_DESIGN_FIELDS.map(field => (
-                  <span key={field}>{field}</span>
-                ))}
-              </div>
+              {savedDesignItems.length > 0 ? (
+                <div className="saved-designs-card-list" aria-label="保存したデザイン">
+                  {savedDesignItems.map(item => (
+                    <article key={item.id} className="saved-design-card">
+                      <button
+                        type="button"
+                        className="saved-design-card-main"
+                        onClick={() => handleOpenDetailCard(item.id)}
+                      >
+                        <span className="saved-design-card-thumb" aria-hidden="true">
+                          {item.imageUrl ? (
+                            <img src={item.imageUrl} alt="" />
+                          ) : (
+                            <FloatingNailChip variant="empty" shape="almond" showHighlight={false} />
+                          )}
+                        </span>
+                        <span className="saved-design-card-copy">
+                          <strong>{item.title}</strong>
+                          <span>
+                            {[item.shape, item.mainColor, item.texture].filter(Boolean).join(' / ') || 'デザイン詳細は未設定'}
+                          </span>
+                        </span>
+                      </button>
+                      <div className="saved-design-card-actions">
+                        <button type="button" onClick={() => handleOpenDetailCard(item.id)}>詳細</button>
+                        <button type="button" onClick={() => handleToggleSavedItem(item.id)}>保存解除</button>
+                      </div>
+                    </article>
+                  ))}
+                </div>
+              ) : (
+                <div className="saved-designs-data-slots" aria-label="表示予定の項目">
+                  {SAVED_DESIGN_FIELDS.map(field => (
+                    <span key={field}>{field}</span>
+                  ))}
+                </div>
+              )}
             </div>
           </section>
           )}


### PR DESCRIPTION
## Summary
- Make the Saved Designs data source explicit: existing NailItems plus session-local Save state.
- Render saved existing NailItems as Saved Designs cards with detail and unsave actions.
- Preserve the zero-saved empty state and avoid any schema/rules changes.

## Validation
- npm run lint
- npm test
- npm run build

Closes #278