### PR TITLE
[codex] Add scrollable jewel home focus experience

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -989,9 +989,9 @@
 
 .jewel-home-stage {
   position: relative;
-  min-height: clamp(560px, 76vh, 760px);
+  min-height: clamp(640px, 82vh, 840px);
   display: grid;
-  grid-template-rows: auto minmax(360px, 1fr) auto;
+  grid-template-rows: auto minmax(330px, 1fr) auto auto;
   gap: 18px;
   overflow: hidden;
   padding: clamp(20px, 4vw, 34px);
@@ -1061,6 +1061,41 @@
   background: rgba(255, 255, 255, 0.14);
 }
 
+.jewel-motion-switcher {
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-top: 12px;
+  padding: 4px;
+  border: 1px solid rgba(248, 217, 77, 0.16);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.06);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.08);
+}
+
+.jewel-motion-switcher button {
+  min-height: 32px;
+  padding: 6px 11px;
+  border: 0;
+  border-radius: 999px;
+  background: transparent;
+  color: rgba(255, 255, 255, 0.68);
+  cursor: pointer;
+  font: inherit;
+  font-size: 0.7rem;
+  font-weight: 900;
+}
+
+.jewel-motion-switcher button.is-active {
+  background: linear-gradient(135deg, rgba(248, 217, 77, 0.9), rgba(255, 244, 181, 0.78));
+  color: #21130e;
+}
+
+.jewel-motion-switcher button:focus-visible {
+  outline: 2px solid var(--jb-gold);
+  outline-offset: 2px;
+}
+
 .jewel-home-actions button:focus-visible,
 .jewel-nail-button:focus-visible {
   outline: 2px solid var(--jb-gold);
@@ -1069,8 +1104,11 @@
 
 .jewel-orbit {
   position: relative;
-  min-height: 360px;
+  min-height: 330px;
   z-index: 1;
+  display: grid;
+  align-items: center;
+  perspective: 900px;
 }
 
 .jewel-orbit-shadow {
@@ -1082,6 +1120,39 @@
   border-radius: 50%;
   background: radial-gradient(ellipse at 50% 50%, rgba(0, 0, 0, 0.42), transparent 70%);
   filter: blur(4px);
+}
+
+.jewel-orbit-scroll {
+  position: relative;
+  z-index: 1;
+  width: 100%;
+  overflow-x: auto;
+  overflow-y: visible;
+  padding: 52px clamp(48px, 8vw, 96px) 68px;
+  scroll-padding-inline: 28vw;
+  scroll-snap-type: x mandatory;
+  scrollbar-color: rgba(248, 217, 77, 0.38) rgba(255, 255, 255, 0.08);
+}
+
+.jewel-orbit-scroll::-webkit-scrollbar {
+  height: 8px;
+}
+
+.jewel-orbit-scroll::-webkit-scrollbar-track {
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.06);
+}
+
+.jewel-orbit-scroll::-webkit-scrollbar-thumb {
+  border-radius: 999px;
+  background: rgba(248, 217, 77, 0.38);
+}
+
+.jewel-orbit-track {
+  display: flex;
+  min-width: max-content;
+  align-items: center;
+  gap: clamp(28px, 7vw, 78px);
 }
 
 .jewel-nail-button {
@@ -1105,6 +1176,51 @@
   transform: translate(-50%, -50%) scale(var(--orbit-scale));
   animation: jewel-float 5.6s ease-in-out infinite;
   animation-delay: var(--orbit-delay);
+}
+
+.jewel-orbit-track .jewel-nail-button {
+  position: relative;
+  left: auto;
+  top: auto;
+  flex: 0 0 126px;
+  min-height: 234px;
+  scroll-snap-align: center;
+  transform: translate3d(0, 0, 0) scale(var(--orbit-scale));
+  transition: transform 260ms ease, filter 260ms ease, opacity 260ms ease;
+}
+
+.jewel-orbit-track .jewel-nail-button:nth-child(2n) {
+  margin-top: 34px;
+}
+
+.jewel-orbit-track .jewel-nail-button:nth-child(3n) {
+  margin-top: -26px;
+}
+
+.jewel-orbit-track .jewel-nail-button:hover,
+.jewel-orbit-track .jewel-nail-button:focus-visible {
+  filter: brightness(1.14);
+}
+
+.jewel-orbit-track .jewel-nail-button.is-focused {
+  z-index: 4;
+  filter: brightness(1.18) saturate(1.08);
+  transform: translate3d(0, -26px, 92px) scale(1.18);
+}
+
+.jewel-orbit-track .jewel-nail-button.is-focused .realistic-nail {
+  box-shadow:
+    inset 10px 0 18px rgba(255, 255, 255, 0.36),
+    inset -12px -10px 24px rgba(47, 15, 39, 0.26),
+    0 34px 54px rgba(0, 0, 0, 0.42),
+    0 0 40px color-mix(in srgb, var(--nail-mid) 56%, transparent),
+    0 0 0 1px rgba(248, 217, 77, 0.34);
+}
+
+.jewel-orbit-track .jewel-nail-button.is-focused .jewel-nail-label {
+  border-color: rgba(248, 217, 77, 0.42);
+  background: rgba(248, 217, 77, 0.18);
+  color: rgba(255, 255, 255, 0.94);
 }
 
 .jewel-nail-button--empty {
@@ -1134,6 +1250,149 @@
   font-size: 0.76rem;
   font-weight: 800;
   text-align: center;
+}
+
+.jewel-focus-window {
+  position: relative;
+  z-index: 2;
+  display: grid;
+  grid-template-columns: minmax(104px, 170px) minmax(0, 1fr);
+  gap: clamp(18px, 4vw, 34px);
+  align-items: center;
+  max-width: 760px;
+  width: min(100%, 760px);
+  margin: -28px auto 0;
+  padding: clamp(16px, 3vw, 24px);
+  border: 1px solid rgba(248, 217, 77, 0.28);
+  border-radius: 14px;
+  background:
+    linear-gradient(135deg, rgba(255, 255, 255, 0.15), rgba(255, 255, 255, 0.05)),
+    rgba(17, 10, 19, 0.78);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.16),
+    0 24px 70px rgba(0, 0, 0, 0.34),
+    0 0 42px rgba(248, 217, 77, 0.08);
+  backdrop-filter: blur(18px);
+  animation: jewel-focus-arrive 420ms ease both;
+}
+
+.jewel-focus-close {
+  position: absolute;
+  top: 12px;
+  right: 12px;
+  min-height: 30px;
+  padding: 5px 10px;
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.08);
+  color: rgba(255, 255, 255, 0.72);
+  cursor: pointer;
+  font: inherit;
+  font-size: 0.66rem;
+  font-weight: 900;
+}
+
+.jewel-focus-close:hover,
+.jewel-focus-close:focus-visible {
+  border-color: rgba(248, 217, 77, 0.48);
+  color: rgba(255, 255, 255, 0.94);
+  outline: none;
+}
+
+.jewel-focus-nail {
+  position: relative;
+  display: grid;
+  min-height: 230px;
+  place-items: center;
+}
+
+.jewel-focus-nail::after {
+  content: '';
+  position: absolute;
+  inset: auto 18% 12px;
+  height: 28px;
+  border-radius: 50%;
+  background: radial-gradient(ellipse at 50% 50%, rgba(0, 0, 0, 0.4), transparent 72%);
+  filter: blur(5px);
+}
+
+.jewel-focus-nail .realistic-nail {
+  width: 104px;
+  height: 214px;
+  transform: perspective(520px) rotateX(10deg) rotateZ(-6deg);
+  animation: jewel-showcase-float 4.8s ease-in-out infinite;
+}
+
+.jewel-focus-copy {
+  min-width: 0;
+  padding-right: 44px;
+}
+
+.jewel-focus-kicker {
+  margin: 0 0 6px;
+  color: rgba(248, 217, 77, 0.78);
+  font-size: 0.66rem;
+  font-weight: 900;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+.jewel-focus-copy h3 {
+  margin: 0;
+  color: rgba(255, 255, 255, 0.96);
+  font-size: clamp(1.15rem, 3vw, 1.7rem);
+  line-height: 1.18;
+}
+
+.jewel-focus-copy p:not(.jewel-focus-kicker) {
+  margin: 10px 0 0;
+  color: rgba(255, 255, 255, 0.7);
+  font-size: 0.84rem;
+  line-height: 1.7;
+  overflow-wrap: anywhere;
+}
+
+.jewel-focus-tags,
+.jewel-focus-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 7px;
+  margin-top: 12px;
+}
+
+.jewel-focus-tags span {
+  padding: 4px 8px;
+  border: 1px solid rgba(248, 217, 77, 0.2);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.07);
+  color: rgba(255, 255, 255, 0.72);
+  font-size: 0.66rem;
+  font-weight: 800;
+}
+
+.jewel-focus-actions button {
+  min-height: 34px;
+  padding: 7px 11px;
+  border: 1px solid rgba(248, 217, 77, 0.22);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.08);
+  color: rgba(255, 255, 255, 0.86);
+  cursor: pointer;
+  font: inherit;
+  font-size: 0.7rem;
+  font-weight: 900;
+}
+
+.jewel-focus-actions button:first-child {
+  background: linear-gradient(135deg, rgba(248, 217, 77, 0.9), rgba(255, 244, 181, 0.78));
+  color: #21130e;
+}
+
+.jewel-focus-actions button:hover,
+.jewel-focus-actions button:focus-visible {
+  transform: translateY(-1px);
+  border-color: rgba(248, 217, 77, 0.52);
+  outline: none;
 }
 
 .realistic-nail {
@@ -1261,6 +1520,53 @@
   50% {
     translate: 0 -14px;
     rotate: 2deg;
+  }
+}
+
+.jewel-motion-carousel .jewel-orbit-track .jewel-nail-button {
+  animation-name: jewel-carousel-float;
+  animation-duration: 6.4s;
+}
+
+.jewel-motion-showcase .jewel-orbit-track .jewel-nail-button {
+  animation-name: jewel-showcase-float;
+  animation-duration: 5.2s;
+}
+
+@keyframes jewel-carousel-float {
+  0%,
+  100% {
+    translate: -8px 0;
+    rotate: -2deg;
+  }
+  50% {
+    translate: 8px -12px;
+    rotate: 3deg;
+  }
+}
+
+@keyframes jewel-showcase-float {
+  0%,
+  100% {
+    translate: 0 0;
+    rotate: -1deg;
+    scale: 1;
+  }
+  50% {
+    translate: 0 -18px;
+    rotate: 1deg;
+    scale: 1.04;
+  }
+}
+
+@keyframes jewel-focus-arrive {
+  from {
+    opacity: 0;
+    transform: translateY(16px) scale(0.96);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
   }
 }
 
@@ -5500,16 +5806,28 @@
 
 @media (max-width: 640px) {
   .jewel-home-stage {
-    min-height: 620px;
+    min-height: 720px;
     padding: 18px;
   }
 
   .jewel-orbit {
-    min-height: 390px;
+    min-height: 320px;
   }
 
-  .jewel-nail-button {
+  .jewel-orbit-scroll {
+    margin-inline: -18px;
+    padding: 44px 42px 62px;
+    scroll-padding-inline: 38vw;
+  }
+
+  .jewel-orbit-track {
+    gap: 22px;
+  }
+
+  .jewel-orbit-track .jewel-nail-button {
     width: 96px;
+    flex-basis: 104px;
+    min-height: 208px;
   }
 
   .realistic-nail {
@@ -5520,6 +5838,26 @@
   .jewel-nail-label {
     max-width: 104px;
     font-size: 0.62rem;
+  }
+
+  .jewel-focus-window {
+    grid-template-columns: 1fr;
+    gap: 10px;
+    margin-top: -14px;
+    padding: 16px;
+  }
+
+  .jewel-focus-nail {
+    min-height: 170px;
+  }
+
+  .jewel-focus-nail .realistic-nail {
+    width: 78px;
+    height: 164px;
+  }
+
+  .jewel-focus-copy {
+    padding-right: 0;
   }
 
   .nail-atelier-preview {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -33,6 +33,13 @@ import './App.css'
 const DISPLAY_MODES = ['Glass', 'Snow Globe', 'Velvet', 'Showcase'] as const
 type DisplayMode = typeof DISPLAY_MODES[number]
 
+const JEWEL_MOTION_MODES = [
+  { id: 'drift', label: '漂う' },
+  { id: 'carousel', label: '回る' },
+  { id: 'showcase', label: '前後' },
+] as const
+type JewelMotionMode = typeof JEWEL_MOTION_MODES[number]['id']
+
 const DISPLAY_MODE_CLASS_NAMES: Record<DisplayMode, string> = {
   Glass: 'display-mode-glass',
   'Snow Globe': 'display-mode-snow-globe',
@@ -353,6 +360,7 @@ function App() {
   const [publicSharesUserId, setPublicSharesUserId] = useState<string | null>(null)
   const [shareActionId, setShareActionId] = useState<string | null>(null)
   const [activeDisplayMode, setActiveDisplayMode] = useState<DisplayMode>('Glass')
+  const [activeJewelMotion, setActiveJewelMotion] = useState<JewelMotionMode>('drift')
   const [activeAppScreen, setActiveAppScreen] = useState<AppScreenId>('home')
   const [publicShare, setPublicShare] = useState<PublicShareDocWithId | null>(null)
   const [publicShareState, setPublicShareState] = useState<PublicShareViewState>(
@@ -785,7 +793,7 @@ function App() {
   const summary = useMemo(() => getNailSummary(nailItems), [nailItems])
   const savedDesignItems = nailItems.filter(item => savedItemIds.includes(item.id))
   const savedPreviewItems = savedDesignItems.slice(0, 3)
-  const homeShowcaseItems = nailItems.slice(0, 7)
+  const homeShowcaseItems = nailItems
 
   const filteredItems = nailItems.filter(item => {
     if (searchQuery.trim()) {
@@ -1091,7 +1099,7 @@ function App() {
           if (!firebaseConfigErrorMessage) setBannerError('')
         }}
       />
-      {detailItem && (
+      {detailItem && activeAppScreen !== 'home' && (
         <Suspense fallback={<div className="lazy-loading">読み込み中...</div>}>
           <NailImageDetailViewer
             item={detailItem}
@@ -1247,13 +1255,13 @@ function App() {
         <div id="nail-section" className={DISPLAY_MODE_CLASS_NAMES[activeDisplayMode]}>
           {activeAppScreen === 'home' && (
             <>
-              <section className="jewel-home-stage" aria-labelledby="studio-title">
+              <section className={`jewel-home-stage jewel-motion-${activeJewelMotion}`} aria-labelledby="studio-title">
                 <div className="jewel-home-copy">
                   <p className="nail-studio-kicker">NAIL JEWEL BOX</p>
-                  <h2 id="studio-title">浮いているネイルを、そっと選ぶ。</h2>
+                  <h2 id="studio-title">スクロールして、思い出のネイルに触れる。</h2>
                   <p>
-                    思い出のネイルが小さなジュエルのように漂う場所です。
-                    気になるネイルをタッチすると、この空間のまま個別ビューが開きます。
+                    浮き方を選びながらネイルを遡り、気になるひとつをタッチ。
+                    選んだネイルだけが前へ出て、同じショーウィンドウの中に記憶が浮かびます。
                   </p>
                   <div className="jewel-home-actions">
                     <button type="button" onClick={() => handleSelectAppScreen('design')}>
@@ -1262,6 +1270,19 @@ function App() {
                     <button type="button" onClick={() => handleSelectAppScreen('profile')}>
                       保存・相談メモを見る
                     </button>
+                  </div>
+                  <div className="jewel-motion-switcher" aria-label="ネイルの浮き方">
+                    {JEWEL_MOTION_MODES.map(mode => (
+                      <button
+                        key={mode.id}
+                        type="button"
+                        className={activeJewelMotion === mode.id ? 'is-active' : ''}
+                        onClick={() => setActiveJewelMotion(mode.id)}
+                        aria-pressed={activeJewelMotion === mode.id}
+                      >
+                        {mode.label}
+                      </button>
+                    ))}
                   </div>
                 </div>
                 <div className="jewel-orbit" aria-label="浮遊するネイル">
@@ -1275,37 +1296,97 @@ function App() {
                       <span className="jewel-nail-label">最初のネイルを記録</span>
                     </button>
                   ) : (
-                    homeShowcaseItems.map((item, index) => {
-                      const shape = isNailShape(item.shape) ? item.shape : (index % 3 === 0 ? 'almond' : index % 3 === 1 ? 'round' : 'square')
-                      const color = isNailColor(item.mainColor) ? item.mainColor : (index % 4 === 0 ? 'blush' : index % 4 === 1 ? 'rose' : index % 4 === 2 ? 'lavender' : 'champagne')
-                      const texture = isNailTexture(item.texture) ? item.texture : 'gloss'
-                      const style = {
-                        '--orbit-x': `${14 + ((index * 23) % 72)}%`,
-                        '--orbit-y': `${18 + ((index * 31) % 58)}%`,
-                        '--orbit-delay': `${index * -0.45}s`,
-                        '--orbit-scale': `${0.88 + (index % 3) * 0.08}`,
-                      } as CSSProperties
-                      return (
-                        <button
-                          key={item.id}
-                          type="button"
-                          className="jewel-nail-button"
-                          style={style}
-                          onClick={() => handleOpenDetailCard(item.id)}
-                        >
-                          <span
-                            className={`realistic-nail realistic-nail--${shape} realistic-nail--${color} realistic-nail--${texture}`}
-                            aria-hidden="true"
-                          >
-                            {item.imageUrl && <img src={item.imageUrl} alt="" />}
-                          </span>
-                          <span className="jewel-nail-label">{item.title}</span>
-                        </button>
-                      )
-                    })
+                    <div className="jewel-orbit-scroll" aria-label="過去のネイルを横にスクロール">
+                      <div className="jewel-orbit-track">
+                        {homeShowcaseItems.map((item, index) => {
+                          const shape = isNailShape(item.shape) ? item.shape : (index % 3 === 0 ? 'almond' : index % 3 === 1 ? 'round' : 'square')
+                          const color = isNailColor(item.mainColor) ? item.mainColor : (index % 4 === 0 ? 'blush' : index % 4 === 1 ? 'rose' : index % 4 === 2 ? 'lavender' : 'champagne')
+                          const texture = isNailTexture(item.texture) ? item.texture : 'gloss'
+                          const isFocused = detailItem?.id === item.id
+                          const style = {
+                            '--orbit-delay': `${index * -0.45}s`,
+                            '--orbit-scale': `${0.92 + (index % 3) * 0.05}`,
+                          } as CSSProperties
+                          return (
+                            <button
+                              key={item.id}
+                              type="button"
+                              className={`jewel-nail-button${isFocused ? ' is-focused' : ''}`}
+                              style={style}
+                              onClick={() => handleOpenDetailCard(item.id)}
+                            >
+                              <span
+                                className={`realistic-nail realistic-nail--${shape} realistic-nail--${color} realistic-nail--${texture}`}
+                                aria-hidden="true"
+                              >
+                                {item.imageUrl && <img src={item.imageUrl} alt="" />}
+                              </span>
+                              <span className="jewel-nail-label">{item.title}</span>
+                            </button>
+                          )
+                        })}
+                      </div>
+                    </div>
                   )}
                   <span className="jewel-orbit-shadow" aria-hidden="true" />
                 </div>
+                {detailItem && (
+                  <div className="jewel-focus-window" aria-live="polite">
+                    {(() => {
+                      const focusIndex = Math.max(homeShowcaseItems.findIndex(item => item.id === detailItem.id), 0)
+                      const shape = isNailShape(detailItem.shape) ? detailItem.shape : (focusIndex % 3 === 0 ? 'almond' : focusIndex % 3 === 1 ? 'round' : 'square')
+                      const color = isNailColor(detailItem.mainColor) ? detailItem.mainColor : (focusIndex % 4 === 0 ? 'blush' : focusIndex % 4 === 1 ? 'rose' : focusIndex % 4 === 2 ? 'lavender' : 'champagne')
+                      const texture = isNailTexture(detailItem.texture) ? detailItem.texture : 'gloss'
+                      return (
+                        <>
+                          <button
+                            type="button"
+                            className="jewel-focus-close"
+                            onClick={() => setDetailItemId(null)}
+                            aria-label="選択中のネイル情報を閉じる"
+                          >
+                            閉じる
+                          </button>
+                          <div className="jewel-focus-nail">
+                            <span
+                              className={`realistic-nail realistic-nail--${shape} realistic-nail--${color} realistic-nail--${texture}`}
+                              aria-hidden="true"
+                            >
+                              {detailItem.imageUrl && <img src={detailItem.imageUrl} alt="" />}
+                            </span>
+                          </div>
+                          <div className="jewel-focus-copy">
+                            <p className="jewel-focus-kicker">Selected memory</p>
+                            <h3>{detailItem.title}</h3>
+                            {detailItem.tags.length > 0 && (
+                              <div className="jewel-focus-tags" aria-label="タグ">
+                                {detailItem.tags.slice(0, 5).map(tag => (
+                                  <span key={tag}>{tag}</span>
+                                ))}
+                              </div>
+                            )}
+                            <p>
+                              {detailItem.memo
+                                ? detailItem.memo
+                                : 'このネイルの気分、色、サロンで話したいことをここに残せます。'}
+                            </p>
+                            <div className="jewel-focus-actions">
+                              <button type="button" onClick={() => handlePlanAppointmentFromDetail(detailItem.id)}>
+                                来店メモに使う
+                              </button>
+                              <button type="button" onClick={() => handleToggleSavedItem(detailItem.id)}>
+                                {savedItemIds.includes(detailItem.id) ? '保存済み' : '保存する'}
+                              </button>
+                              <button type="button" onClick={() => handleStartEdit(detailItem)}>
+                                編集する
+                              </button>
+                            </div>
+                          </div>
+                        </>
+                      )
+                    })()}
+                  </div>
+                )}
                 <p className="jewel-home-hint">{nailItems.length} memories in your box</p>
               </section>
             </>


### PR DESCRIPTION
## Summary
- Reworks the signed-in Home nail view into a horizontal, scrollable jewelry-box history rail.
- Adds three selectable floating motion styles: 漂う, 回る, 前後.
- Changes Home nail selection from a detail modal to an inline glass jewelry focus window where the selected nail moves forward with its memo, tags, save action, edit action, and booking memo connection.

## Why
The current Home experience still felt too close to a utilitarian list/detail pattern. This moves the interaction toward the intended rich Nailous experience: scrolling through floating nail memories and touching one to bring it forward within the same jewel showcase.

## Validation
- npm run lint
- npm run build
- npm test
- bash scripts/qa-preflight.sh
- Local signed-out desktop/mobile render smoke check

Note: qa-preflight still reports the existing JS bundle size warning only.
