### PR TITLE
[codex] Reframe Jewelry Box home experience

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -987,6 +987,283 @@
   text-transform: uppercase;
 }
 
+.jewel-home-stage {
+  position: relative;
+  min-height: clamp(560px, 76vh, 760px);
+  display: grid;
+  grid-template-rows: auto minmax(360px, 1fr) auto;
+  gap: 18px;
+  overflow: hidden;
+  padding: clamp(20px, 4vw, 34px);
+  border: 1px solid color-mix(in srgb, var(--jb-gold) 28%, rgba(255, 255, 255, 0.12));
+  border-radius: 12px;
+  background: linear-gradient(160deg, rgba(10, 6, 14, 0.98), rgba(31, 16, 34, 0.96) 48%, rgba(13, 24, 24, 0.94)), #0b0710;
+  color: rgba(255, 255, 255, 0.88);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.1), 0 24px 64px rgba(20, 8, 24, 0.28);
+}
+
+.jewel-home-stage::before {
+  content: '';
+  position: absolute;
+  inset: 12% 5% 18%;
+  border: 1px solid rgba(248, 217, 77, 0.16);
+  border-radius: 50%;
+  transform: perspective(720px) rotateX(68deg);
+  opacity: 0.72;
+  pointer-events: none;
+}
+
+.jewel-home-copy {
+  position: relative;
+  z-index: 1;
+  max-width: 560px;
+}
+
+.jewel-home-copy h2 {
+  max-width: 520px;
+  margin: 0 0 10px;
+  color: rgba(255, 255, 255, 0.98);
+  font-size: clamp(1.72rem, 6vw, 3.2rem);
+  line-height: 1.02;
+}
+
+.jewel-home-copy p {
+  max-width: 520px;
+  margin: 0;
+  color: rgba(255, 255, 255, 0.66);
+  font-size: 0.9rem;
+  line-height: 1.75;
+}
+
+.jewel-home-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 14px;
+}
+
+.jewel-home-actions button {
+  min-height: 38px;
+  padding: 8px 13px;
+  border: 1px solid rgba(248, 217, 77, 0.28);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.08);
+  color: rgba(255, 255, 255, 0.92);
+  cursor: pointer;
+  font: inherit;
+  font-size: 0.76rem;
+  font-weight: 800;
+}
+
+.jewel-home-actions button:hover,
+.jewel-home-actions button:focus-visible {
+  border-color: rgba(248, 217, 77, 0.58);
+  background: rgba(255, 255, 255, 0.14);
+}
+
+.jewel-home-actions button:focus-visible,
+.jewel-nail-button:focus-visible {
+  outline: 2px solid var(--jb-gold);
+  outline-offset: 3px;
+}
+
+.jewel-orbit {
+  position: relative;
+  min-height: 360px;
+  z-index: 1;
+}
+
+.jewel-orbit-shadow {
+  position: absolute;
+  left: 18%;
+  right: 18%;
+  bottom: 6%;
+  height: 54px;
+  border-radius: 50%;
+  background: radial-gradient(ellipse at 50% 50%, rgba(0, 0, 0, 0.42), transparent 70%);
+  filter: blur(4px);
+}
+
+.jewel-nail-button {
+  --orbit-x: 50%;
+  --orbit-y: 50%;
+  --orbit-scale: 1;
+  --orbit-delay: 0s;
+  position: absolute;
+  left: var(--orbit-x);
+  top: var(--orbit-y);
+  display: grid;
+  justify-items: center;
+  gap: 8px;
+  width: 116px;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: rgba(255, 255, 255, 0.82);
+  cursor: pointer;
+  font: inherit;
+  transform: translate(-50%, -50%) scale(var(--orbit-scale));
+  animation: jewel-float 5.6s ease-in-out infinite;
+  animation-delay: var(--orbit-delay);
+}
+
+.jewel-nail-button--empty {
+  left: 50%;
+  top: 50%;
+  width: 150px;
+}
+
+.jewel-nail-label {
+  max-width: 132px;
+  padding: 4px 8px;
+  border: 1px solid rgba(248, 217, 77, 0.16);
+  border-radius: 999px;
+  background: rgba(10, 6, 14, 0.62);
+  color: rgba(255, 255, 255, 0.78);
+  font-size: 0.68rem;
+  font-weight: 800;
+  line-height: 1.25;
+  overflow-wrap: anywhere;
+}
+
+.jewel-home-hint {
+  position: relative;
+  z-index: 1;
+  margin: 0;
+  color: rgba(255, 255, 255, 0.52);
+  font-size: 0.76rem;
+  font-weight: 800;
+  text-align: center;
+}
+
+.realistic-nail {
+  position: relative;
+  width: 82px;
+  height: 168px;
+  display: block;
+  overflow: hidden;
+  border: 1px solid rgba(255, 255, 255, 0.22);
+  border-radius: 45% 45% 52% 52% / 12% 12% 82% 82%;
+  background:
+    linear-gradient(110deg, rgba(255, 255, 255, 0.72) 0 8%, transparent 9% 27%, rgba(255, 255, 255, 0.28) 28% 33%, transparent 34%),
+    linear-gradient(180deg, var(--nail-light), var(--nail-mid) 52%, var(--nail-deep));
+  box-shadow:
+    inset 10px 0 18px rgba(255, 255, 255, 0.32),
+    inset -12px -10px 24px rgba(47, 15, 39, 0.28),
+    0 24px 34px rgba(0, 0, 0, 0.34),
+    0 0 24px color-mix(in srgb, var(--nail-mid) 36%, transparent);
+  transform: perspective(380px) rotateX(12deg) rotateZ(-10deg);
+}
+
+.realistic-nail::before {
+  content: '';
+  position: absolute;
+  inset: 8px 15px auto;
+  height: 64%;
+  border-radius: inherit;
+  background: linear-gradient(90deg, rgba(255, 255, 255, 0.44), transparent 42%);
+  opacity: 0.72;
+}
+
+.realistic-nail::after {
+  content: '';
+  position: absolute;
+  left: 16%;
+  right: 16%;
+  bottom: 10px;
+  height: 18px;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.22);
+  filter: blur(2px);
+}
+
+.realistic-nail img {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  opacity: 0.58;
+  mix-blend-mode: soft-light;
+}
+
+.realistic-nail--round {
+  border-radius: 46% 46% 44% 44% / 16% 16% 74% 74%;
+}
+
+.realistic-nail--square {
+  border-radius: 24% 24% 18% 18% / 10% 10% 30% 30%;
+}
+
+.realistic-nail--coffin {
+  clip-path: polygon(24% 0, 76% 0, 92% 70%, 72% 100%, 28% 100%, 8% 70%);
+}
+
+.realistic-nail--stiletto {
+  clip-path: polygon(50% 0, 88% 58%, 72% 100%, 28% 100%, 12% 58%);
+}
+
+.realistic-nail--blush {
+  --nail-light: #fff2f7;
+  --nail-mid: #f1a8c2;
+  --nail-deep: #9e4766;
+}
+
+.realistic-nail--rose {
+  --nail-light: #ffe5ed;
+  --nail-mid: #d96a8b;
+  --nail-deep: #7d2949;
+}
+
+.realistic-nail--lavender {
+  --nail-light: #f4edff;
+  --nail-mid: #b9a2dc;
+  --nail-deep: #614f90;
+}
+
+.realistic-nail--mint {
+  --nail-light: #ebfff7;
+  --nail-mid: #94d8c1;
+  --nail-deep: #3e806f;
+}
+
+.realistic-nail--champagne {
+  --nail-light: #fff6d9;
+  --nail-mid: #e8c977;
+  --nail-deep: #9d7b34;
+}
+
+.realistic-nail--matte {
+  filter: saturate(0.86) brightness(0.96);
+}
+
+.realistic-nail--glitter {
+  background:
+    radial-gradient(circle at 28% 24%, rgba(255, 255, 255, 0.9) 0 1px, transparent 2px),
+    radial-gradient(circle at 66% 42%, rgba(255, 255, 255, 0.8) 0 1px, transparent 2px),
+    radial-gradient(circle at 42% 70%, rgba(248, 217, 77, 0.9) 0 1px, transparent 2px),
+    linear-gradient(110deg, rgba(255, 255, 255, 0.72) 0 8%, transparent 9% 27%, rgba(255, 255, 255, 0.28) 28% 33%, transparent 34%),
+    linear-gradient(180deg, var(--nail-light), var(--nail-mid) 52%, var(--nail-deep));
+}
+
+.realistic-nail--chrome {
+  background:
+    linear-gradient(100deg, rgba(255, 255, 255, 0.9), transparent 18%, rgba(255, 255, 255, 0.62) 34%, transparent 50%, rgba(14, 30, 42, 0.34) 72%, rgba(255, 255, 255, 0.58)),
+    linear-gradient(180deg, var(--nail-light), var(--nail-mid) 52%, var(--nail-deep));
+}
+
+@keyframes jewel-float {
+  0%,
+  100% {
+    translate: 0 0;
+    rotate: -1deg;
+  }
+  50% {
+    translate: 0 -14px;
+    rotate: 2deg;
+  }
+}
+
 /* Public share route */
 
 #public-share-page {
@@ -1144,6 +1421,104 @@
   display: flex;
   flex-direction: column;
   gap: 12px;
+}
+
+.nail-atelier-preview {
+  display: grid;
+  grid-template-columns: minmax(180px, 0.42fr) minmax(0, 1fr);
+  gap: 14px;
+  align-items: center;
+  padding: 16px;
+  border: 1px solid color-mix(in srgb, var(--jb-gold) 24%, var(--border));
+  border-radius: 10px;
+  background:
+    linear-gradient(145deg, rgba(255, 255, 255, 0.9), rgba(255, 246, 250, 0.72)),
+    rgba(255, 255, 255, 0.68);
+}
+
+.nail-atelier-stage {
+  position: relative;
+  min-height: 260px;
+  display: grid;
+  place-items: center;
+  overflow: hidden;
+  border: 1px solid color-mix(in srgb, var(--jb-gold) 22%, var(--border));
+  border-radius: 10px;
+  background:
+    linear-gradient(160deg, rgba(13, 8, 18, 0.96), rgba(40, 22, 42, 0.9)),
+    #0f0914;
+}
+
+.nail-atelier-stage .realistic-nail {
+  width: 98px;
+  height: 210px;
+  transform: perspective(420px) rotateX(10deg) rotateZ(-7deg);
+}
+
+.nail-atelier-deco {
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  width: 98px;
+  height: 210px;
+  transform: translate(-50%, -50%) rotate(-7deg);
+  pointer-events: none;
+}
+
+.nail-atelier-deco-dot {
+  position: absolute;
+  width: 9px;
+  height: 9px;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.88);
+  box-shadow: 0 0 8px rgba(255, 255, 255, 0.62);
+}
+
+.nail-atelier-deco-dot:nth-child(1) {
+  left: 50%;
+  top: 30%;
+}
+
+.nail-atelier-deco-dot:nth-child(2) {
+  left: 38%;
+  top: 48%;
+}
+
+.nail-atelier-deco-dot:nth-child(3) {
+  right: 34%;
+  top: 62%;
+}
+
+.nail-atelier-deco-dot:nth-child(4) {
+  left: 48%;
+  bottom: 18%;
+}
+
+.nail-atelier-deco-dot--line,
+.nail-atelier-deco-dot--foil {
+  width: 22px;
+  height: 4px;
+  border-radius: 999px;
+  background: var(--jb-gold);
+}
+
+.nail-atelier-copy {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.nail-atelier-copy span {
+  min-height: 32px;
+  display: inline-flex;
+  align-items: center;
+  padding: 5px 10px;
+  border: 1px solid color-mix(in srgb, var(--jb-gold) 24%, var(--border));
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.76);
+  color: var(--text-h);
+  font-size: 0.74rem;
+  font-weight: 800;
 }
 
 .nail-design-header {
@@ -2048,6 +2423,39 @@
   display: grid;
   grid-template-columns: repeat(3, minmax(0, 1fr));
   gap: 10px;
+}
+
+.profile-shortcuts {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.profile-shortcuts button {
+  min-height: 78px;
+  padding: 12px;
+  border: 1px solid color-mix(in srgb, var(--jb-gold) 28%, var(--border));
+  border-radius: 8px;
+  background:
+    linear-gradient(145deg, rgba(255, 255, 255, 0.86), rgba(248, 217, 77, 0.18)),
+    rgba(255, 255, 255, 0.64);
+  color: var(--text-h);
+  cursor: pointer;
+  font: inherit;
+  font-size: 0.86rem;
+  font-weight: 900;
+  text-align: left;
+}
+
+.profile-shortcuts button:hover,
+.profile-shortcuts button:focus-visible {
+  border-color: color-mix(in srgb, var(--jb-gold) 52%, var(--accent-border));
+  transform: translateY(-1px);
+}
+
+.profile-shortcuts button:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
 }
 
 .profile-stat {
@@ -5087,6 +5495,48 @@
   }
   .footer-links {
     gap: 12px;
+  }
+}
+
+@media (max-width: 640px) {
+  .jewel-home-stage {
+    min-height: 620px;
+    padding: 18px;
+  }
+
+  .jewel-orbit {
+    min-height: 390px;
+  }
+
+  .jewel-nail-button {
+    width: 96px;
+  }
+
+  .realistic-nail {
+    width: 66px;
+    height: 138px;
+  }
+
+  .jewel-nail-label {
+    max-width: 104px;
+    font-size: 0.62rem;
+  }
+
+  .nail-atelier-preview {
+    grid-template-columns: 1fr;
+  }
+
+  .nail-atelier-stage {
+    min-height: 220px;
+  }
+
+  .nail-atelier-stage .realistic-nail {
+    width: 82px;
+    height: 176px;
+  }
+
+  .profile-shortcuts {
+    grid-template-columns: 1fr;
   }
 }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef, useMemo, lazy, Suspense } from 'react'
-import type { KeyboardEvent as ReactKeyboardEvent } from 'react'
+import type { CSSProperties, KeyboardEvent as ReactKeyboardEvent } from 'react'
 import { auth, signInWithGoogle, signOutUser, onAuthStateChanged } from './lib/auth'
 import type { User } from './lib/auth'
 import { addNailItem, updateNailItem, deleteNailItem, fetchNailItems } from './lib/firestore'
@@ -106,11 +106,9 @@ const APP_SCREENS = [
   { id: 'home', label: 'Home' },
   { id: 'design', label: 'Design' },
   { id: 'inspiration', label: 'Explore' },
-  { id: 'saved', label: 'Saved' },
-  { id: 'book', label: 'Book' },
   { id: 'profile', label: 'Profile' },
 ] as const
-type AppScreenId = typeof APP_SCREENS[number]['id']
+type AppScreenId = typeof APP_SCREENS[number]['id'] | 'saved' | 'book'
 
 const sortByDate = (items: NailItemDoc[]): NailItemDoc[] =>
   [...items].sort((a, b) => {
@@ -787,6 +785,7 @@ function App() {
   const summary = useMemo(() => getNailSummary(nailItems), [nailItems])
   const savedDesignItems = nailItems.filter(item => savedItemIds.includes(item.id))
   const savedPreviewItems = savedDesignItems.slice(0, 3)
+  const homeShowcaseItems = nailItems.slice(0, 7)
 
   const filteredItems = nailItems.filter(item => {
     if (searchQuery.trim()) {
@@ -1248,35 +1247,99 @@ function App() {
         <div id="nail-section" className={DISPLAY_MODE_CLASS_NAMES[activeDisplayMode]}>
           {activeAppScreen === 'home' && (
             <>
-              <section className="nail-studio-hero" aria-labelledby="studio-title">
-                <div>
-                  <p className="nail-studio-kicker">JEWELRY BOX STUDIO</p>
-                  <h2 id="studio-title">ネイルを一つずつ、宝石箱へ。</h2>
+              <section className="jewel-home-stage" aria-labelledby="studio-title">
+                <div className="jewel-home-copy">
+                  <p className="nail-studio-kicker">NAIL JEWEL BOX</p>
+                  <h2 id="studio-title">浮いているネイルを、そっと選ぶ。</h2>
                   <p>
-                    追加した写真はあとから浮遊ビュー・比較・共有へつながります。
-                    まずは今日のネイルを一つ、コレクションに入れておきましょう。
+                    思い出のネイルが小さなジュエルのように漂う場所です。
+                    気になるネイルをタッチすると、この空間のまま個別ビューが開きます。
                   </p>
+                  <div className="jewel-home-actions">
+                    <button type="button" onClick={() => handleSelectAppScreen('design')}>
+                      新しいネイルを作る
+                    </button>
+                    <button type="button" onClick={() => handleSelectAppScreen('profile')}>
+                      保存・相談メモを見る
+                    </button>
+                  </div>
                 </div>
-                <div className="nail-studio-count" aria-label={`保存済みネイル ${nailItems.length} 件`}>
-                  <span>{nailItems.length}</span>
-                  <small>saved</small>
+                <div className="jewel-orbit" aria-label="浮遊するネイル">
+                  {homeShowcaseItems.length === 0 ? (
+                    <button
+                      type="button"
+                      className="jewel-nail-button jewel-nail-button--empty"
+                      onClick={() => handleSelectAppScreen('design')}
+                    >
+                      <span className="realistic-nail realistic-nail--almond realistic-nail--blush realistic-nail--gloss" aria-hidden="true" />
+                      <span className="jewel-nail-label">最初のネイルを記録</span>
+                    </button>
+                  ) : (
+                    homeShowcaseItems.map((item, index) => {
+                      const shape = isNailShape(item.shape) ? item.shape : (index % 3 === 0 ? 'almond' : index % 3 === 1 ? 'round' : 'square')
+                      const color = isNailColor(item.mainColor) ? item.mainColor : (index % 4 === 0 ? 'blush' : index % 4 === 1 ? 'rose' : index % 4 === 2 ? 'lavender' : 'champagne')
+                      const texture = isNailTexture(item.texture) ? item.texture : 'gloss'
+                      const style = {
+                        '--orbit-x': `${14 + ((index * 23) % 72)}%`,
+                        '--orbit-y': `${18 + ((index * 31) % 58)}%`,
+                        '--orbit-delay': `${index * -0.45}s`,
+                        '--orbit-scale': `${0.88 + (index % 3) * 0.08}`,
+                      } as CSSProperties
+                      return (
+                        <button
+                          key={item.id}
+                          type="button"
+                          className="jewel-nail-button"
+                          style={style}
+                          onClick={() => handleOpenDetailCard(item.id)}
+                        >
+                          <span
+                            className={`realistic-nail realistic-nail--${shape} realistic-nail--${color} realistic-nail--${texture}`}
+                            aria-hidden="true"
+                          >
+                            {item.imageUrl && <img src={item.imageUrl} alt="" />}
+                          </span>
+                          <span className="jewel-nail-label">{item.title}</span>
+                        </button>
+                      )
+                    })
+                  )}
+                  <span className="jewel-orbit-shadow" aria-hidden="true" />
                 </div>
+                <p className="jewel-home-hint">{nailItems.length} memories in your box</p>
               </section>
-              {renderDisplayModeSwitcher('studio-mode-switcher')}
             </>
           )}
           {activeAppScreen === 'design' && (
             <section className="nail-design-screen" aria-labelledby="nail-design-title">
             <div className="nail-design-header">
               <div>
-                <p className="nail-design-kicker">NAIL DESIGN</p>
-                <h3 id="nail-design-title">次のネイルを記録する。</h3>
-                <p>写真・タグ・メモをまとめて、あとから浮遊ビューや共有に使える形で保存します。</p>
+                <p className="nail-design-kicker">NAIL ATELIER</p>
+                <h3 id="nail-design-title">ネイルを一つ、ジュエルとして残す。</h3>
+                <p>先に質感を見ながら整えて、最後に写真やメモを添えて保存します。</p>
               </div>
               <div className="nail-design-meta" aria-label="保存できる情報">
+                <span>Shape</span>
+                <span>Texture</span>
                 <span>Photo</span>
-                <span>Tags</span>
-                <span>Memo</span>
+              </div>
+            </div>
+            <div className="nail-atelier-preview" aria-label="作成中のネイルプレビュー">
+              <div className="nail-atelier-stage">
+                <span
+                  className={`realistic-nail realistic-nail--${selectedNailShape} realistic-nail--${selectedNailColor} realistic-nail--${selectedNailTexture}`}
+                  aria-hidden="true"
+                />
+                {selectedDecorationParts.length > 0 && (
+                  <span className="nail-atelier-deco" aria-hidden="true">
+                    {selectedDecorationParts.slice(0, 4).map(part => <i key={part} className={`nail-atelier-deco-dot nail-atelier-deco-dot--${part}`} />)}
+                  </span>
+                )}
+              </div>
+              <div className="nail-atelier-copy">
+                <span>{NAIL_SHAPES.find(shape => shape.id === selectedNailShape)?.label}</span>
+                <span>{NAIL_COLORS.find(color => color.id === selectedNailColor)?.label}</span>
+                <span>{NAIL_TEXTURES.find(texture => texture.id === selectedNailTexture)?.label}</span>
               </div>
             </div>
             <div id="nail-form">
@@ -1758,10 +1821,18 @@ function App() {
                   <small>With images</small>
                 </div>
               </div>
+              <div className="profile-shortcuts" aria-label="補助画面">
+                <button type="button" onClick={() => handleSelectAppScreen('saved')}>
+                  保存したネイル
+                </button>
+                <button type="button" onClick={() => handleSelectAppScreen('book')}>
+                  来店相談メモ
+                </button>
+              </div>
             </div>
           </section>
           )}
-          {activeAppScreen === 'home' && (
+          {activeAppScreen === 'profile' && (
           <>
           {!isFetching && nailItems.length > 0 && (
             <div id="nail-summary">


### PR DESCRIPTION
## Summary
- Rework Home into a focused floating nail jewel-box stage instead of a management/list surface.
- Reduce bottom navigation to Home / Design / Explore / Profile; move Saved Designs and Book memo access into Profile shortcuts.
- Add a more realistic CSS nail object system and a Nail Atelier preview for Design.
- Move archive/list/share management tools out of Home and into Profile so Home centers the core viewing experience.

## Product context
This responds to the product direction feedback that the previous architecture only matched the intended experience by about 5%. The target is now: users see floating 3D-like nails on Home, tap a nail in-place, and use Design as a visual atelier rather than a cheap form surface.

## Validation
- npm run lint
- npm test
- npm run build
- bash scripts/qa-preflight.sh
- Local unsigned-out smoke at http://127.0.0.1:5173/ and 390px viewport

Refs #232