### PR TITLE
[codex] Improve jewel home realism and motion

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -32,9 +32,13 @@
 }
 
 #auth-bar {
+  position: fixed;
+  top: 18px;
+  right: 18px;
+  z-index: 30;
   min-height: 40px;
   display: flex;
-  justify-content: center;
+  justify-content: flex-end;
   align-items: center;
   margin-bottom: 4px;
 }
@@ -42,22 +46,29 @@
 .auth-user {
   display: flex;
   align-items: center;
-  gap: 12px;
+  gap: 8px;
   font-size: 14px;
 }
 
-.auth-user button {
+.auth-user button,
+.icon-button,
+.jewel-icon-action {
   min-height: var(--tap-target-min);
-  padding: 6px 12px;
+  min-width: var(--tap-target-min);
+  display: inline-grid;
+  place-items: center;
+  padding: 0;
   border: 1px solid var(--border);
-  border-radius: 6px;
+  border-radius: 50%;
   background: none;
   color: inherit;
   cursor: pointer;
   font-size: 13px;
 }
 
-.auth-user button:hover {
+.auth-user button:hover,
+.icon-button:hover,
+.jewel-icon-action:hover {
   background: rgba(255, 255, 255, 0.08);
 }
 
@@ -129,8 +140,96 @@
 }
 
 .auth-data-mgmt {
-  color: var(--accent) !important;
-  font-weight: 600;
+  color: inherit !important;
+}
+
+.mono-icon {
+  position: relative;
+  display: block;
+  width: 18px;
+  height: 18px;
+  color: currentColor;
+}
+
+.mono-icon::before,
+.mono-icon::after {
+  content: '';
+  position: absolute;
+  box-sizing: border-box;
+}
+
+.mono-icon-plus::before {
+  left: 3px;
+  right: 3px;
+  top: 8px;
+  border-top: 2px solid currentColor;
+}
+
+.mono-icon-plus::after {
+  top: 3px;
+  bottom: 3px;
+  left: 8px;
+  border-left: 2px solid currentColor;
+}
+
+.mono-icon-note::before {
+  inset: 3px 4px 3px 4px;
+  border: 1.8px solid currentColor;
+  border-radius: 2px;
+}
+
+.mono-icon-note::after {
+  left: 7px;
+  right: 6px;
+  top: 8px;
+  border-top: 1.8px solid currentColor;
+  box-shadow: 0 4px 0 currentColor;
+}
+
+.mono-icon-settings::before {
+  inset: 3px;
+  border: 1.8px solid currentColor;
+  border-radius: 50%;
+}
+
+.mono-icon-settings::after {
+  inset: 7px;
+  border: 2px solid currentColor;
+  border-radius: 50%;
+}
+
+.mono-icon-exit::before {
+  left: 3px;
+  top: 4px;
+  width: 8px;
+  height: 10px;
+  border: 1.8px solid currentColor;
+  border-right: 0;
+  border-radius: 2px 0 0 2px;
+}
+
+.mono-icon-exit::after {
+  right: 2px;
+  top: 8px;
+  width: 10px;
+  border-top: 1.8px solid currentColor;
+  box-shadow: 4px -4px 0 -2px currentColor, 4px 4px 0 -2px currentColor;
+}
+
+.mono-icon-close::before,
+.mono-icon-close::after {
+  left: 3px;
+  right: 3px;
+  top: 8px;
+  border-top: 2px solid currentColor;
+}
+
+.mono-icon-close::before {
+  transform: rotate(45deg);
+}
+
+.mono-icon-close::after {
+  transform: rotate(-45deg);
 }
 
 /* Signed-out Jewelry Box home */
@@ -988,6 +1087,8 @@
 }
 
 .jewel-home-stage {
+  --pointer-x: 0;
+  --pointer-y: 0;
   position: relative;
   min-height: clamp(640px, 82vh, 840px);
   display: grid;
@@ -995,21 +1096,21 @@
   gap: 18px;
   overflow: hidden;
   padding: clamp(20px, 4vw, 34px);
-  border: 1px solid color-mix(in srgb, var(--jb-gold) 28%, rgba(255, 255, 255, 0.12));
-  border-radius: 12px;
-  background: linear-gradient(160deg, rgba(10, 6, 14, 0.98), rgba(31, 16, 34, 0.96) 48%, rgba(13, 24, 24, 0.94)), #0b0710;
+  border: 0;
+  border-radius: 0;
+  background: linear-gradient(160deg, rgba(10, 6, 14, 0.98), rgba(20, 19, 22, 0.96) 52%, rgba(12, 15, 15, 0.94)), #0b0710;
   color: rgba(255, 255, 255, 0.88);
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.1), 0 24px 64px rgba(20, 8, 24, 0.28);
+  box-shadow: 0 24px 64px rgba(20, 8, 24, 0.2);
 }
 
 .jewel-home-stage::before {
   content: '';
   position: absolute;
   inset: 12% 5% 18%;
-  border: 1px solid rgba(248, 217, 77, 0.16);
+  border: 1px solid rgba(255, 255, 255, 0.08);
   border-radius: 50%;
   transform: perspective(720px) rotateX(68deg);
-  opacity: 0.72;
+  opacity: 0.45;
   pointer-events: none;
 }
 
@@ -1021,10 +1122,11 @@
 
 .jewel-home-copy h2 {
   max-width: 520px;
-  margin: 0 0 10px;
+  margin: 0;
   color: rgba(255, 255, 255, 0.98);
-  font-size: clamp(1.72rem, 6vw, 3.2rem);
-  line-height: 1.02;
+  font-size: clamp(1.3rem, 4vw, 2.15rem);
+  font-weight: 400;
+  line-height: 1.08;
 }
 
 .jewel-home-copy p {
@@ -1039,20 +1141,13 @@
   display: flex;
   flex-wrap: wrap;
   gap: 8px;
-  margin-top: 14px;
+  margin-top: 16px;
 }
 
 .jewel-home-actions button {
-  min-height: 38px;
-  padding: 8px 13px;
-  border: 1px solid rgba(248, 217, 77, 0.28);
-  border-radius: 999px;
-  background: rgba(255, 255, 255, 0.08);
+  border-color: rgba(255, 255, 255, 0.18);
+  background: rgba(255, 255, 255, 0.07);
   color: rgba(255, 255, 255, 0.92);
-  cursor: pointer;
-  font: inherit;
-  font-size: 0.76rem;
-  font-weight: 800;
 }
 
 .jewel-home-actions button:hover,
@@ -1064,36 +1159,106 @@
 .jewel-motion-switcher {
   display: inline-flex;
   flex-wrap: wrap;
-  gap: 6px;
+  gap: 5px;
   margin-top: 12px;
-  padding: 4px;
-  border: 1px solid rgba(248, 217, 77, 0.16);
+  padding: 5px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
   border-radius: 999px;
-  background: rgba(255, 255, 255, 0.06);
+  background: rgba(255, 255, 255, 0.045);
   box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.08);
 }
 
 .jewel-motion-switcher button {
-  min-height: 32px;
-  padding: 6px 11px;
+  width: 34px;
+  min-height: 34px;
+  display: inline-grid;
+  place-items: center;
+  padding: 0;
   border: 0;
   border-radius: 999px;
   background: transparent;
   color: rgba(255, 255, 255, 0.68);
   cursor: pointer;
   font: inherit;
-  font-size: 0.7rem;
-  font-weight: 900;
 }
 
 .jewel-motion-switcher button.is-active {
-  background: linear-gradient(135deg, rgba(248, 217, 77, 0.9), rgba(255, 244, 181, 0.78));
-  color: #21130e;
+  background: rgba(255, 255, 255, 0.92);
+  color: #101010;
 }
 
 .jewel-motion-switcher button:focus-visible {
   outline: 2px solid var(--jb-gold);
   outline-offset: 2px;
+}
+
+.motion-glyph {
+  position: relative;
+  width: 18px;
+  height: 18px;
+  display: block;
+}
+
+.motion-glyph::before,
+.motion-glyph::after {
+  content: '';
+  position: absolute;
+  box-sizing: border-box;
+}
+
+.motion-glyph--float::before {
+  left: 2px;
+  top: 7px;
+  width: 14px;
+  height: 5px;
+  border: 1.8px solid currentColor;
+  border-radius: 999px;
+  transform: rotate(-8deg);
+}
+
+.motion-glyph--float::after {
+  left: 6px;
+  top: 3px;
+  width: 6px;
+  height: 6px;
+  border: 1.8px solid currentColor;
+  border-radius: 50%;
+  opacity: 0.56;
+}
+
+.motion-glyph--orbit::before {
+  inset: 2px;
+  border: 1.8px solid currentColor;
+  border-radius: 50%;
+}
+
+.motion-glyph--orbit::after {
+  right: 1px;
+  top: 2px;
+  width: 6px;
+  height: 6px;
+  border-top: 1.8px solid currentColor;
+  border-right: 1.8px solid currentColor;
+  transform: rotate(22deg);
+}
+
+.motion-glyph--compare::before,
+.motion-glyph--compare::after {
+  width: 10px;
+  height: 13px;
+  border: 1.8px solid currentColor;
+  border-radius: 2px;
+}
+
+.motion-glyph--compare::before {
+  left: 2px;
+  top: 4px;
+}
+
+.motion-glyph--compare::after {
+  right: 2px;
+  top: 1px;
+  background: color-mix(in srgb, currentColor 12%, transparent);
 }
 
 .jewel-home-actions button:focus-visible,
@@ -1109,6 +1274,16 @@
   display: grid;
   align-items: center;
   perspective: 900px;
+  transition: filter 240ms ease, opacity 240ms ease, transform 240ms ease;
+}
+
+.has-open-detail .jewel-home-copy,
+.has-open-detail .jewel-orbit,
+.has-open-detail .jewel-home-hint {
+  filter: blur(8px);
+  opacity: 0.42;
+  transform: scale(0.985);
+  pointer-events: none;
 }
 
 .jewel-orbit-shadow {
@@ -1132,6 +1307,7 @@
   scroll-padding-inline: 28vw;
   scroll-snap-type: x mandatory;
   scrollbar-color: rgba(248, 217, 77, 0.38) rgba(255, 255, 255, 0.08);
+  touch-action: pan-x;
 }
 
 .jewel-orbit-scroll::-webkit-scrollbar {
@@ -1153,6 +1329,10 @@
   min-width: max-content;
   align-items: center;
   gap: clamp(28px, 7vw, 78px);
+  transform: rotateX(calc(var(--pointer-y) * -2deg)) rotateY(calc(var(--pointer-x) * 3deg));
+  transform-style: preserve-3d;
+  transition: transform 520ms cubic-bezier(0.16, 1, 0.3, 1);
+  will-change: transform;
 }
 
 .jewel-nail-button {
@@ -1186,7 +1366,9 @@
   min-height: 234px;
   scroll-snap-align: center;
   transform: translate3d(0, 0, 0) scale(var(--orbit-scale));
-  transition: transform 260ms ease, filter 260ms ease, opacity 260ms ease;
+  transform-style: preserve-3d;
+  transition: transform 520ms cubic-bezier(0.16, 1, 0.3, 1), filter 260ms ease, opacity 260ms ease;
+  will-change: transform;
 }
 
 .jewel-orbit-track .jewel-nail-button:nth-child(2n) {
@@ -1223,6 +1405,87 @@
   color: rgba(255, 255, 255, 0.94);
 }
 
+.jewel-orbit-track .jewel-nail-button.is-newly-added {
+  z-index: 6;
+  animation: jewel-new-arrival 1.55s cubic-bezier(0.16, 1, 0.3, 1) both, jewel-float 5.6s ease-in-out 1.55s infinite;
+}
+
+.jewel-orbit-track .jewel-nail-button.is-newly-added .realistic-nail {
+  box-shadow:
+    inset 12px 0 20px rgba(255, 255, 255, 0.42),
+    inset -14px -12px 28px rgba(47, 15, 39, 0.28),
+    0 42px 70px rgba(0, 0, 0, 0.48),
+    0 0 58px color-mix(in srgb, var(--nail-mid) 66%, transparent),
+    0 0 0 1px rgba(255, 255, 255, 0.34);
+}
+
+.has-new-arrival .jewel-orbit::after {
+  content: '';
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  z-index: 0;
+  width: min(42vw, 420px);
+  aspect-ratio: 1;
+  border-radius: 50%;
+  background: radial-gradient(circle, rgba(255, 255, 255, 0.16), transparent 68%);
+  filter: blur(4px);
+  transform: translate(-50%, -50%);
+  animation: jewel-arrival-ripple 1.4s ease-out both;
+  pointer-events: none;
+}
+
+.jewel-motion-carousel .jewel-orbit-track {
+  gap: clamp(4px, 1.4vw, 14px);
+  padding-inline: clamp(42px, 9vw, 120px);
+  transform:
+    rotateX(calc(14deg + var(--pointer-y) * -2deg))
+    rotateY(calc(var(--pointer-x) * 5deg))
+    translateZ(-18px);
+  transform-origin: 50% 135%;
+}
+
+.jewel-motion-carousel .jewel-orbit-track .jewel-nail-button {
+  opacity: 0.68;
+  transform: translate3d(0, 16px, -84px) rotateY(-32deg) rotateZ(-4deg) scale(0.78);
+}
+
+.jewel-motion-carousel .jewel-orbit-track .jewel-nail-button:nth-child(3n + 2) {
+  opacity: 1;
+  transform: translate3d(0, -28px, 112px) rotateY(0deg) rotateZ(1deg) scale(1.1);
+}
+
+.jewel-motion-carousel .jewel-orbit-track .jewel-nail-button:nth-child(3n) {
+  transform: translate3d(0, 14px, -62px) rotateY(30deg) rotateZ(4deg) scale(0.84);
+}
+
+.jewel-motion-carousel .jewel-orbit-track .jewel-nail-button:nth-child(4n) {
+  transform: translate3d(0, 36px, -128px) rotateY(42deg) rotateZ(6deg) scale(0.72);
+}
+
+.jewel-motion-showcase .jewel-orbit-track {
+  gap: 0;
+  min-width: 100%;
+  justify-content: center;
+}
+
+.jewel-motion-showcase .jewel-orbit-track .jewel-nail-button {
+  flex-basis: 106px;
+  margin-inline: -18px;
+  opacity: 0.56;
+  transform: translate3d(0, 0, 0) rotateZ(-7deg) scale(0.88);
+}
+
+.jewel-motion-showcase .jewel-orbit-track .jewel-nail-button:nth-child(2n) {
+  transform: translate3d(0, 22px, 30px) rotateZ(6deg) scale(0.98);
+  opacity: 0.78;
+}
+
+.jewel-motion-showcase .jewel-orbit-track .jewel-nail-button:nth-child(3n) {
+  transform: translate3d(0, -22px, 70px) rotateZ(2deg) scale(1.06);
+  opacity: 1;
+}
+
 .jewel-nail-button--empty {
   left: 50%;
   top: 50%;
@@ -1252,6 +1515,17 @@
   text-align: center;
 }
 
+.jewel-focus-overlay {
+  position: absolute;
+  inset: 0;
+  z-index: 8;
+  display: grid;
+  place-items: center;
+  padding: clamp(18px, 5vw, 44px);
+  background: rgba(3, 3, 4, 0.24);
+  animation: jewel-overlay-arrive 220ms ease both;
+}
+
 .jewel-focus-window {
   position: relative;
   z-index: 2;
@@ -1261,17 +1535,16 @@
   align-items: center;
   max-width: 760px;
   width: min(100%, 760px);
-  margin: -28px auto 0;
+  margin: 0 auto;
   padding: clamp(16px, 3vw, 24px);
-  border: 1px solid rgba(248, 217, 77, 0.28);
-  border-radius: 14px;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  border-radius: 10px;
   background:
-    linear-gradient(135deg, rgba(255, 255, 255, 0.15), rgba(255, 255, 255, 0.05)),
-    rgba(17, 10, 19, 0.78);
+    linear-gradient(135deg, rgba(255, 255, 255, 0.13), rgba(255, 255, 255, 0.05)),
+    rgba(14, 14, 16, 0.78);
   box-shadow:
     inset 0 1px 0 rgba(255, 255, 255, 0.16),
-    0 24px 70px rgba(0, 0, 0, 0.34),
-    0 0 42px rgba(248, 217, 77, 0.08);
+    0 24px 70px rgba(0, 0, 0, 0.34);
   backdrop-filter: blur(18px);
   animation: jewel-focus-arrive 420ms ease both;
 }
@@ -1280,16 +1553,16 @@
   position: absolute;
   top: 12px;
   right: 12px;
-  min-height: 30px;
-  padding: 5px 10px;
+  min-width: 34px;
+  min-height: 34px;
+  display: grid;
+  place-items: center;
+  padding: 0;
   border: 1px solid rgba(255, 255, 255, 0.14);
-  border-radius: 999px;
+  border-radius: 50%;
   background: rgba(255, 255, 255, 0.08);
   color: rgba(255, 255, 255, 0.72);
   cursor: pointer;
-  font: inherit;
-  font-size: 0.66rem;
-  font-weight: 900;
 }
 
 .jewel-focus-close:hover,
@@ -1404,36 +1677,47 @@
   border: 1px solid rgba(255, 255, 255, 0.22);
   border-radius: 45% 45% 52% 52% / 12% 12% 82% 82%;
   background:
-    linear-gradient(110deg, rgba(255, 255, 255, 0.72) 0 8%, transparent 9% 27%, rgba(255, 255, 255, 0.28) 28% 33%, transparent 34%),
+    radial-gradient(ellipse at 50% 12%, rgba(255, 255, 255, 0.76), transparent 22%),
+    radial-gradient(ellipse at 52% 92%, rgba(255, 255, 255, 0.2), transparent 24%),
+    linear-gradient(104deg, rgba(255, 255, 255, 0.82) 0 7%, transparent 8% 24%, rgba(255, 255, 255, 0.38) 25% 31%, transparent 32%),
+    linear-gradient(90deg, rgba(255, 255, 255, 0.24), transparent 22% 76%, rgba(22, 5, 22, 0.18)),
     linear-gradient(180deg, var(--nail-light), var(--nail-mid) 52%, var(--nail-deep));
   box-shadow:
-    inset 10px 0 18px rgba(255, 255, 255, 0.32),
-    inset -12px -10px 24px rgba(47, 15, 39, 0.28),
-    0 24px 34px rgba(0, 0, 0, 0.34),
-    0 0 24px color-mix(in srgb, var(--nail-mid) 36%, transparent);
+    inset 12px 0 18px rgba(255, 255, 255, 0.34),
+    inset -14px -12px 28px rgba(47, 15, 39, 0.3),
+    inset 0 12px 24px rgba(255, 255, 255, 0.18),
+    inset 0 -18px 26px rgba(30, 8, 24, 0.16),
+    0 26px 36px rgba(0, 0, 0, 0.36),
+    0 0 26px color-mix(in srgb, var(--nail-mid) 42%, transparent);
   transform: perspective(380px) rotateX(12deg) rotateZ(-10deg);
+  transform-style: preserve-3d;
+  isolation: isolate;
 }
 
 .realistic-nail::before {
   content: '';
   position: absolute;
-  inset: 8px 15px auto;
-  height: 64%;
+  inset: 7px 13px auto 17px;
+  height: 68%;
   border-radius: inherit;
-  background: linear-gradient(90deg, rgba(255, 255, 255, 0.44), transparent 42%);
-  opacity: 0.72;
+  background:
+    linear-gradient(92deg, rgba(255, 255, 255, 0.62), rgba(255, 255, 255, 0.14) 34%, transparent 54%),
+    radial-gradient(ellipse at 42% 0%, rgba(255, 255, 255, 0.64), transparent 34%);
+  opacity: 0.8;
+  mix-blend-mode: screen;
 }
 
 .realistic-nail::after {
   content: '';
   position: absolute;
-  left: 16%;
-  right: 16%;
-  bottom: 10px;
-  height: 18px;
-  border-radius: 50%;
-  background: rgba(255, 255, 255, 0.22);
-  filter: blur(2px);
+  inset: 6px;
+  border-radius: inherit;
+  background:
+    linear-gradient(90deg, transparent 0 72%, rgba(255, 255, 255, 0.18) 78%, transparent 90%),
+    radial-gradient(ellipse at 50% 96%, rgba(255, 255, 255, 0.28), transparent 18%);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.16);
+  opacity: 0.82;
+  pointer-events: none;
 }
 
 .realistic-nail img {
@@ -1567,6 +1851,44 @@
   to {
     opacity: 1;
     transform: translateY(0) scale(1);
+  }
+}
+
+@keyframes jewel-new-arrival {
+  0% {
+    opacity: 0;
+    filter: blur(10px) brightness(1.34);
+    transform: translate3d(36vw, -22vh, 240px) rotateY(-34deg) rotateZ(18deg) scale(0.32);
+  }
+  58% {
+    opacity: 1;
+    filter: blur(0) brightness(1.16);
+    transform: translate3d(0, -42px, 126px) rotateY(6deg) rotateZ(-4deg) scale(1.2);
+  }
+  100% {
+    opacity: 1;
+    filter: blur(0) brightness(1);
+    transform: translate3d(0, 0, 0) scale(var(--orbit-scale));
+  }
+}
+
+@keyframes jewel-arrival-ripple {
+  0% {
+    opacity: 0.85;
+    scale: 0.32;
+  }
+  100% {
+    opacity: 0;
+    scale: 1;
+  }
+}
+
+@keyframes jewel-overlay-arrive {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
   }
 }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,9 @@
 import { useState, useEffect, useRef, useMemo, lazy, Suspense } from 'react'
-import type { CSSProperties, KeyboardEvent as ReactKeyboardEvent } from 'react'
+import type {
+  CSSProperties,
+  KeyboardEvent as ReactKeyboardEvent,
+  PointerEvent as ReactPointerEvent,
+} from 'react'
 import { auth, signInWithGoogle, signOutUser, onAuthStateChanged } from './lib/auth'
 import type { User } from './lib/auth'
 import { addNailItem, updateNailItem, deleteNailItem, fetchNailItems } from './lib/firestore'
@@ -34,9 +38,9 @@ const DISPLAY_MODES = ['Glass', 'Snow Globe', 'Velvet', 'Showcase'] as const
 type DisplayMode = typeof DISPLAY_MODES[number]
 
 const JEWEL_MOTION_MODES = [
-  { id: 'drift', label: '漂う' },
-  { id: 'carousel', label: '回る' },
-  { id: 'showcase', label: '前後' },
+  { id: 'drift', label: 'Float', icon: 'float' },
+  { id: 'carousel', label: 'Orbit', icon: 'orbit' },
+  { id: 'showcase', label: 'Compare', icon: 'compare' },
 ] as const
 type JewelMotionMode = typeof JEWEL_MOTION_MODES[number]['id']
 
@@ -361,6 +365,7 @@ function App() {
   const [shareActionId, setShareActionId] = useState<string | null>(null)
   const [activeDisplayMode, setActiveDisplayMode] = useState<DisplayMode>('Glass')
   const [activeJewelMotion, setActiveJewelMotion] = useState<JewelMotionMode>('drift')
+  const [recentlyAddedNailId, setRecentlyAddedNailId] = useState<string | null>(null)
   const [activeAppScreen, setActiveAppScreen] = useState<AppScreenId>('home')
   const [publicShare, setPublicShare] = useState<PublicShareDocWithId | null>(null)
   const [publicShareState, setPublicShareState] = useState<PublicShareViewState>(
@@ -384,6 +389,19 @@ function App() {
     setDetailItemId(itemId)
   }
 
+  const handleJewelStagePointerMove = (event: ReactPointerEvent<HTMLElement>) => {
+    const rect = event.currentTarget.getBoundingClientRect()
+    const x = ((event.clientX - rect.left) / rect.width - 0.5) * 2
+    const y = ((event.clientY - rect.top) / rect.height - 0.5) * 2
+    event.currentTarget.style.setProperty('--pointer-x', x.toFixed(3))
+    event.currentTarget.style.setProperty('--pointer-y', y.toFixed(3))
+  }
+
+  const handleJewelStagePointerLeave = (event: ReactPointerEvent<HTMLElement>) => {
+    event.currentTarget.style.setProperty('--pointer-x', '0')
+    event.currentTarget.style.setProperty('--pointer-y', '0')
+  }
+
   const handleDetailCardKeyDown = (event: ReactKeyboardEvent, itemId: string) => {
     if (event.key !== 'Enter' && event.key !== ' ') return
     event.preventDefault()
@@ -393,6 +411,12 @@ function App() {
   useEffect(() => () => {
     if (previewUrlRef.current) URL.revokeObjectURL(previewUrlRef.current)
   }, [])
+
+  useEffect(() => {
+    if (!recentlyAddedNailId) return
+    const timeoutId = window.setTimeout(() => setRecentlyAddedNailId(null), 2600)
+    return () => window.clearTimeout(timeoutId)
+  }, [recentlyAddedNailId])
 
   useEffect(() => {
     const previousTitle = document.title
@@ -514,7 +538,7 @@ function App() {
 
   useEffect(() => {
     if (isPublicSharePage) return
-    if (!user) return
+    if (!user || activeAppScreen !== 'profile') return
     let didCancel = false
     fetchPublicSharesForOwner(user.uid)
       .then(shares => {
@@ -528,10 +552,9 @@ function App() {
         setPublicShares([])
         setPublicSharesUserId(user.uid)
         setShareError('共有リンクの取得に失敗しました。')
-        setBannerError('共有リンクの取得に失敗しました。')
       })
     return () => { didCancel = true }
-  }, [isPublicSharePage, user])
+  }, [activeAppScreen, isPublicSharePage, user])
 
   const ALLOWED_TYPES = ['image/jpeg', 'image/png', 'image/webp']
   const MAX_FILE_BYTES = 5 * 1024 * 1024
@@ -712,6 +735,8 @@ function App() {
       imageSource: nailImageSource,
     }
     try {
+      let savedItemId: string | null = editingId
+      const isCreatingNewItem = editingId === null
       if (editingId) {
         const editingItem = nailItems.find(i => i.id === editingId)
         let imageUrl = editingItem?.imageUrl ?? ''
@@ -721,6 +746,7 @@ function App() {
         await updateNailItem(uid, editingId, { ...baseInput, imageUrl })
       } else {
         const itemId = await addNailItem(uid, { ...baseInput, imageUrl: '' })
+        savedItemId = itemId
         if (nailImageFile) {
           const imageUrl = await uploadNailImage(uid, itemId, nailImageFile)
           await updateNailItem(uid, itemId, { ...baseInput, imageUrl })
@@ -729,6 +755,14 @@ function App() {
       setNailItems(sortByDate(await fetchNailItems(uid)))
       setNailItemsUserId(uid)
       resetForm()
+      if (isCreatingNewItem && savedItemId) {
+        setRecentlyAddedNailId(savedItemId)
+        setDetailItemId(null)
+        setActiveAppScreen('home')
+        window.requestAnimationFrame(() => {
+          document.getElementById('nail-section')?.scrollIntoView({ block: 'start' })
+        })
+      }
     } catch (e: unknown) {
       const msg = e instanceof Error ? e.message : String(e)
       const isStorageError = msg.toLowerCase().includes('storage') || msg.toLowerCase().includes('permission')
@@ -1181,16 +1215,24 @@ function App() {
         <div id="auth-bar">
           {user === undefined ? null : user ? (
             <div className="auth-user">
-              <span>{user.displayName ?? user.email}</span>
               <button
                 type="button"
-                className="auth-data-mgmt"
+                className="icon-button auth-data-mgmt"
                 onClick={() => setIsDataModalOpen(true)}
+                aria-label="ヘルプとデータ管理"
+                title="Data"
               >
-                データ管理
+                <span className="mono-icon mono-icon-settings" aria-hidden="true" />
               </button>
-              <button type="button" onClick={handleSignOut} disabled={authActionPending}>
-                {authActionPending ? 'Signing out...' : 'Sign out'}
+              <button
+                type="button"
+                className="icon-button"
+                onClick={handleSignOut}
+                disabled={authActionPending}
+                aria-label="サインアウト"
+                title="Sign out"
+              >
+                <span className="mono-icon mono-icon-exit" aria-hidden="true" />
               </button>
             </div>
           ) : null}
@@ -1255,20 +1297,33 @@ function App() {
         <div id="nail-section" className={DISPLAY_MODE_CLASS_NAMES[activeDisplayMode]}>
           {activeAppScreen === 'home' && (
             <>
-              <section className={`jewel-home-stage jewel-motion-${activeJewelMotion}`} aria-labelledby="studio-title">
+              <section
+                className={`jewel-home-stage jewel-motion-${activeJewelMotion}${detailItem ? ' has-open-detail' : ''}${recentlyAddedNailId ? ' has-new-arrival' : ''}`}
+                aria-labelledby="studio-title"
+                onPointerMove={handleJewelStagePointerMove}
+                onPointerLeave={handleJewelStagePointerLeave}
+              >
                 <div className="jewel-home-copy">
-                  <p className="nail-studio-kicker">NAIL JEWEL BOX</p>
-                  <h2 id="studio-title">スクロールして、思い出のネイルに触れる。</h2>
-                  <p>
-                    浮き方を選びながらネイルを遡り、気になるひとつをタッチ。
-                    選んだネイルだけが前へ出て、同じショーウィンドウの中に記憶が浮かびます。
-                  </p>
+                  <p className="nail-studio-kicker">NAILOUS</p>
+                  <h2 id="studio-title">Collection</h2>
                   <div className="jewel-home-actions">
-                    <button type="button" onClick={() => handleSelectAppScreen('design')}>
-                      新しいネイルを作る
+                    <button
+                      type="button"
+                      className="jewel-icon-action"
+                      onClick={() => handleSelectAppScreen('design')}
+                      aria-label="新しいネイルを追加"
+                      title="Add"
+                    >
+                      <span className="mono-icon mono-icon-plus" aria-hidden="true" />
                     </button>
-                    <button type="button" onClick={() => handleSelectAppScreen('profile')}>
-                      保存・相談メモを見る
+                    <button
+                      type="button"
+                      className="jewel-icon-action"
+                      onClick={() => handleSelectAppScreen('profile')}
+                      aria-label="保存と相談メモを見る"
+                      title="Memo"
+                    >
+                      <span className="mono-icon mono-icon-note" aria-hidden="true" />
                     </button>
                   </div>
                   <div className="jewel-motion-switcher" aria-label="ネイルの浮き方">
@@ -1279,8 +1334,10 @@ function App() {
                         className={activeJewelMotion === mode.id ? 'is-active' : ''}
                         onClick={() => setActiveJewelMotion(mode.id)}
                         aria-pressed={activeJewelMotion === mode.id}
+                        aria-label={mode.label}
+                        title={mode.label}
                       >
-                        {mode.label}
+                        <span className={`motion-glyph motion-glyph--${mode.icon}`} aria-hidden="true" />
                       </button>
                     ))}
                   </div>
@@ -1303,6 +1360,7 @@ function App() {
                           const color = isNailColor(item.mainColor) ? item.mainColor : (index % 4 === 0 ? 'blush' : index % 4 === 1 ? 'rose' : index % 4 === 2 ? 'lavender' : 'champagne')
                           const texture = isNailTexture(item.texture) ? item.texture : 'gloss'
                           const isFocused = detailItem?.id === item.id
+                          const isNewlyAdded = recentlyAddedNailId === item.id
                           const style = {
                             '--orbit-delay': `${index * -0.45}s`,
                             '--orbit-scale': `${0.92 + (index % 3) * 0.05}`,
@@ -1311,7 +1369,7 @@ function App() {
                             <button
                               key={item.id}
                               type="button"
-                              className={`jewel-nail-button${isFocused ? ' is-focused' : ''}`}
+                              className={`jewel-nail-button${isFocused ? ' is-focused' : ''}${isNewlyAdded ? ' is-newly-added' : ''}`}
                               style={style}
                               onClick={() => handleOpenDetailCard(item.id)}
                             >
@@ -1331,7 +1389,18 @@ function App() {
                   <span className="jewel-orbit-shadow" aria-hidden="true" />
                 </div>
                 {detailItem && (
-                  <div className="jewel-focus-window" aria-live="polite">
+                  <div
+                    className="jewel-focus-overlay"
+                    role="presentation"
+                    onClick={() => setDetailItemId(null)}
+                  >
+                  <div
+                    className="jewel-focus-window"
+                    role="dialog"
+                    aria-modal="true"
+                    aria-labelledby="jewel-focus-title"
+                    onClick={e => e.stopPropagation()}
+                  >
                     {(() => {
                       const focusIndex = Math.max(homeShowcaseItems.findIndex(item => item.id === detailItem.id), 0)
                       const shape = isNailShape(detailItem.shape) ? detailItem.shape : (focusIndex % 3 === 0 ? 'almond' : focusIndex % 3 === 1 ? 'round' : 'square')
@@ -1345,7 +1414,7 @@ function App() {
                             onClick={() => setDetailItemId(null)}
                             aria-label="選択中のネイル情報を閉じる"
                           >
-                            閉じる
+                            <span className="mono-icon mono-icon-close" aria-hidden="true" />
                           </button>
                           <div className="jewel-focus-nail">
                             <span
@@ -1357,7 +1426,7 @@ function App() {
                           </div>
                           <div className="jewel-focus-copy">
                             <p className="jewel-focus-kicker">Selected memory</p>
-                            <h3>{detailItem.title}</h3>
+                            <h3 id="jewel-focus-title">{detailItem.title}</h3>
                             {detailItem.tags.length > 0 && (
                               <div className="jewel-focus-tags" aria-label="タグ">
                                 {detailItem.tags.slice(0, 5).map(tag => (
@@ -1385,6 +1454,7 @@ function App() {
                         </>
                       )
                     })()}
+                  </div>
                   </div>
                 )}
                 <p className="jewel-home-hint">{nailItems.length} memories in your box</p>


### PR DESCRIPTION
## Summary
- Improves the Home nail material with layered highlights, edge depth, and stronger glossy reflections.
- Makes the Orbit display feel more like a curved showcase surface instead of only a flat horizontal rail.
- Adds pointer-follow motion so the nail collection subtly tilts with finger/cursor movement.
- Adds a new-arrival motion after saving a new nail: the app returns to Home and the new nail flies into the jewelry view.
- Keeps the newer icon-only Home controls and focus overlay direction already present in the working UI.

## Why
The current deployed Home experience was closer, but still only around 30% of the target. This PR pushes the core tactile experience forward: more realistic nails, curved spatial display, smoother interaction feedback, and a more satisfying add-to-collection moment.

## Validation
- npm run lint
- npm run build
- npm test
- bash scripts/qa-preflight.sh
- Local browser load smoke check on Vite dev server

Note: qa-preflight still reports the existing JS bundle size warning only.
